### PR TITLE
AI toolbar, formatting, preview & watcher fixes

### DIFF
--- a/changelogs/v0.9.1.md
+++ b/changelogs/v0.9.1.md
@@ -1,0 +1,46 @@
+# v0.9.1
+
+## New features
+
+### Markdown toolbar
+A persistent AI + formatting toolbar now sits between the note title and the editor, always visible in Write mode.
+
+**AI row** — Rephrase, Summarize, Expand, Fix Grammar, Change Tone, Custom prompt. Buttons are disabled when no text is selected.
+
+**Formatting row** — three groups separated by dividers:
+- Inline: Bold · Italic · Strikethrough · Inline code · Link
+- Headings: H1 · H2 · H3
+- Block: Blockquote · Bullet list · Numbered list
+
+Smart toggle behaviour: clicking a format button a second time removes the syntax. Inline buttons (Bold, Italic, etc.) require a selection; line-level buttons (headings, lists, blockquote) work on the cursor line with no selection needed. Link toggle detects `[text](url)` and unwraps it on re-click.
+
+### Markdown preview panel
+Selecting text in Write mode opens a live preview panel docked to the bottom of the editor. The panel renders the selection through the full markdown pipeline — callouts, math, code blocks, highlights, GFM — and updates in real time as formatting is applied. Dismiss with `Esc` or the ✕ button.
+
+### Colour swatches in inline code
+Hex, RGB, RGBA, HSL, and HSLA colour values inside backticks now render with a small filled circle swatch in both Write preview and Read mode.
+
+Examples: `` `#ff6b6b` ``, `` `rgb(59, 130, 246)` ``, `` `hsl(160, 84%, 39%)` ``
+
+## Bug fixes
+
+### Note edits lost on mode/note switch (critical)
+Edits made in Write mode were not visible when switching to Read mode or switching to another note and back, even though they survived an app restart. Three separate issues were fixed:
+
+1. **Stale `notes` memo in `NotesView`** — the primary cause. `notes` was memoised on `getProjectNotes` (a stable function reference that never changes), so the `activeNote` prop passed to `NoteEditor` was always a snapshot from the last unrelated render. Fixed by adding `allNotes` (the raw store array) as the memo dependency, so `activeNote` reflects the latest content immediately after every keystroke.
+
+2. **Debounce flush on navigation** — the 300 ms save timer was silently abandoned when switching notes or switching to Read mode. A `flushPending()` function now fires synchronously before mode switches and in the effect cleanup on note change, ensuring the latest content is always committed to the store before leaving.
+
+3. **`db:changed` snapshot overwrote optimistic state** — the file watcher fired a `db:changed` event ~200 ms after every save, causing the renderer to re-hydrate from SQLite. Since the IPC write was still in flight, the snapshot contained the previous content, overwriting the optimistic Zustand update. Fixed by skipping `hydrateFromElectron` entirely for own writes — the optimistic update is already correct.
+
+### File watcher self-write loop
+The chokidar watcher would fire on `.md` files written by the app itself, reading them back and overwriting SQLite. A `suppressedNoteIds` map now marks each note for 2 s immediately before `writeNoteFile` is called; `handleFileChange` and `handleFileAdd` skip the upsert for suppressed IDs.
+
+### ColumnBreakdownCard stale card counts
+Card counts in the Project Overview column breakdown were computed via `getColumnCards` subscribed only to its function reference, so counts never updated when cards were moved between columns. Fixed by deriving counts directly from the `allCards` prop already passed to the component.
+
+## Architecture notes
+
+- `AITextToolbar` is no longer a React portal — it renders inline in the flex column, always occupying a fixed height, so the editor area never shifts.
+- `applyFormat` in `ai-text-toolbar.tsx` returns `{ from, to }` of the affected range so callers can read the correct post-dispatch text for the preview panel.
+- `suppressNextChange(noteId)` is exported from `file-watcher.ts` and called from every `writeNoteFile` site in `handlers.ts`.

--- a/electron/file-watcher.ts
+++ b/electron/file-watcher.ts
@@ -25,6 +25,23 @@ let watcher: FSWatcher | null = null;
 // filePath → noteId, populated on add/change so delete can find the record
 const pathToNoteId = new Map<string, string>();
 
+// Note IDs that the app itself just wrote — suppress the chokidar round-trip
+// that would otherwise overwrite SQLite with the file we just saved from SQLite.
+const suppressedNoteIds = new Map<string, ReturnType<typeof setTimeout>>();
+
+/**
+ * Call this immediately before writing a note file from the app (IPC handler).
+ * Any chokidar change/add event for that note within the next 2 s is ignored.
+ */
+export function suppressNextChange(noteId: string): void {
+  const existing = suppressedNoteIds.get(noteId);
+  if (existing) clearTimeout(existing);
+  suppressedNoteIds.set(
+    noteId,
+    setTimeout(() => suppressedNoteIds.delete(noteId), 2000),
+  );
+}
+
 /**
  * Starts watching the notes/ subdirectory of the workspace folder.
  * The `onChanged` callback is called after every SQLite mutation so the
@@ -72,6 +89,7 @@ function handleFileAdd(filePath: string, db: Database.Database, onChanged: () =>
   const note = parseNoteFile(filePath);
   if (!note) return;
   pathToNoteId.set(filePath, note.id);
+  if (suppressedNoteIds.has(note.id)) return;
   upsertNoteFromFile(db, note);
   onChanged();
 }
@@ -81,6 +99,7 @@ function handleFileChange(filePath: string, db: Database.Database, onChanged: ()
   const note = parseNoteFile(filePath);
   if (!note) return;
   pathToNoteId.set(filePath, note.id);
+  if (suppressedNoteIds.has(note.id)) return;
   upsertNoteFromFile(db, note);
   onChanged();
 }

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -22,6 +22,7 @@ import type Database from "better-sqlite3";
 import * as q from "../db/queries";
 import { registerChatHandler } from "./chat";
 import { writeNoteFile, deleteNoteFile, deleteProjectNotesDir, stripMarkdown, findNoteFilePath } from "../notes-files";
+import { suppressNextChange } from "../file-watcher";
 import { buildContextResponse } from "../lib/context";
 import { generatePrd } from "../lib/prd";
 import { isLocalEndpoint, callLLM } from "../lib/llm";
@@ -128,6 +129,7 @@ export function registerIpcHandlers(db: Database.Database, workspacePath: string
       contentText: stripMarkdown(args.content ?? ""),
     });
     if (note.type !== "dashboard") {
+      suppressNextChange(note.id);
       writeNoteFile(workspacePath, {
         ...note,
         projectName: getProjectName(db, note.projectId),
@@ -150,6 +152,7 @@ export function registerIpcHandlers(db: Database.Database, workspacePath: string
       }
       const note = q.restoreNote(db, id);
       if (note.type !== "dashboard") {
+        suppressNextChange(note.id);
         writeNoteFile(workspacePath, { ...note, projectName: getProjectName(db, note.projectId) });
       }
       return note;
@@ -160,6 +163,7 @@ export function registerIpcHandlers(db: Database.Database, workspacePath: string
     }
     const note = q.updateNote(db, id, enrichedPatch);
     if (note.type !== "dashboard") {
+      suppressNextChange(note.id);
       writeNoteFile(workspacePath, {
         ...note,
         projectName: getProjectName(db, note.projectId),
@@ -174,6 +178,7 @@ export function registerIpcHandlers(db: Database.Database, workspacePath: string
     // moving a note to root (folder="") is never silently ignored.
     const note = q.moveNoteFolder(db, id, folder ?? "");
     if (note.type !== "dashboard") {
+      suppressNextChange(note.id);
       writeNoteFile(workspacePath, { ...note, projectName: getProjectName(db, note.projectId) });
     }
     return note;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -100,12 +100,11 @@ export default function Home() {
 
       // Register db:changed listener synchronously so React gets the cleanup fn
       const unsubDb = electron.onDbChanged(() => {
-        // Don't clear history if the change came from our own write (store ipc or flow canvas).
-        if (ownWriteGuard.isOwnWrite()) {
-          void hydrateFromElectron(false);
-        } else {
-          hydrateFromElectron(true);
-        }
+        // Own writes are already reflected in Zustand via optimistic updates —
+        // re-hydrating from SQLite would race against in-flight IPC and overwrite
+        // the optimistic state with stale content. Skip hydration entirely.
+        if (ownWriteGuard.isOwnWrite()) return;
+        hydrateFromElectron(true);
       });
 
       // Auto-updater listeners — events may arrive in any order

--- a/src/components/layout/project-overview.tsx
+++ b/src/components/layout/project-overview.tsx
@@ -307,14 +307,13 @@ function ColumnBreakdownCard({
   allCards: TaskCard[];
   setView: (v: "board") => void;
 }) {
-  const getColumnCards = useCairnStore((s) => s.getColumnCards);
   if (columns.length === 0) return null;
   return (
     <div>
       <div className="text-[0.714rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wider mb-2.5">By column</div>
       <div className="space-y-1.5">
         {columns.map((col) => {
-          const count = getColumnCards(col.id).length;
+          const count = allCards.filter((c) => c.columnId === col.id).length;
           const pct   = allCards.length > 0 ? (count / allCards.length) * 100 : 0;
           const color = COLUMN_COLORS[col.type] ?? COLUMN_COLORS.custom;
           return (

--- a/src/components/notes/ai-text-toolbar.tsx
+++ b/src/components/notes/ai-text-toolbar.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import { Loader2, Wand2, RefreshCw, AlignLeft, Expand, SpellCheck, MessageSquare, X } from "lucide-react";
+import {
+  Loader2, Wand2, RefreshCw, AlignLeft, Expand, SpellCheck, MessageSquare, X,
+  Bold, Italic, Strikethrough, Code, Code2, Link, Quote, List, ListOrdered,
+  Heading1, Heading2, Heading3, Highlighter, CheckSquare, Minus,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip } from "@/components/ui/tooltip";
+
+// ── AI actions ────────────────────────────────────────────────────────────────
 
 export type AITextAction =
   | "rephrase"
@@ -14,14 +19,36 @@ export type AITextAction =
   | "change_tone"
   | "custom";
 
+// ── Format actions ────────────────────────────────────────────────────────────
+// Inline: wrap/unwrap the selection.
+// Line:   toggle a prefix on every selected line.
+
+export type FormatAction =
+  | "bold"
+  | "italic"
+  | "strikethrough"
+  | "code"
+  | "highlight"
+  | "link"
+  | "h1" | "h2" | "h3"
+  | "quote"
+  | "bullet"
+  | "ordered"
+  | "task"
+  | "codeblock"
+  | "hr";
+
 interface AITextToolbarProps {
-  position: { top: number; left: number };
   onAction: (action: AITextAction, customPrompt?: string) => void;
+  onFormat: (action: FormatAction) => void;
   loading: boolean;
   onDismiss: () => void;
+  hasSelection: boolean;
 }
 
-const ACTIONS: { id: AITextAction; label: string; icon: React.ReactNode }[] = [
+// ── AI action definitions ─────────────────────────────────────────────────────
+
+const AI_ACTIONS: { id: AITextAction; label: string; icon: React.ReactNode }[] = [
   { id: "rephrase",    label: "Rephrase",    icon: <RefreshCw size={11} /> },
   { id: "summarize",   label: "Summarize",   icon: <AlignLeft size={11} /> },
   { id: "expand",      label: "Expand",      icon: <Expand size={11} /> },
@@ -30,21 +57,54 @@ const ACTIONS: { id: AITextAction; label: string; icon: React.ReactNode }[] = [
   { id: "custom",      label: "Custom…",     icon: <Wand2 size={11} /> },
 ];
 
-export function AITextToolbar({ position, onAction, loading, onDismiss }: AITextToolbarProps) {
+// ── Format button definitions ─────────────────────────────────────────────────
+
+const FORMAT_GROUPS: { id: FormatAction; label: string; icon: React.ReactNode }[][] = [
+  // Inline formatting
+  [
+    { id: "bold",          label: "Bold (⌘B)",        icon: <Bold size={12} /> },
+    { id: "italic",        label: "Italic (⌘I)",      icon: <Italic size={12} /> },
+    { id: "strikethrough", label: "Strikethrough",     icon: <Strikethrough size={12} /> },
+    { id: "highlight",     label: "Highlight ==text==",icon: <Highlighter size={12} /> },
+    { id: "code",          label: "Inline code",       icon: <Code size={12} /> },
+    { id: "link",          label: "Link",              icon: <Link size={12} /> },
+  ],
+  // Headings
+  [
+    { id: "h1", label: "Heading 1", icon: <Heading1 size={12} /> },
+    { id: "h2", label: "Heading 2", icon: <Heading2 size={12} /> },
+    { id: "h3", label: "Heading 3", icon: <Heading3 size={12} /> },
+  ],
+  // Block / list
+  [
+    { id: "quote",   label: "Blockquote",    icon: <Quote size={12} /> },
+    { id: "bullet",  label: "Bullet list",   icon: <List size={12} /> },
+    { id: "ordered", label: "Numbered list", icon: <ListOrdered size={12} /> },
+    { id: "task",    label: "Task list",     icon: <CheckSquare size={12} /> },
+  ],
+  // Insert
+  [
+    { id: "codeblock", label: "Code block", icon: <Code2 size={12} /> },
+    { id: "hr",        label: "Divider ---", icon: <Minus size={12} /> },
+  ],
+];
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+// Inline actions require a selection; line-level actions work on the cursor line
+const REQUIRES_SELECTION = new Set<FormatAction>(["bold", "italic", "strikethrough", "highlight", "code", "link"]);
+
+export function AITextToolbar({ onAction, onFormat, loading, onDismiss, hasSelection }: AITextToolbarProps) {
   const [showCustom, setShowCustom] = useState(false);
   const [customPrompt, setCustomPrompt] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
-  const toolbarRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (showCustom) inputRef.current?.focus();
   }, [showCustom]);
 
   function handleAction(action: AITextAction) {
-    if (action === "custom") {
-      setShowCustom(true);
-      return;
-    }
+    if (action === "custom") { setShowCustom(true); return; }
     onAction(action);
   }
 
@@ -56,86 +116,112 @@ export function AITextToolbar({ position, onAction, loading, onDismiss }: AIText
     setShowCustom(false);
   }
 
-  const toolbar = (
+  const btnBase = "flex items-center justify-center w-6 h-6 rounded transition-colors text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface)]";
+
+  return (
     <div
-      ref={toolbarRef}
       data-ai-toolbar
-      className="fixed z-50 animate-fade-in"
-      style={{
-        top: 0,
-        left: 0,
-        transform: `translate(calc(${position.left}px - 50%), calc(${position.top}px - 100%))`,
-      }}
-      // Prevent mousedown from bubbling up and dismissing the toolbar
+      className="border-b border-[var(--border)] animate-fade-in shadow-md shadow-black/10"
+      style={{ background: "var(--surface-2)" }}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      <div className="flex flex-col gap-1">
-        {/* Main toolbar */}
-        <div className="flex items-center gap-0.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-lg shadow-black/20 p-1">
-          {loading ? (
-            <div className="flex items-center gap-2 px-2 py-1 text-xs text-[var(--text-tertiary)]">
-              <Loader2 size={11} className="animate-spin" />
-              <span>Writing…</span>
-            </div>
-          ) : (
-            <>
-              {ACTIONS.map((action) => (
-                <button
-                  key={action.id}
-                  onClick={() => handleAction(action.id)}
-                  className={cn(
-                    "flex items-center gap-1.5 px-2 py-1 rounded-md text-[0.786rem] transition-colors whitespace-nowrap",
-                    "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]",
-                    showCustom && action.id === "custom" && "bg-[var(--surface-2)] text-[var(--text-primary)]"
-                  )}
-                >
-                  {action.icon}
-                  {action.label}
-                </button>
-              ))}
-              <div className="w-px h-4 bg-[var(--border)] mx-0.5" />
-              <Tooltip content="Dismiss" side="top">
-                <button
-                  onClick={onDismiss}
-                  className="p-1 rounded-md text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors"
-                >
-                  <X size={11} />
-                </button>
-              </Tooltip>
-            </>
-          )}
-        </div>
-
-        {/* Custom prompt input */}
-        {showCustom && !loading && (
-          <form
-            onSubmit={handleCustomSubmit}
-            className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-lg shadow-black/20 p-1.5"
-          >
-            <Wand2 size={11} className="text-[var(--text-tertiary)] flex-shrink-0 ml-1" />
-            <input
-              ref={inputRef}
-              value={customPrompt}
-              onChange={(e) => setCustomPrompt(e.target.value)}
-              onKeyDown={(e) => e.key === "Escape" && (setShowCustom(false), setCustomPrompt(""))}
-              placeholder="Describe what to do with the text…"
-              className="flex-1 bg-transparent text-xs text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none min-w-48"
-            />
-            <button
-              type="submit"
-              disabled={!customPrompt.trim()}
-              className="px-2 py-0.5 rounded text-[0.786rem] bg-[var(--accent)] text-white disabled:opacity-40 disabled:cursor-not-allowed hover:opacity-90 transition-opacity"
-            >
-              Apply
-            </button>
-          </form>
+      {/* ── AI action row ── */}
+      <div className="flex items-center gap-0.5 px-3 py-1.5 border-b border-[var(--border)]">
+        {loading ? (
+          <div className="flex items-center gap-2 px-2 py-1 text-xs text-[var(--text-tertiary)]">
+            <Loader2 size={11} className="animate-spin" />
+            <span>Writing…</span>
+          </div>
+        ) : (
+          <>
+            {AI_ACTIONS.map((action) => (
+              <button
+                key={action.id}
+                onClick={() => handleAction(action.id)}
+                disabled={!hasSelection}
+                className={cn(
+                  "flex items-center gap-1.5 px-2 py-1 rounded-md text-[0.786rem] transition-colors whitespace-nowrap",
+                  hasSelection
+                    ? "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface)]"
+                    : "text-[var(--text-tertiary)] opacity-40 cursor-not-allowed",
+                  showCustom && action.id === "custom" && "bg-[var(--surface)] text-[var(--text-primary)]"
+                )}
+              >
+                {action.icon}
+                {action.label}
+              </button>
+            ))}
+            <div className="flex-1" />
+            <div className="w-px h-4 bg-[var(--border)] mx-0.5" />
+            <Tooltip content="Dismiss" side="bottom">
+              <button
+                onClick={onDismiss}
+                className="p-1 rounded-md text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface)] transition-colors"
+              >
+                <X size={11} />
+              </button>
+            </Tooltip>
+          </>
         )}
+      </div>
+
+      {/* Custom prompt input */}
+      {showCustom && !loading && (
+        <form
+          onSubmit={handleCustomSubmit}
+          className="flex items-center gap-1.5 px-4 py-1.5 border-b border-[var(--border)]"
+        >
+          <Wand2 size={11} className="text-[var(--text-tertiary)] flex-shrink-0" />
+          <input
+            ref={inputRef}
+            value={customPrompt}
+            onChange={(e) => setCustomPrompt(e.target.value)}
+            onKeyDown={(e) => e.key === "Escape" && (setShowCustom(false), setCustomPrompt(""))}
+            placeholder="Describe what to do with the text…"
+            className="flex-1 bg-transparent text-xs text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none"
+          />
+          <button
+            type="submit"
+            disabled={!customPrompt.trim()}
+            className="px-2 py-0.5 rounded text-[0.786rem] bg-[var(--accent)] text-white disabled:opacity-40 disabled:cursor-not-allowed hover:opacity-90 transition-opacity"
+          >
+            Apply
+          </button>
+        </form>
+      )}
+
+      {/* ── Formatting bar ── */}
+      <div className="flex items-center gap-1 px-3 py-1.5">
+        {FORMAT_GROUPS.map((group, gi) => (
+          <React.Fragment key={gi}>
+            {gi > 0 && <div className="w-px h-4 bg-[var(--border)] mx-0.5" />}
+            {group.map((fmt) => {
+              const needsSel = REQUIRES_SELECTION.has(fmt.id);
+              const disabled = needsSel && !hasSelection;
+              return (
+                <Tooltip key={fmt.id} content={fmt.label} side="bottom">
+                  <button
+                    onClick={() => onFormat(fmt.id)}
+                    disabled={disabled}
+                    className={cn(
+                      btnBase,
+                      disabled && "opacity-40 cursor-not-allowed"
+                    )}
+                    onMouseDown={(e) => e.preventDefault()} // keep CM selection alive
+                  >
+                    {fmt.icon}
+                  </button>
+                </Tooltip>
+              );
+            })}
+          </React.Fragment>
+        ))}
       </div>
     </div>
   );
-
-  return createPortal(toolbar, document.body);
 }
+
+// ── AI prompt builder ─────────────────────────────────────────────────────────
 
 export function buildAIActionPrompt(action: AITextAction, selectedText: string, customPrompt?: string): string {
   const base = `You are an AI writing assistant embedded in a note editor. The user has selected the following text:\n\n"${selectedText}"\n\n`;
@@ -147,4 +233,241 @@ export function buildAIActionPrompt(action: AITextAction, selectedText: string, 
     case "change_tone":  return base + "Rewrite this text in a more professional and polished tone. Return only the rewritten text, no commentary.";
     case "custom":       return base + `${customPrompt}. Return only the resulting text, no commentary.`;
   }
+}
+
+// ── Format logic ──────────────────────────────────────────────────────────────
+// Exported so note-editor.tsx can call it directly with the CodeMirror view.
+
+import type { EditorView } from "@codemirror/view";
+
+/**
+ * Apply a FormatAction to the current CodeMirror selection.
+ *
+ * Inline actions (bold, italic, strikethrough, code, link):
+ *   - If selection is already wrapped, unwrap it.
+ *   - Otherwise wrap it. If nothing is selected, insert a placeholder.
+ *
+ * Line actions (h1–h3, quote, bullet, ordered):
+ *   - Toggle the prefix on every line touched by the selection.
+ *   - If all lines already have the prefix, remove it; otherwise add it.
+ */
+/** Returns the doc range of the affected content after the dispatch, so callers
+ *  can read the updated text for preview. Line actions expand the range to cover
+ *  full lines; inline actions return the wrapped selection range. */
+export function applyFormat(view: EditorView, action: FormatAction): { from: number; to: number } | null {
+  const state = view.state;
+  const { from, to } = state.selection.main;
+  const selectedText = state.sliceDoc(from, to);
+
+  // ── Inline wrapping ───────────────────────────────────────────────────────
+
+  type WrapDef = { open: string; close: string; placeholder: string };
+  const WRAP: Partial<Record<FormatAction, WrapDef>> = {
+    bold:          { open: "**", close: "**", placeholder: "bold text" },
+    italic:        { open: "_",  close: "_",  placeholder: "italic text" },
+    strikethrough: { open: "~~", close: "~~", placeholder: "strikethrough" },
+    highlight:     { open: "==", close: "==", placeholder: "highlighted text" },
+    code:          { open: "`",  close: "`",  placeholder: "code" },
+  };
+
+  if (action in WRAP) {
+    const { open, close, placeholder } = WRAP[action]!;
+    const isWrapped =
+      selectedText.startsWith(open) && selectedText.endsWith(close) && selectedText.length > open.length + close.length;
+
+    let resultFrom = from, resultTo = to;
+    if (isWrapped) {
+      const inner = selectedText.slice(open.length, selectedText.length - close.length);
+      view.dispatch({
+        changes: { from, to, insert: inner },
+        selection: { anchor: from, head: from + inner.length },
+      });
+      resultTo = from + inner.length;
+    } else if (selectedText.length === 0) {
+      const insert = open + placeholder + close;
+      view.dispatch({
+        changes: { from, to, insert },
+        selection: { anchor: from + open.length, head: from + open.length + placeholder.length },
+      });
+      resultTo = from + insert.length;
+    } else {
+      const insert = open + selectedText + close;
+      view.dispatch({
+        changes: { from, to, insert },
+        selection: { anchor: from, head: from + insert.length },
+      });
+      resultTo = from + insert.length;
+    }
+    view.focus();
+    return { from: resultFrom, to: resultTo };
+  }
+
+  // ── Link ──────────────────────────────────────────────────────────────────
+
+  if (action === "link") {
+    // Detect existing [text](url) — unwrap to just the link text
+    const linkRe = /^\[(.+?)\]\(.+?\)$/;
+    const linkMatch = selectedText.match(linkRe);
+    if (linkMatch) {
+      const inner = linkMatch[1];
+      view.dispatch({
+        changes: { from, to, insert: inner },
+        selection: { anchor: from, head: from + inner.length },
+      });
+      view.focus();
+      return { from, to: from + inner.length };
+    }
+    if (selectedText.length === 0) {
+      const insert = "[link text](url)";
+      view.dispatch({
+        changes: { from, to, insert },
+        selection: { anchor: from + 1, head: from + 10 },
+      });
+      view.focus();
+      return { from, to: from + insert.length };
+    } else {
+      const insert = `[${selectedText}](url)`;
+      view.dispatch({
+        changes: { from, to, insert },
+        selection: { anchor: from + selectedText.length + 3, head: from + insert.length - 1 },
+      });
+      view.focus();
+      return { from, to: from + insert.length };
+    }
+  }
+
+  // ── Line-level prefixes ───────────────────────────────────────────────────
+
+  const LINE_PREFIX: Partial<Record<FormatAction, string>> = {
+    h1:      "# ",
+    h2:      "## ",
+    h3:      "### ",
+    quote:   "> ",
+    bullet:  "- ",
+    ordered: "1. ",
+    task:    "- [ ] ",
+  };
+
+  if (action in LINE_PREFIX) {
+    const prefix = LINE_PREFIX[action]!;
+
+    // Collect all lines spanned by the selection
+    const startLine = state.doc.lineAt(from);
+    const endLine   = state.doc.lineAt(to);
+
+    // Check if ALL touched lines already have this prefix (for toggle).
+    // Ordered lists use a regex so "2. " / "10. " are recognised, not just "1. ".
+    const hasPrefix = action === "ordered"
+      ? (text: string) => /^\d+\.\s/.test(text)
+      : (text: string) => text.startsWith(prefix);
+
+    let allHave = true;
+    for (let ln = startLine.number; ln <= endLine.number; ln++) {
+      const line = state.doc.line(ln);
+      if (!hasPrefix(line.text)) { allHave = false; break; }
+    }
+
+    // For ordered lists, rebuild numbering; for others, uniform prefix toggle
+    const changes: { from: number; to: number; insert: string }[] = [];
+    let orderedIndex = 1;
+
+    for (let ln = startLine.number; ln <= endLine.number; ln++) {
+      const line = state.doc.line(ln);
+
+      // Strip any existing heading / list / quote prefix first so we don't
+      // double-up when switching between formats (e.g. # → ## → # ).
+      const stripped = line.text
+        .replace(/^(#{1,6}\s)/, "")
+        .replace(/^(>\s)/, "")
+        .replace(/^(-\s\[[ x]\]\s)/, "")
+        .replace(/^(-\s)/, "")
+        .replace(/^(\d+\.\s)/, "");
+
+      if (allHave) {
+        // Remove prefix
+        changes.push({ from: line.from, to: line.to, insert: stripped });
+      } else {
+        // Add prefix (with correct numbering for ordered lists)
+        const p = action === "ordered" ? `${orderedIndex++}. ` : prefix;
+        changes.push({ from: line.from, to: line.to, insert: p + stripped });
+      }
+    }
+
+    view.dispatch({ changes });
+    view.focus();
+    // Return full line range from the post-dispatch state so the caller can
+    // read the complete updated line text for the preview.
+    const newState = view.state;
+    const newStart = newState.doc.lineAt(startLine.from);
+    const newEnd   = newState.doc.lineAt(
+      Math.min(endLine.from, newState.doc.length)
+    );
+    return { from: newStart.from, to: newEnd.to };
+  }
+
+  // ── Block inserts (no prefix toggling) ───────────────────────────────────
+
+  if (action === "codeblock") {
+    const startLine = state.doc.lineAt(from);
+    const endLine   = state.doc.lineAt(to);
+
+    // ── Toggle off: find enclosing ``` fences anywhere around the selection ───
+    // Walk upward from startLine to find an opening fence
+    let openFenceLine: ReturnType<typeof state.doc.line> | null = null;
+    for (let ln = startLine.number; ln >= 1; ln--) {
+      const l = state.doc.line(ln);
+      if (/^```/.test(l.text)) { openFenceLine = l; break; }
+    }
+    // Walk downward from endLine to find a closing fence
+    let closeFenceLine: ReturnType<typeof state.doc.line> | null = null;
+    for (let ln = endLine.number; ln <= state.doc.lines; ln++) {
+      const l = state.doc.line(ln);
+      if (/^```/.test(l.text)) { closeFenceLine = l; break; }
+    }
+    // Only treat as "already fenced" when the two fences are distinct lines
+    const isFenced = openFenceLine !== null && closeFenceLine !== null &&
+      openFenceLine.number !== closeFenceLine.number;
+
+    if (isFenced) {
+      // Content is everything between the fence lines (exclusive of the fence lines themselves)
+      const contentFrom = openFenceLine!.to + 1;  // char after the \n on the ``` line
+      const contentTo   = closeFenceLine!.from - 1; // char before the \n leading into the ``` line
+      const content = contentTo >= contentFrom
+        ? state.doc.sliceString(contentFrom, contentTo)
+        : "";
+      view.dispatch({
+        changes: { from: openFenceLine!.from, to: closeFenceLine!.to, insert: content },
+        selection: { anchor: openFenceLine!.from, head: openFenceLine!.from + content.length },
+      });
+      view.focus();
+      return { from: openFenceLine!.from, to: openFenceLine!.from + content.length };
+    }
+
+    // ── Toggle on: wrap selection (or placeholder) in a fenced block ──────────
+    const inner  = selectedText.length > 0 ? selectedText : "code here";
+    const insert = `\`\`\`\n${inner}\n\`\`\``;
+    const replaceFrom = startLine.from;
+    const replaceTo   = selectedText.length > 0 ? endLine.to : startLine.to;
+    view.dispatch({
+      changes: { from: replaceFrom, to: replaceTo, insert },
+      // Select the inner content (after the opening fence + newline)
+      selection: { anchor: replaceFrom + 4, head: replaceFrom + 4 + inner.length },
+    });
+    view.focus();
+    return { from: replaceFrom, to: replaceFrom + insert.length };
+  }
+
+  if (action === "hr") {
+    const line   = state.doc.lineAt(from);
+    const insert = (line.text.trim() === "" ? "" : "\n") + "---\n";
+    const pos    = line.text.trim() === "" ? line.from : line.to;
+    view.dispatch({
+      changes: { from: pos, to: pos, insert },
+      selection: { anchor: pos + insert.length },
+    });
+    view.focus();
+    return { from: pos, to: pos + insert.length };
+  }
+
+  return null;
 }

--- a/src/components/notes/note-editor.tsx
+++ b/src/components/notes/note-editor.tsx
@@ -17,7 +17,7 @@ import { TableOfContents, headingSlug } from "./TableOfContents";
 import { CodeBlock } from "./CodeBlock";
 import { Callout } from "./Callout";
 import { MathBlock } from "./MathBlock";
-import { AITextToolbar, buildAIActionPrompt, type AITextAction } from "./ai-text-toolbar";
+import { AITextToolbar, buildAIActionPrompt, applyFormat, type AITextAction, type FormatAction } from "./ai-text-toolbar";
 import { MarkdownEditor, type MarkdownEditorHandle } from "./markdown-editor";
 // ── Remark plugin: callout blockquotes ────────────────────────────────────────
 // Transforms > [!type] blockquotes in the mdast by tagging the blockquote node
@@ -180,6 +180,134 @@ function makeLatexPlugins() {
 
 
 
+// ── Color swatch inline code renderer ────────────────────────────────────────
+// Detects hex / rgb / rgba / hsl / hsla values inside inline code spans and
+// renders a small color swatch dot next to the code text.
+
+const COLOR_RE = /^(#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|(rgba?|hsla?)\s*\([^)]+\))$/i;
+
+function InlineCode({ className, children }: { className?: string; children?: React.ReactNode }) {
+  if (className?.startsWith("language-")) return <>{children}</>;
+  const text = String(children ?? "").trim();
+  const isColor = COLOR_RE.test(text);
+  return (
+    <code className="px-1 py-0.5 rounded bg-[var(--surface-3)] font-mono text-[0.786rem] text-[var(--text-primary)]">
+      {isColor && (
+        <span
+          style={{
+            display: "inline-block",
+            width: "0.7em",
+            height: "0.7em",
+            borderRadius: "50%",
+            background: text,
+            border: "1px solid color-mix(in srgb, var(--text-primary) 20%, transparent)",
+            marginRight: "0.35em",
+            verticalAlign: "middle",
+            flexShrink: 0,
+          }}
+        />
+      )}
+      {children}
+    </code>
+  );
+}
+
+// ── MD Preview Panel ──────────────────────────────────────────────────────────
+// Docked to the bottom of the editor. Renders selected raw markdown through
+// the full pipeline and displays it as a collapsible bottom panel.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const PREVIEW_REMARK_PLUGINS: any[] = [remarkGfm, remarkMath, remarkPromoteDisplayMath, remarkCallout];
+
+interface MDPreviewPanelProps {
+  text: string;
+  onDismiss: () => void;
+}
+
+function MDPreviewPanel({ text, onDismiss }: MDPreviewPanelProps) {
+  // Each panel instance gets its own latex plugin pair so the mutable capture
+  // array is isolated — safe because the panel remounts when text changes.
+  const { rehypeCaptureLatex: previewCapture, rehypeMergedPass: previewMerge } = useMemo(makeLatexPlugins, []);
+
+  // Dismiss on Escape
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") onDismiss(); }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onDismiss]);
+
+  return (
+    <div
+      data-md-preview-portal
+      className="flex-shrink-0 border-t border-[var(--border)] animate-fade-in"
+      style={{ background: "var(--surface)" }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      {/* Header bar */}
+      <div className="flex items-center justify-between px-4 py-1.5 border-b border-[var(--border)]" style={{ background: "var(--surface-2)" }}>
+        <span className="text-[0.714rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Preview</span>
+        <button
+          onClick={onDismiss}
+          className="p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface)] transition-colors"
+        >
+          <X size={11} />
+        </button>
+      </div>
+      {/* Rendered markdown — capped at ~30vh so it never swamps the editor */}
+      <div className="prose-cairn px-6 py-4 overflow-y-auto" style={{ maxHeight: "30vh" }}>
+        <ReactMarkdown
+          remarkPlugins={PREVIEW_REMARK_PLUGINS}
+          rehypePlugins={[previewCapture, rehypeKatex, previewMerge]}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          components={({
+            mark({ children }: any) {
+              return (
+                <mark className="rounded px-0.5" style={{ background: "color-mix(in srgb, var(--accent) 22%, transparent)", color: "var(--text-primary)" }}>
+                  {children}
+                </mark>
+              );
+            },
+            callout({ children, ...props }: any) {
+              const p = props as Record<string, string>;
+              return (
+                <Callout
+                  type={p["data-callout-type"] ?? "note"}
+                  title={p["data-title"] || undefined}
+                  collapsible={p["data-collapsible"] === "true"}
+                  defaultOpen={p["data-default-open"] !== "false"}
+                >
+                  {children}
+                </Callout>
+              );
+            },
+            mathblock({ children, ...props }: any) {
+              const p = props as Record<string, string>;
+              return <MathBlock renderedChildren={children} latex={p["data-latex"] ?? ""} />;
+            },
+            pre({ children }: any) {
+              const child = Array.isArray(children) ? children[0] : children;
+              const code = child as React.ReactElement<{ className?: string; children?: React.ReactNode }>;
+              const className = code?.props?.className ?? "";
+              const lang = className.replace("language-", "") || undefined;
+              const content = String(code?.props?.children ?? "").replace(/\n$/, "");
+              return <CodeBlock code={content} language={lang} />;
+            },
+            code({ children, className }: any) {
+              return <InlineCode className={className}>{children}</InlineCode>;
+            },
+          } as any)}
+        >
+          {text}
+        </ReactMarkdown>
+      </div>
+    </div>
+  );
+}
+
+
+
+
+
 interface NoteEditorProps {
   note: Note;
 }
@@ -206,9 +334,12 @@ export function NoteEditor({ note }: NoteEditorProps) {
   const [spawnToolCalls, setSpawnToolCalls] = useState<string[]>([]);
 
   // AI toolbar state
-  const [toolbarPos, setToolbarPos] = useState<{ top: number; left: number } | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
+  const [hasSelection, setHasSelection] = useState(false);
   const selectionRef = useRef<{ text: string } | null>(null);
+
+  // MD preview panel state — selected text to render in the bottom panel
+  const [previewText, setPreviewText] = useState<string | null>(null);
 
   // Scroll container ref — used by TableOfContents to scroll to headings
   const previewScrollRef = useRef<HTMLDivElement>(null);
@@ -221,11 +352,35 @@ export function NoteEditor({ note }: NoteEditorProps) {
   const { rehypeCaptureLatex, rehypeMergedPass } = useMemo(() => makeLatexPlugins(), [note.id]);
 
   // ── Save ──────────────────────────────────────────────────────────────────
+  // pendingContent tracks the latest unsaved markdown so the flush can write
+  // it without a stale closure value.
+  const pendingContent = useRef<{ noteId: string; markdown: string } | null>(null);
+  const updateNoteRef = useRef(updateNote);
+  updateNoteRef.current = updateNote;
+
+  // Flush any pending debounced save immediately. Safe to call at any time.
+  const flushPending = useCallback(() => {
+    if (saveTimer.current) {
+      clearTimeout(saveTimer.current);
+      saveTimer.current = null;
+    }
+    if (pendingContent.current) {
+      const { noteId, markdown } = pendingContent.current;
+      pendingContent.current = null;
+      updateNoteRef.current(noteId, {
+        content: markdown,
+        contentText: stripMarkdown(markdown),
+      });
+    }
+  }, []);
+
   const handleContentChange = useCallback(
     (markdown: string) => {
       setWordCount(countWords(markdown));
+      pendingContent.current = { noteId: note.id, markdown };
       if (saveTimer.current) clearTimeout(saveTimer.current);
       saveTimer.current = setTimeout(() => {
+        pendingContent.current = null;
         updateNote(note.id, {
           content: markdown,
           contentText: stripMarkdown(markdown),
@@ -234,6 +389,12 @@ export function NoteEditor({ note }: NoteEditorProps) {
     },
     [note.id, updateNote]
   );
+
+  // Flush on note change or unmount so switching notes never drops edits.
+  useEffect(() => {
+    return () => flushPending();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [note.id]);
 
   const titleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const handleTitleChange = useCallback(
@@ -251,18 +412,14 @@ export function NoteEditor({ note }: NoteEditorProps) {
   const handleSelectionChange = useCallback(
     (sel: { text: string; coords: { top: number; left: number } } | null) => {
       if (!sel) {
-        setToolbarPos(null);
+        setHasSelection(false);
+        setPreviewText(null);
         selectionRef.current = null;
         return;
       }
       selectionRef.current = { text: sel.text };
-      const rect = containerRef.current?.getBoundingClientRect();
-      const centerX = rect ? rect.left + rect.width / 2 : window.innerWidth / 2;
-      const OFFSET = 10;
-      setToolbarPos({
-        top: sel.coords.top - OFFSET,
-        left: centerX,
-      });
+      setHasSelection(true);
+      setPreviewText(sel.text);
     },
     []
   );
@@ -292,12 +449,22 @@ export function NoteEditor({ note }: NoteEditorProps) {
         editorRef.current?.replaceSelection(replacement);
       } finally {
         setAiLoading(false);
-        setToolbarPos(null);
+        setPreviewText(null);
         selectionRef.current = null;
       }
     },
     [aiConfig]
   );
+
+  const handleFormat = useCallback((action: FormatAction) => {
+    const view = editorRef.current?.getView();
+    if (!view) return;
+    const range = applyFormat(view, action);
+    if (range) {
+      const newText = view.state.sliceDoc(range.from, range.to).trim();
+      if (newText.length >= 3) setPreviewText(newText);
+    }
+  }, []);
 
   useEffect(() => {
     if (!spawnLoading) return;
@@ -348,10 +515,10 @@ export function NoteEditor({ note }: NoteEditorProps) {
       ref={containerRef}
       className="flex flex-col h-full overflow-hidden"
       onMouseDown={(e) => {
-        // Dismiss toolbar when clicking outside the editor content
+        // Dismiss preview when clicking outside the editor or docked panels
         const target = e.target as HTMLElement;
-        if (!target.closest(".cm-editor") && !target.closest("[data-ai-toolbar]")) {
-          setToolbarPos(null);
+        if (!target.closest(".cm-editor") && !target.closest("[data-ai-toolbar]") && !target.closest("[data-md-preview-portal]")) {
+          setPreviewText(null);
         }
       }}
     >
@@ -372,7 +539,7 @@ export function NoteEditor({ note }: NoteEditorProps) {
             Write
           </button>
           <button
-            onClick={() => setMode("read")}
+            onClick={() => { flushPending(); setMode("read"); }}
             className={cn(
               "flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium transition-colors",
               mode === "read"
@@ -464,6 +631,20 @@ export function NoteEditor({ note }: NoteEditorProps) {
         />
       </div>
 
+      {/* ── AI + Format toolbar — write mode only ───────────────────────────── */}
+      {mode === "write" && (
+        <AITextToolbar
+          onAction={handleAIAction}
+          onFormat={handleFormat}
+          loading={aiLoading}
+          hasSelection={hasSelection}
+          onDismiss={() => {
+            setPreviewText(null);
+            selectionRef.current = null;
+          }}
+        />
+      )}
+
       {/* ── Editor / Preview ────────────────────────────────────────────────── */}
       <div className="flex-1 min-h-0 overflow-hidden relative">
         {/* CodeMirror — always mounted so state is preserved when toggling */}
@@ -480,7 +661,7 @@ export function NoteEditor({ note }: NoteEditorProps) {
 
         {/* Read / preview pane */}
         {mode === "read" && (
-          <div ref={previewScrollRef} className="absolute inset-0 overflow-y-auto">
+          <div ref={previewScrollRef} className="absolute inset-0 overflow-y-auto overflow-x-hidden">
             {/* TOC — floats to the right of the content column on wide viewports */}
             {note.content && (
               <TableOfContents
@@ -622,8 +803,7 @@ export function NoteEditor({ note }: NoteEditorProps) {
                       },
                       // Inline code only — fenced blocks are handled by `pre` above
                       code({ className, children }) {
-                        if (className?.startsWith("language-")) return <>{children}</>;
-                        return <code className="px-1 py-0.5 rounded bg-[var(--surface-3)] font-mono text-[0.786rem] text-[var(--text-primary)]">{children}</code>;
+                        return <InlineCode className={className}>{children}</InlineCode>;
                       },
                       // Headings get id + data-heading-id for TOC anchor scrolling
                       h1({ children }) {
@@ -735,16 +915,13 @@ export function NoteEditor({ note }: NoteEditorProps) {
       {/* ── Backlinks panel ─────────────────────────────────────────────────── */}
       <BacklinksPanel note={note} notes={notes} cards={cards} columns={columns} onOpenCard={() => setView("board")} />
 
-      {/* ── AI floating toolbar ─────────────────────────────────────────────── */}
-      {toolbarPos && (
-        <AITextToolbar
-          position={toolbarPos}
-          onAction={handleAIAction}
-          loading={aiLoading}
-          onDismiss={() => {
-            setToolbarPos(null);
-            selectionRef.current = null;
-          }}
+
+
+      {/* ── MD preview panel — docked to bottom of editor ───────────────────── */}
+      {previewText && (
+        <MDPreviewPanel
+          text={previewText}
+          onDismiss={() => setPreviewText(null)}
         />
       )}
     </div>

--- a/src/components/notes/notes-view.tsx
+++ b/src/components/notes/notes-view.tsx
@@ -85,6 +85,7 @@ export function NotesView() {
     revealNote, generatePrd,
     getTagById,
     getWorkspaceProjects,
+    notes: allNotes,
   } = useCairnStore();
 
   const [activeNoteId, setActiveNoteId]         = useState<string | null>(null);
@@ -104,13 +105,18 @@ export function NotesView() {
   const [folderMoveNoteId, setFolderMoveNoteId]  = useState<string | null>(null);
   const [folderMoveDest, setFolderMoveDest]       = useState("");
 
+  // Subscribe to allNotes directly so this component re-renders when note
+  // content changes (e.g. while typing). The selector functions are stable
+  // references and don't trigger re-renders on content updates.
   const notes         = useMemo(
     () => activeProjectId ? getProjectNotes(activeProjectId) : [],
-    [activeProjectId, getProjectNotes],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeProjectId, allNotes],
   );
   const archivedNotes = useMemo(
     () => activeProjectId ? getArchivedProjectNotes(activeProjectId) : [],
-    [activeProjectId, getArchivedProjectNotes],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeProjectId, allNotes],
   );
   const workspaceProjects = activeWorkspaceId ? getWorkspaceProjects(activeWorkspaceId) : [];
   const projectTagIds   = [...new Set(notes.flatMap((n) => n.tagIds))];


### PR DESCRIPTION
## What does this PR do?

Adds v0.9.1 changelog and a large editor update: introduces an inline AI + formatting toolbar (no portal) with AI actions and grouped formatting buttons, and a docked markdown preview panel. Exports applyFormat (with comprehensive inline/line/block formatting logic) for CodeMirror integration and buildAIActionPrompt for AI actions. Renders color swatches for inline code values.

Fixes several sync/consistency issues: implements suppressNextChange in the file watcher and calls it from IPC write handlers to avoid chokidar self-write loops and stale re-hydration; skip hydrateFromElectron on own writes to prevent optimistic state being overwritten. Adds flushPending to NoteEditor to synchronously flush debounced saves on navigation/unmount and invokes it when switching to Read mode. Ensures ColumnBreakdownCard derives counts from allCards (fixes stale counts) and updates NotesView memo dependencies to subscribe to allNotes so edits render live.
## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code quality
- [ ] Docs / changelog
- [ ] Tests

## Screenshots / recording

<img width="1346" height="817" alt="image" src="https://github.com/user-attachments/assets/af9ed68e-76aa-45c1-89f2-6c267958b924" />

## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

