### PR TITLE
Prevent file-watcher deletes and sync notes from disk

### DIFF
--- a/changelogs/v0.9.5.md
+++ b/changelogs/v0.9.5.md
@@ -1,0 +1,23 @@
+# v0.9.5
+
+## Bug fixes
+
+### Notes in folders deleted on rename
+Renaming a note that was in a subfolder caused the note to be permanently deleted from SQLite. The file watcher fires an `unlink` event when `writeNoteFile` deletes the old filename before writing the new one. Because `suppressNextChange` was called *after* `q.updateNote`, the suppress arrived too late — the watcher's delete handler had already looked up the note ID from its path map and deleted the SQLite row. Fixed by calling `suppressNextChange(id)` before the database operation in all three write handlers (`db:note:update`, `db:note:restore`, `db:note:moveToFolder`), and adding a second guard in `handleFileDelete` that skips deletion when the note ID is still in the suppress set.
+
+### Notes missing from SQLite after restart
+Notes created or moved during a session occasionally disappeared after restarting the app, even though the `.md` file was correctly written to disk. On startup, `syncNotesFromDisk` now walks the entire notes directory and upserts any `.md` file whose `id` is not present in SQLite, making the disk the recovery source of truth. This runs once on startup and again after `reinitialise()` when the workspace changes.
+
+### Note title rename lag and stale save
+The title input was bound directly to the store, causing a full IPC → SQLite → re-render round-trip on every debounce tick. Fast typing left multiple debounce timers in flight each holding a stale captured value, so the wrong title could be saved. Fixed with local state for instant input response, a ref that always holds the latest typed value, and an `onBlur` handler that saves immediately and reverts to the last valid title if the field is left empty.
+
+### Empty title crash
+Clearing a note title and tabbing away triggered `Cannot read properties of undefined (reading 'id')` downstream. The title handler now never saves an empty string — the debounce no-ops if the trimmed value is empty, and `onBlur` reverts the input to the last saved title.
+
+## Improvements
+
+### Folder tree for Move to folder and New folder
+Both the "Move to folder" and "New folder" dialogs now show an interactive folder tree instead of a plain text input. Each folder row in the tree has a `+` button on hover to create a child folder inline — the input appears directly below the row, pre-scoped to that parent. Clicking a folder row in Move mode moves the note immediately. The Root row is always shown. Empty folders are visible in the tree and fully selectable.
+
+### Empty folder state
+Empty folders in the notes sidebar now show a "New note" button inside the folder body instead of rendering nothing, making it easy to add the first note without right-clicking or using the toolbar.

--- a/electron/file-watcher.ts
+++ b/electron/file-watcher.ts
@@ -113,6 +113,11 @@ function handleFileDelete(filePath: string, db: Database.Database, onChanged: ()
 
   if (!noteId) return; // file was never tracked (e.g. not a Cairn note)
 
+  // If the note is suppressed, the file was deleted by the app itself as part
+  // of a rename/move (writeNoteFile deletes the old path before writing the new
+  // one). The note still exists in SQLite under the new path — do not delete it.
+  if (suppressedNoteIds.has(noteId)) return;
+
   try {
     q.deleteNote(db, noteId);
     onChanged();

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -156,9 +156,9 @@ export function registerIpcHandlers(ctx: DbContext): void {
         }
         q.updateNote(ctx.db, id, enrichedRest);
       }
+      suppressNextChange(id);
       const note = q.restoreNote(ctx.db, id);
       if (note.type !== "dashboard") {
-        suppressNextChange(note.id);
         writeNoteFile(ctx.workspacePath, { ...note, projectName: getProjectName(ctx.db, note.projectId) });
       }
       return note;
@@ -167,9 +167,11 @@ export function registerIpcHandlers(ctx: DbContext): void {
     if (patch.content !== undefined && patch.contentText === undefined) {
       enrichedPatch.contentText = stripMarkdown(patch.content);
     }
+    // Suppress before the update so the watcher's unlink event (fired when
+    // writeNoteFile renames the file) is ignored before it can delete the row.
+    suppressNextChange(id);
     const note = q.updateNote(ctx.db, id, enrichedPatch);
     if (note.type !== "dashboard") {
-      suppressNextChange(note.id);
       writeNoteFile(ctx.workspacePath, {
         ...note,
         projectName: getProjectName(ctx.db, note.projectId),
@@ -182,9 +184,9 @@ export function registerIpcHandlers(ctx: DbContext): void {
   ipcMain.handle("db:note:moveToFolder", (_e, { id, folder }: { id: string; folder: string }) => handle(() => {
     // Use moveNoteFolder (direct SET) rather than updateNote (COALESCE) so that
     // moving a note to root (folder="") is never silently ignored.
+    suppressNextChange(id);
     const note = q.moveNoteFolder(ctx.db, id, folder ?? "");
     if (note.type !== "dashboard") {
-      suppressNextChange(note.id);
       writeNoteFile(ctx.workspacePath, { ...note, projectName: getProjectName(ctx.db, note.projectId) });
     }
     return note;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -21,6 +21,7 @@ import { initDb } from "./db/client";
 import { registerIpcHandlers, registerAppHandlers } from "./ipc/handlers";
 import { readWorkspaceConfig, getDbPathForWorkspace } from "./workspace-config";
 import { startFileWatcher } from "./file-watcher";
+import { syncNotesFromDisk } from "./notes-files";
 import { markMcpNotificationsRead } from "./db/queries";
 import { setupProtocol, registerAssetProtocol, setAssetWorkspacePath } from "./lib/protocol";
 import { createTray } from "./lib/tray";
@@ -148,6 +149,10 @@ app.whenReady().then(async () => {
   const initialDbPath = getDbPathForWorkspace(initialWorkspacePath);
   const initialDb = initDb(initialDbPath);
 
+  // Recover any notes written to disk but missing from SQLite (e.g. due to
+  // a fire-and-forget IPC race or unexpected shutdown).
+  syncNotesFromDisk(initialDb, initialWorkspacePath);
+
   // ── Mutable context — swapped in reinitialise() without relaunching ──
   const ctx: import("./ipc/handlers").DbContext = {
     db: initialDb,
@@ -180,6 +185,9 @@ app.whenReady().then(async () => {
     // Open the new DB
     const newDbPath = getDbPathForWorkspace(newWorkspacePath);
     const newDb = initDb(newDbPath);
+
+    // Recover any notes on disk not yet in SQLite before swapping context
+    syncNotesFromDisk(newDb, newWorkspacePath);
 
     // Swap context — all handlers read from ctx at call time
     ctx.db = newDb;

--- a/electron/notes-files.ts
+++ b/electron/notes-files.ts
@@ -231,6 +231,38 @@ export function parseNoteFile(filePath: string): NoteData | null {
   }
 }
 
+// ── Startup sync ──────────────────────────────
+//
+// Walks the entire notes directory and upserts every .md file whose id is not
+// already present in SQLite. Runs once on startup (and after reinitialise) so
+// that notes written to disk but not committed to SQLite (e.g. due to a
+// fire-and-forget IPC race or an unexpected shutdown) are recovered.
+
+export function syncNotesFromDisk(db: Database.Database, workspacePath: string): void {
+  const root = notesDir(workspacePath);
+  if (!fs.existsSync(root)) return;
+  syncDir(db, root);
+}
+
+function syncDir(db: Database.Database, dir: string): void {
+  for (const entry of fs.readdirSync(dir)) {
+    const fp = path.join(dir, entry);
+    const stat = fs.lstatSync(fp);
+    if (stat.isDirectory()) {
+      syncDir(db, fp);
+    } else if (entry.endsWith(".md")) {
+      const note = parseNoteFile(fp);
+      if (!note) continue;
+      // Only upsert if the note is missing from SQLite — avoids overwriting
+      // in-memory state that is ahead of the file (e.g. unsaved edits).
+      const exists = db.prepare("SELECT id FROM notes WHERE id = ?").get(note.id);
+      if (!exists) {
+        upsertNoteFromFile(db, note);
+      }
+    }
+  }
+}
+
 // ── Upsert a parsed note into SQLite ──────────
 //
 // Uses INSERT OR IGNORE + UPDATE to avoid UNIQUE constraint errors when the

--- a/src/components/notes/note-editor.tsx
+++ b/src/components/notes/note-editor.tsx
@@ -416,11 +416,25 @@ export function NoteEditor({ note }: NoteEditorProps) {
       titleRef.current = value;
       if (titleTimer.current) clearTimeout(titleTimer.current);
       titleTimer.current = setTimeout(() => {
-        updateNote(note.id, { title: titleRef.current });
+        const t = titleRef.current.trim();
+        if (!t) return; // never save an empty title
+        updateNote(note.id, { title: t });
       }, 500);
     },
     [note.id, updateNote]
   );
+
+  const handleTitleBlur = useCallback(() => {
+    if (titleTimer.current) clearTimeout(titleTimer.current);
+    const t = titleRef.current.trim();
+    if (!t) {
+      // Revert to last saved title if field is left empty
+      setLocalTitle(note.title);
+      titleRef.current = note.title;
+      return;
+    }
+    updateNote(note.id, { title: t });
+  }, [note.id, note.title, updateNote]);
 
   // ── AI toolbar — driven by CodeMirror selection events ────────────────────
   const handleSelectionChange = useCallback(
@@ -625,6 +639,7 @@ export function NoteEditor({ note }: NoteEditorProps) {
           type="text"
           value={localTitle}
           onChange={handleTitleChange}
+          onBlur={handleTitleBlur}
           placeholder="Note title"
           className="w-full bg-transparent text-2xl font-bold text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none tracking-tight max-w-4xl mx-auto block"
         />

--- a/src/components/notes/notes-view.tsx
+++ b/src/components/notes/notes-view.tsx
@@ -134,7 +134,18 @@ export function NotesView() {
     : buildFolderTree(notes);
 
   // All unique folder paths for the "move to folder" picker
-  const allFolderPaths = [...new Set(notes.map((n) => n.folder).filter(Boolean))].sort();
+  // Collect all folder paths from the tree (includes empty folders)
+  const allFolderPaths = useMemo(() => {
+    const paths: string[] = [];
+    function collect(nodes: typeof folderTree) {
+      for (const node of nodes) {
+        paths.push(node.path);
+        collect(node.children);
+      }
+    }
+    collect(folderTree);
+    return paths.sort();
+  }, [folderTree]);
 
   // Auto-select first note
   useEffect(() => {
@@ -412,84 +423,29 @@ export function NotesView() {
       )}
 
       {/* New folder dialog */}
-      <Dialog open={newFolderOpen} onOpenChange={(o) => { if (!o) { setNewFolderOpen(false); setNewFolderName(""); } }}>
-        <DialogContent size="sm">
-          <DialogHeader>
-            <DialogTitle>New folder</DialogTitle>
-          </DialogHeader>
-          <div className="px-5 py-4 space-y-3">
-            <input
-              autoFocus
-              value={newFolderName}
-              onChange={(e) => setNewFolderName(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") handleCreateFolder(); if (e.key === "Escape") { setNewFolderOpen(false); setNewFolderName(""); } }}
-              placeholder="Folder name (e.g. Design/Typography)"
-              className="w-full px-3 py-2 text-sm rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent-dim)]"
-            />
-            <p className="text-[0.786rem] text-[var(--text-tertiary)]">
-              Use / to create nested folders, e.g. <span className="font-mono">Research/Papers</span>
-            </p>
-            <div className="flex justify-end gap-2">
-              <DialogClose asChild>
-                <Button variant="ghost" size="sm">Cancel</Button>
-              </DialogClose>
-              <Button variant="accent" size="sm" onClick={handleCreateFolder} disabled={!newFolderName.trim()}>
-                <FolderPlus size={12} /> Create folder
-              </Button>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
+      {newFolderOpen && (
+        <FolderPickerDialog
+          folderTree={folderTree}
+          mode="create"
+          onSelect={(path) => {
+            handleCreateNote(path);
+            setCollapsedFolders((prev) => ({ ...prev, [path]: false }));
+            setNewFolderOpen(false);
+          }}
+          onClose={() => setNewFolderOpen(false)}
+        />
+      )}
 
       {/* Move note to folder dialog */}
-      <Dialog open={!!folderMoveNoteId} onOpenChange={(o) => { if (!o) { setFolderMoveNoteId(null); setFolderMoveDest(""); } }}>
-        <DialogContent size="sm">
-          <DialogHeader>
-            <DialogTitle>Move to folder</DialogTitle>
-          </DialogHeader>
-          <div className="px-5 py-4 space-y-3">
-            <input
-              autoFocus
-              value={folderMoveDest}
-              onChange={(e) => setFolderMoveDest(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter" && folderMoveNoteId) { handleMoveNoteToFolder(folderMoveNoteId, folderMoveDest); } if (e.key === "Escape") { setFolderMoveNoteId(null); setFolderMoveDest(""); } }}
-              placeholder="Folder path (leave blank for root)"
-              className="w-full px-3 py-2 text-sm rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent-dim)]"
-            />
-            {allFolderPaths.length > 0 && (
-              <div className="space-y-0.5">
-                <p className="text-[0.714rem] text-[var(--text-tertiary)] uppercase tracking-wider">Existing folders</p>
-                <button
-                  onClick={() => { if (folderMoveNoteId) handleMoveNoteToFolder(folderMoveNoteId, ""); }}
-                  className="w-full text-left px-2 py-1 rounded text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-2)] transition-colors"
-                >
-                  / (root)
-                </button>
-                {allFolderPaths.map((fp) => (
-                  <button
-                    key={fp}
-                    onClick={() => { if (folderMoveNoteId) handleMoveNoteToFolder(folderMoveNoteId, fp); }}
-                    className="w-full text-left px-2 py-1 rounded text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-2)] transition-colors"
-                  >
-                    {fp}
-                  </button>
-                ))}
-              </div>
-            )}
-            <div className="flex justify-end gap-2">
-              <DialogClose asChild>
-                <Button variant="ghost" size="sm">Cancel</Button>
-              </DialogClose>
-              <Button
-                variant="accent" size="sm"
-                onClick={() => { if (folderMoveNoteId) handleMoveNoteToFolder(folderMoveNoteId, folderMoveDest); }}
-              >
-                <FolderSymlink size={12} /> Move
-              </Button>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
+      {folderMoveNoteId && (
+        <FolderPickerDialog
+          folderTree={folderTree}
+          mode="move"
+          currentFolder={notes.find((n) => n.id === folderMoveNoteId)?.folder ?? ""}
+          onSelect={(fp) => { handleMoveNoteToFolder(folderMoveNoteId, fp); }}
+          onClose={() => { setFolderMoveNoteId(null); setFolderMoveDest(""); }}
+        />
+      )}
 
       <Dialog open={!!deleteNoteId} onOpenChange={(o) => { if (!o) setDeleteNoteId(null); }}>
         <DialogContent size="sm">
@@ -610,6 +566,17 @@ const FolderTreeNode = memo(function FolderTreeNode({
               onReveal={() => onNoteReveal(note)}
             />
           ))}
+          {/* Empty folder state */}
+          {node.notes.length === 0 && node.children.length === 0 && (
+            <button
+              onClick={() => onCreateInFolder(node.path)}
+              className="w-full flex items-center gap-1.5 px-2 py-1.5 text-[0.714rem] text-[var(--text-tertiary)] hover:text-[var(--accent)] hover:bg-[var(--surface-2)] transition-colors"
+              style={{ paddingLeft: `${indent + 24}px` }}
+            >
+              <Plus size={10} />
+              New note
+            </button>
+          )}
         </div>
       )}
     </div>
@@ -704,6 +671,232 @@ function ArchivedNoteListItem({ note, onRestore, onDelete }: { note: Note; onRes
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+    </div>
+  );
+}
+
+// ── FolderPickerDialog ────────────────────────────────────────────────────────
+
+interface FolderPickerDialogProps {
+  folderTree: FolderNode[];
+  /** "move" — clicking a row moves immediately. "create" — picking a row sets parent, inline input creates child. */
+  mode: "move" | "create";
+  currentFolder?: string;
+  onSelect: (folder: string) => void;
+  onClose: () => void;
+}
+
+function FolderPickerDialog({ folderTree, mode, currentFolder = "", onSelect, onClose }: FolderPickerDialogProps) {
+  // parentPath="" means creating at root; "Design" means child of Design
+  const [addingUnder, setAddingUnder] = useState<string | null>(null);
+  const [newFolderName, setNewFolderName] = useState("");
+  const newInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (addingUnder !== null) newInputRef.current?.focus();
+  }, [addingUnder]);
+
+  function handleCreate() {
+    const name = newFolderName.trim();
+    if (!name) return;
+    const full = addingUnder ? `${addingUnder}/${name}` : name;
+    onSelect(full);
+  }
+
+  function openAdd(parentPath: string, e: React.MouseEvent) {
+    e.stopPropagation();
+    setAddingUnder(parentPath);
+    setNewFolderName("");
+  }
+
+  function cancelAdd() {
+    setAddingUnder(null);
+    setNewFolderName("");
+  }
+
+  const inlineInput = (
+    <div className="flex items-center gap-2 px-3 py-2 border-t border-[var(--border)] bg-[var(--surface-2)]">
+      <FolderPlus size={12} className="text-[var(--accent)] shrink-0" />
+      <input
+        ref={newInputRef}
+        value={newFolderName}
+        onChange={(e) => setNewFolderName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleCreate();
+          if (e.key === "Escape") cancelAdd();
+        }}
+        placeholder="Folder name…"
+        className="flex-1 bg-transparent text-xs text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] outline-none"
+      />
+      <button
+        onClick={handleCreate}
+        disabled={!newFolderName.trim()}
+        className="text-[0.714rem] text-[var(--accent)] disabled:opacity-30 hover:underline shrink-0"
+      >
+        Create & move
+      </button>
+      <button onClick={cancelAdd} className="text-[0.714rem] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]">
+        ✕
+      </button>
+    </div>
+  );
+
+  return (
+    <Dialog open onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent size="sm">
+        <DialogHeader>
+          <DialogTitle>{mode === "create" ? "New folder" : "Move to folder"}</DialogTitle>
+        </DialogHeader>
+        <div className="px-5 pb-5 pt-1">
+          <div className="rounded-lg border border-[var(--border)] overflow-hidden mb-3">
+
+            {/* Root row */}
+            <div className={cn(
+              "group flex items-center gap-2 px-3 py-2 text-xs transition-colors border-b border-[var(--border)]",
+              currentFolder === "" && mode === "move" ? "bg-[var(--accent-dim)] text-[var(--accent)]" : "text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+            )}>
+              <button
+                className="flex items-center gap-2 flex-1 min-w-0 text-left"
+                onClick={() => mode === "move" ? onSelect("") : openAdd("", { stopPropagation: () => {} } as React.MouseEvent)}
+              >
+                <Folder size={12} className="shrink-0" />
+                <span className="font-medium">Root</span>
+              </button>
+              <button
+                onClick={(e) => openAdd("", e)}
+                className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--accent)] transition-all"
+                title="New folder in root"
+              >
+                <FolderPlus size={11} />
+              </button>
+            </div>
+
+            {/* Inline input under root */}
+            {addingUnder === "" && inlineInput}
+
+            {folderTree.length === 0 && addingUnder === null && (
+              <p className="px-3 py-3 text-[0.714rem] text-[var(--text-tertiary)]">No folders yet</p>
+            )}
+
+            {/* Recursive tree */}
+            {folderTree.map((node) => (
+              <FolderPickerNode
+                key={node.path}
+                node={node}
+                currentFolder={currentFolder}
+                depth={0}
+                mode={mode}
+                addingUnder={addingUnder}
+                newFolderName={newFolderName}
+                newInputRef={newInputRef}
+                onSelect={onSelect}
+                onOpenAdd={openAdd}
+                onNameChange={setNewFolderName}
+                onCreate={handleCreate}
+                onCancel={cancelAdd}
+                inlineInput={inlineInput}
+              />
+            ))}
+          </div>
+
+          <div className="flex justify-end">
+            <DialogClose asChild>
+              <Button variant="ghost" size="sm">Cancel</Button>
+            </DialogClose>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface FolderPickerNodeProps {
+  node: FolderNode;
+  currentFolder: string;
+  depth: number;
+  mode: "move" | "create";
+  addingUnder: string | null;
+  newFolderName: string;
+  newInputRef: React.RefObject<HTMLInputElement | null>;
+  onSelect: (folder: string) => void;
+  onOpenAdd: (parentPath: string, e: React.MouseEvent) => void;
+  onNameChange: (v: string) => void;
+  onCreate: () => void;
+  onCancel: () => void;
+  inlineInput: React.ReactNode;
+}
+
+function FolderPickerNode({
+  node, currentFolder, depth, mode, addingUnder, onSelect, onOpenAdd, inlineInput,
+}: FolderPickerNodeProps) {
+  const [open, setOpen] = useState(true);
+  const isSelected = mode === "move" && currentFolder === node.path;
+  const indent = depth * 12;
+
+  return (
+    <div className="border-t border-[var(--border)]">
+      <div
+        className={cn(
+          "group flex items-center gap-2 text-xs transition-colors",
+          isSelected
+            ? "bg-[var(--accent-dim)] text-[var(--accent)]"
+            : "text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+        )}
+        style={{ paddingLeft: `${12 + indent}px`, paddingRight: "12px", paddingTop: "7px", paddingBottom: "7px" }}
+      >
+        {/* Chevron */}
+        {node.children.length > 0 ? (
+          <button
+            onClick={(e) => { e.stopPropagation(); setOpen((o) => !o); }}
+            className="shrink-0 text-[var(--text-tertiary)]"
+          >
+            {open ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
+          </button>
+        ) : (
+          <span className="w-[10px] shrink-0" />
+        )}
+        {/* Folder name */}
+        <button
+          className="flex items-center gap-2 flex-1 min-w-0 text-left"
+          onClick={(e) => mode === "move" ? onSelect(node.path) : onOpenAdd(node.path, e)}
+        >
+          {open && node.children.length > 0
+            ? <FolderOpen size={12} className="shrink-0" />
+            : <Folder size={12} className="shrink-0" />}
+          <span className="truncate">{node.name}</span>
+        </button>
+        {/* Add child folder button */}
+        <button
+          onClick={(e) => onOpenAdd(node.path, e)}
+          className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--accent)] transition-all shrink-0"
+          title={`New folder in ${node.name}`}
+        >
+          <FolderPlus size={11} />
+        </button>
+      </div>
+
+      {/* Inline input for this node */}
+      {addingUnder === node.path && inlineInput}
+
+      {/* Children */}
+      {open && node.children.map((child) => (
+        <FolderPickerNode
+          key={child.path}
+          node={child}
+          currentFolder={currentFolder}
+          depth={depth + 1}
+          mode={mode}
+          addingUnder={addingUnder}
+          newFolderName=""
+          newInputRef={{ current: null }}
+          onSelect={onSelect}
+          onOpenAdd={onOpenAdd}
+          onNameChange={() => {}}
+          onCreate={() => {}}
+          onCancel={() => {}}
+          inlineInput={inlineInput}
+        />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Fix a race where renaming/moving notes could cause the file watcher to delete SQLite rows by: suppressing watcher events before DB write operations in IPC handlers and adding a suppressed-note check in the file-watcher delete handler. Add syncNotesFromDisk to walk the notes dir on startup and after reinitialise to upsert .md files missing from SQLite (recover notes written to disk but not committed). Improve note title editing: use local state/ref, debounced saves with an onBlur immediate save, and never persist empty titles (avoids stale saves and downstream crashes). Replace simple New folder / Move dialogs with a FolderPickerDialog tree (shows empty folders, inline create child folders, and immediate move on select) and add a "New note" action for empty folders in the sidebar. Add changelog v0.9.5.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [ ] Docs / changelog
- [ ] Tests


## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [ ] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

<!-- Anything you're unsure about, decisions you'd like feedback on, or areas to pay extra attention to. Delete if not needed. -->
