### PR TITLE
Asset protocol: dynamic workspace and serve files

### DIFF
--- a/changelogs/v0.9.3.md
+++ b/changelogs/v0.9.3.md
@@ -1,0 +1,14 @@
+# v0.9.3
+
+## Bug fixes
+
+### Pasted images not rendering in Read mode
+Images pasted into notes were saved correctly to disk but never displayed in Read mode — the image area was blank.
+
+Three separate issues were identified and fixed:
+
+1. **`react-markdown` URL sanitization** — the root cause. `react-markdown` v10 introduced a `urlTransform` that silently strips any URL not on its allowlist (`http`, `https`, `mailto`, `tel`). The `asset://` scheme used for local images was not on the list, so `src` arrived at the `img` component as an empty string. Fixed by passing a custom `urlTransform` that passes `asset://` URLs through unchanged and delegates everything else to `defaultUrlTransform`.
+
+2. **Wrong workspace path in the asset protocol handler** — `registerAssetProtocol` was called with the fallback `userData/cairn` path before onboarding completed, so the handler was looking for image files in the wrong directory. Fixed by registering the handler once at startup with no path, and updating the path separately via `setAssetWorkspacePath()` — called with the correct workspace path on startup and again whenever the workspace changes.
+
+3. **Double protocol registration on workspace change** — `reinitialise()` called `registerAssetProtocol()` a second time after the user picked a workspace folder. Electron's `protocol.handle` throws if the scheme is already registered, silently breaking the reinitialise path. Fixed as part of the same refactor — the handler is now registered once and the path is updated in place.

--- a/electron/lib/protocol.ts
+++ b/electron/lib/protocol.ts
@@ -16,25 +16,43 @@ import { pathToFileURL } from "url";
 
 const isDev = !app.isPackaged;
 
-// workspacePath is set once registerAssetProtocol() is called from main.ts
+// Active workspace path — updated by setAssetWorkspacePath() without
+// re-registering the handler (protocol.handle may only be called once per scheme).
 let _workspacePath: string | null = null;
 
-export function registerAssetProtocol(workspacePath: string): void {
+/**
+ * Update the workspace path used by the asset:// handler.
+ * Call this whenever the active workspace changes (initial setup + reinitialise).
+ */
+export function setAssetWorkspacePath(workspacePath: string): void {
   _workspacePath = workspacePath;
+}
+
+/**
+ * Register the asset:// protocol handler exactly once on app startup.
+ * Uses _workspacePath at request time so setAssetWorkspacePath() updates
+ * take effect immediately without re-registering.
+ */
+export function registerAssetProtocol(): void {
   session.defaultSession.protocol.handle("asset", (request) => {
     const url = new URL(request.url);
-    // url.hostname is the filename, e.g. asset://abc123.png → hostname="abc123.png"
-    // url.pathname may be "/" — the actual filename is in hostname for asset:// URLs
     const filename = decodeURIComponent(url.hostname + url.pathname.replace(/^\//, ""));
     if (!_workspacePath) return new Response("No workspace", { status: 503 });
     const assetDir = path.resolve(_workspacePath, "assets");
-    // path.resolve normalises any `../` sequences before the traversal check.
     const filePath = path.resolve(assetDir, filename);
     if (!filePath.startsWith(assetDir + path.sep) && filePath !== assetDir) {
       return new Response("Forbidden", { status: 403 });
     }
     if (!fs.existsSync(filePath)) return new Response("Not found", { status: 404 });
-    return net.fetch(pathToFileURL(filePath).href);
+    const ext = path.extname(filePath).toLowerCase().slice(1);
+    const mimeTypes: Record<string, string> = {
+      png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
+      gif: "image/gif", webp: "image/webp", svg: "image/svg+xml",
+      avif: "image/avif",
+    };
+    const mime = mimeTypes[ext] ?? "application/octet-stream";
+    const data = fs.readFileSync(filePath);
+    return new Response(data, { headers: { "Content-Type": mime } });
   });
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -22,7 +22,7 @@ import { registerIpcHandlers, registerAppHandlers } from "./ipc/handlers";
 import { readWorkspaceConfig, getDbPathForWorkspace } from "./workspace-config";
 import { startFileWatcher } from "./file-watcher";
 import { markMcpNotificationsRead } from "./db/queries";
-import { setupProtocol, registerAssetProtocol } from "./lib/protocol";
+import { setupProtocol, registerAssetProtocol, setAssetWorkspacePath } from "./lib/protocol";
 import { createTray } from "./lib/tray";
 import { startMcpNotificationPoller } from "./lib/mcp-poller";
 
@@ -140,9 +140,10 @@ app.whenReady().then(async () => {
 
   if (config) fs.mkdirSync(initialWorkspacePath, { recursive: true });
 
-  // Register asset:// protocol handler so the renderer can display pasted images.
-  // Re-registered in reinitialise() when workspace changes.
-  registerAssetProtocol(initialWorkspacePath);
+  // Register the asset:// protocol handler once. The workspace path it reads
+  // is updated via setAssetWorkspacePath() — no re-registration needed.
+  registerAssetProtocol();
+  setAssetWorkspacePath(initialWorkspacePath);
 
   const initialDbPath = getDbPathForWorkspace(initialWorkspacePath);
   const initialDb = initDb(initialDbPath);
@@ -187,8 +188,8 @@ app.whenReady().then(async () => {
     // Restart file watcher on the new path
     startFileWatcher(newWorkspacePath, newDb, notifyDbChanged);
 
-    // Re-register the asset:// protocol for the new workspace
-    registerAssetProtocol(newWorkspacePath);
+    // Point the asset:// handler at the new workspace (no re-registration needed)
+    setAssetWorkspacePath(newWorkspacePath);
 
     // Tell the renderer to re-hydrate from the new DB
     if (!win.isDestroyed()) {

--- a/src/components/notes/note-editor.tsx
+++ b/src/components/notes/note-editor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useRef, useCallback, useState, useEffect, useMemo } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
@@ -675,12 +675,13 @@ export function NoteEditor({ note }: NoteEditorProps) {
               {note.content ? (
                 <div className="prose-cairn">
                   <ReactMarkdown
-                    remarkPlugins={[remarkGfm, remarkMath, remarkPromoteDisplayMath, remarkCallout]}
-                    rehypePlugins={[rehypeCaptureLatex, rehypeKatex, rehypeMergedPass]}
-                    components={({
+                     remarkPlugins={[remarkGfm, remarkMath, remarkPromoteDisplayMath, remarkCallout]}
+                     rehypePlugins={[rehypeCaptureLatex, rehypeKatex, rehypeMergedPass]}
+                     urlTransform={(url) => url.startsWith("asset://") ? url : defaultUrlTransform(url)}
+                     components={({
                       // Images — renders asset:// and https:// URLs
                       img({ src, alt }) {
-                        const srcStr = typeof src === "string" ? src : undefined;
+                        const srcStr = typeof src === "string" && src !== "" ? src : undefined;
                         const isExternal = srcStr?.startsWith("http://") || srcStr?.startsWith("https://");
                         const imgEl = (
                           <img


### PR DESCRIPTION
## What does this PR do?

Register the asset:// protocol once and allow updating the active workspace path at runtime via setAssetWorkspacePath(), avoiding re-registration when the workspace changes. The protocol handler now reads files directly from the workspace assets directory, returns file bytes with a proper Content-Type (basic MIME map), and preserves the traversal check. main.ts updated to call registerAssetProtocol() once and to set the initial/updated workspace via setAssetWorkspacePath().

Also update the markdown renderer to preserve asset:// links (use urlTransform to pass through asset:// URLs) and tighten image src handling to treat empty src as undefined. These changes simplify protocol lifecycle and ensure asset images are served correctly to the renderer.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Docs / changelog
- [ ] Tests

## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

The real root cause was `react-markdown` v10's `urlTransform` silently stripping `asset://` URLs — `src` arrived at the `img` component as an empty string with no error. The protocol handler fixes (single registration, correct workspace path) were also necessary but wouldn't have helped on their own since the URL never reached the handler. The last three checklist items are N/A — no new IPC handlers, no schema changes, no mcp-server changes.