### PR TITLE
feat: interactive PRD generation, ask_questions tool, note drag-to-folder, markdown line break fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,3 +119,8 @@ Notes write to both `.md` files and SQLite simultaneously. Dashboards write to S
 - All DB writes from renderer go through `ipc()` / `ipcAwait()` to the Electron main process
 - `graphData` is lazy — only populated when `loadGraph(activeWorkspaceId)` is called. Both `KnowledgeGraphView` and `InsightsView` call it on mount.
 - D3 `fontSize` in SVG must always be multiplied by `useFontScale()` — never hardcode px values
+
+## Project Management
+
+Use cairn mcp server to manage notes, tasks and idea flow nodes.  
+When you find anything interesting create a note in the right project and add a card to the board (if needed).

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Cairn is a desktop app (Electron + Next.js) that combines markdown notes with a 
 - **Notes** — Split-pane markdown editor (write on the left, preview on the right)
 - **AI text actions** — Select any text in a note → floating toolbar → Rephrase, Summarize, Expand, Fix Grammar, Change Tone, or custom prompt
 - **Kanban board** — Drag-and-drop cards across columns with priority indicators
+- **Drag notes into folders** — Drag any note in the sidebar directly onto a folder row to move it; a "Move to root" drop zone appears while dragging
 - **Linked context** — Notes and cards reference each other bidirectionally
 - **Global search** — Instant full-text search across all notes and tasks (`⌘K`)
-- **AI chat** — Integrated assistant with live project context; reads and writes your data (`⌘/`)
+- **AI chat** — Integrated assistant with live project context; reads and writes your data (`⌘/`); supports inline `ask_questions` forms for structured clarification
+- **Interactive PRD generation** — Describe what you want to build; the agent reads your project context, asks targeted clarifying questions via an inline form, then writes and saves a full PRD to your notes
 - **Idea Flow** — A freeform node canvas per project (`⌘4`): add idea, note reference, task reference, group, URL, and AI summary nodes; connect them with labelled edges; the AI and MCP can read and write the canvas as first-class authors
 - **Live dashboards** — Ask the AI to generate an interactive HTML dashboard for any project; choose from a template gallery or start blank; dashboards fetch live data on every load via a sandboxed `window.cairn.query()` bridge; runtime errors surface an inline "Fix with AI" button; HTML editable directly via a built-in CodeMirror overlay
 - **MCP server** — Exposes your workspace to external AI agents (OpenCode, Claude Desktop, etc.) via the Model Context Protocol
@@ -270,18 +272,25 @@ Tests live alongside the code they cover:
 | @dagrejs/dagre | Graph auto-layout (Idea Flow) |
 | CodeMirror 6 | Note editor |
 | react-markdown | Markdown preview |
+| remark-gfm | GitHub Flavored Markdown |
+| remark-breaks | Hard line breaks in markdown |
+| remark-math / rehype-katex | Math expression rendering |
 | Mermaid | Diagram rendering in notes |
+| lowlight | Syntax highlighting in code blocks |
+| cmdk | Command palette |
 | react-day-picker | Date picker |
 | date-fns | Date utilities |
-| Radix UI | Accessible UI primitives |
+| Radix UI | Accessible UI primitives (dialog, dropdown, tooltip, popover, select, context menu) |
+| Vercel AI SDK | AI streaming utilities |
 | esbuild | Bundler |
 | @modelcontextprotocol/sdk | MCP server |
 | Lucide React | Icons |
 | Zod | Schema validation |
 | nanoid | ID generation |
+| tailwind-merge | Tailwind class merge utility |
 | vitest | Unit test runner |
 
-> The **Settings → About** screen in the app shows real installed versions and all open source licenses. These are generated automatically at build time — see below.
+> The **Settings → About** screen in the app shows real installed versions grouped by category (Platform, Data, AI, UI, Editor, Visualisation) and all open source licenses. These are generated automatically at build time — see below.
 
 ## About screen & license generation
 
@@ -303,10 +312,10 @@ If you add a package that should appear in the **Stack** grid in the About scree
 
 ```js
 // scripts/generate-licenses.js — ROLE_MAP
-"your-package-name": ["Display Name", "Short role description"],
+"your-package-name": ["Display Name", "Short role description", "Category"],
 ```
 
-The key must exactly match the package name in `package.json`. The display name and role are what appear in the UI grid. All installed packages (whether in `ROLE_MAP` or not) are automatically included in the full **Open Source Licenses** list.
+The key must exactly match the package name in `package.json`. Valid categories are `Platform`, `Data`, `AI`, `UI`, `Editor`, and `Visualisation` — entries are grouped under these headings in the About screen. All installed packages (whether in `ROLE_MAP` or not) are automatically included in the full **Open Source Licenses** list.
 
 ## Star History
 <p align="center">

--- a/changelogs/v0.9.6.md
+++ b/changelogs/v0.9.6.md
@@ -1,0 +1,32 @@
+# v0.9.6
+
+## Improvements
+
+### Interactive PRD generation
+The Generate PRD flow has been replaced with an interactive micro-chat session. Instead of a single form that blindly generates a document, the agent now reads your project context first (notes, tasks, architecture docs), then calls a new `ask_questions` tool to present targeted clarifying questions as an inline form before writing anything. Once you answer, it produces the PRD and saves it directly to a `PRDs/` folder in your notes. The full process is visible — tool calls appear as they happen and the agent streams its response in real time.
+
+### Inline question forms in chat
+A new `ask_questions` tool is available to the AI assistant in both the main chat panel and the PRD modal. When called, it renders a structured form with labeled text inputs — one per question — directly in the conversation, rather than asking questions in prose. Answers are submitted together with a single "Continue →" button (⌘↩ also works). Submitted forms stay visible in the thread, greyed out, so the conversation history is preserved.
+
+### Drag notes into folders
+Notes in the sidebar can now be dragged directly onto folder rows to move them. The target folder highlights with an accent outline on hover. A "Move to root" drop zone appears between the folder tree and root notes while a drag is in progress, allowing notes to be moved out of any folder. Drag and drop works from both the flat filtered list and the full folder tree.
+
+### Markdown line breaks preserved in chat and notes
+Single newlines in chat messages and notes are now rendered as hard line breaks. Previously, CommonMark's default behaviour collapsed them into spaces, which caused multi-line user messages and agent answers to lose their formatting. `remark-breaks` is now applied everywhere `remarkGfm` is used: the chat message renderer, the note editor read mode, the note editor selection preview panel, and the About / changelog viewer.
+
+### Chat messages render markdown
+User messages in the chat panel are now rendered through the same markdown pipeline as assistant messages, rather than as plain text. This means bold labels (e.g. the `**Label:** answer` lines submitted from question forms), inline code, and other formatting display correctly in the user bubble.
+
+### Stack grouped by category in About
+The stack list in Settings → About is now organised into six labelled sections — Platform, Data, AI, UI, Editor, and Visualisation — instead of a single flat grid. Several previously missing packages have also been added to the map: `remark-breaks`, `remark-math`, `rehype-katex`, `katex`, CodeMirror internals, `cmdk`, the Vercel AI SDK, `tailwind-merge`, and all Radix UI primitives in use.
+
+## Bug fixes
+
+### Embedded images missing in note selection preview
+The small markdown preview panel shown when text is selected in the note editor was stripping `asset://` image URLs before rendering them. The fix applies the same `urlTransform` already used in the main read mode — passing `asset://` URLs through unchanged while still sanitising all other schemes.
+
+### Dialog accessibility warning
+All `DialogContent` usages were triggering a Radix UI console warning about a missing `Description` or `aria-describedby`. The `DialogContent` wrapper now explicitly forwards `aria-describedby={undefined}` when no value is provided, which is the Radix-recognised signal that the omission is intentional. No changes were required at any call site.
+
+### Notes mini-list removed from project sidebar
+When the Notes view was active, the project sidebar showed a list of up to five notes below the nav items. This duplicated the dedicated notes sidebar and served no clear purpose. The list has been removed.

--- a/electron/ipc/chat-executor.ts
+++ b/electron/ipc/chat-executor.ts
@@ -393,6 +393,12 @@ export async function executeTool(
       q.deleteCard(db, args.cardId as string);
       return { deleted: true, id: args.cardId, title: card.title };
     }
+    case "ask_questions": {
+      // Renderer-only tool — the modal intercepts the tool-call event and
+      // renders an inline question form. The executor just acknowledges so the
+      // tool loop can continue after the user submits answers.
+      return { ok: true, questions: args.questions };
+    }
     case "generate_prd": {
       return generatePrd(db, workspacePath, {
         projectId: args.projectId as string,

--- a/electron/ipc/tool-parity.test.ts
+++ b/electron/ipc/tool-parity.test.ts
@@ -6,8 +6,8 @@
  * same keys in their summary responses, consistent return types, and
  * no tool missing from either side.
  *
- * Chat-only tools (get_active_context, generate_prd, spawn_tasks_from_note)
- * are intentionally absent from MCP — these are excluded from the parity check.
+ * Chat-only tools (defined in CHAT_ONLY_TOOLS in tool-schemas.ts) are
+ * intentionally absent from MCP — these are excluded from the parity check.
  *
  * We also verify get_project_summary returns the canonical ProjectSummaryResult
  * shape from both chat-executor and the shared read-tools module.
@@ -20,6 +20,7 @@ import { applySchema } from "../db/schema";
 import { createWorkspace, createProject, createColumn, createNote, updateNote, createCard, getFullSnapshot } from "../db/queries";
 import { executeReadTool, type CairnSnapshot } from "../lib/read-tools";
 import { TOOLS } from "../lib/tools";
+import { CHAT_ONLY_TOOLS as CHAT_ONLY_TOOLS_LIST } from "../lib/tool-schemas";
 
 // ── Fixture ───────────────────────────────────────────────────────────────────
 
@@ -40,8 +41,9 @@ function seed(db: Database.Database) {
 
 // ── Tool name sets ────────────────────────────────────────────────────────────
 
-// Chat-only tools that intentionally do not exist in the MCP server
-const CHAT_ONLY_TOOLS = new Set(["get_active_context", "generate_prd", "spawn_tasks_from_note"]);
+// Chat-only tools that intentionally do not exist in the MCP server.
+// Imported directly from tool-schemas so this test stays in sync automatically.
+const CHAT_ONLY_TOOLS = new Set(CHAT_ONLY_TOOLS_LIST);
 
 // Shared read tools handled by executeReadTool (and also in mcp-server.ts)
 const SHARED_READ_TOOLS = [

--- a/electron/lib/tool-schemas.ts
+++ b/electron/lib/tool-schemas.ts
@@ -450,12 +450,25 @@ export const TOOL_SCHEMAS = {
     }),
   },
 
+  // ── Interactive clarification (chat-only, renderer-handled) ─────────────────
+
+  ask_questions: {
+    description: "Present a structured list of clarifying questions to the user as an inline form. Each question gets its own labeled text input. The user fills in all answers and submits them together. Use this instead of asking questions in prose.",
+    schema: z.object({
+      questions: z.array(z.object({
+        id:     z.string().describe("Short unique identifier, e.g. \"target_users\""),
+        label:  z.string().describe("Short bold label shown above the input, e.g. \"Target users\""),
+        prompt: z.string().describe("One-sentence question shown as placeholder text"),
+      })).describe("2–4 targeted questions"),
+    }),
+  },
+
 } as const;
 
 export type ToolName = keyof typeof TOOL_SCHEMAS;
 
 // Chat-only tools (not exposed via MCP)
-export const CHAT_ONLY_TOOLS: ToolName[] = ["get_active_context", "generate_prd", "spawn_tasks_from_note"];
+export const CHAT_ONLY_TOOLS: ToolName[] = ["get_active_context", "generate_prd", "spawn_tasks_from_note", "ask_questions"];
 
 export type ToolCategory = "read" | "write" | "delete";
 

--- a/electron/lib/tools.ts
+++ b/electron/lib/tools.ts
@@ -62,6 +62,7 @@ export const TOOL_LABELS: Record<string, (args: ToolArgs) => string> = {
   update_dashboard:       () => "Updating dashboard",
   get_dashboard_constants: () => "Reading dashboard API reference",
   get_idea_flow_rules:    () => "Reading Idea Flow rules",
+  ask_questions:          (a) => `Asking ${(a.questions as unknown[])?.length ?? ""} question${(a.questions as unknown[])?.length !== 1 ? "s" : ""}`,
 };
 
 // Tool definitions for the AI (OpenAI function calling format)
@@ -96,9 +97,11 @@ export interface ChatRequest {
   workspaceId?: string;
   history?: Array<{ role: "user" | "assistant" | "system"; content: string }>;
   config?: { baseUrl?: string; model?: string; apiKey?: string; maxSteps?: number };
+  systemPrompt?: string;
 }
 
-export function buildSystemPrompt(_req: ChatRequest): string {
+export function buildSystemPrompt(req: ChatRequest): string {
+  if (req.systemPrompt) return req.systemPrompt;
   return `You are the Cairn AI assistant — an intelligent helper embedded inside a note-taking and project management app.
 
 ## How to get context
@@ -133,4 +136,53 @@ Each project has a visual node canvas. Call get_idea_flow_rules for node type da
 Call get_knowledge_graph for cross-entity research. Call get_neighbors for focused N-hop traversal from a single node — more efficient than loading the full graph.
 
 Tone: calm, focused, like a thoughtful co-worker.`;
+}
+
+/**
+ * System prompt for the interactive PRD generation micro-chat.
+ * Scoped to a single project. The agent gathers context, asks focused
+ * questions, then writes the PRD as a note via create_note.
+ */
+export function buildPrdSystemPrompt(projectId: string): string {
+  return `You are an expert product manager helping write a Product Requirements Document (PRD).
+
+## Your workflow — follow this order exactly
+
+1. **Gather context first.**
+   Call get_project_context_pack with projectId="${projectId}" immediately.
+   Scan the returned notes for architecture docs, tech specs, or anything describing the product or stack.
+   Call get_note on any relevant notes to read their full content.
+
+2. **Ask focused clarifying questions.**
+   Based on the user's description and the context you found, ask 2–4 targeted questions whose answers would materially improve the PRD.
+   Be specific — do not ask things you can already infer from context.
+   Format as: **Question label** — one-sentence prompt.
+
+3. **Wait for answers.**
+   Do not write the PRD until the user has answered. If they say "skip" or "just write it", proceed immediately.
+
+4. **Write the PRD** as a thorough markdown document with these sections:
+   # <title>
+   ## Overview
+   ## Problem Statement
+   ## Goals & Non-Goals
+   ## User Stories
+   ## Functional Requirements
+   ## Non-Functional Requirements
+   ## Acceptance Criteria
+   ## Open Questions
+
+5. **Save it** by calling create_note with:
+   - projectId: "${projectId}"
+   - title: the PRD title
+   - content: the full markdown
+   - folder: "PRDs"
+   Then confirm with just the note title — do not repeat the full markdown.
+
+## Constraints
+- Never ask the user for IDs.
+- Keep questions concise — this is a focused session, not a discovery interview.
+- PRD content must be specific and actionable, not generic boilerplate.
+
+Tone: direct and concise, like a senior PM pairing with the user.`;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-day-picker": "^9.14.0",
         "react-force-graph-2d": "^1.29.1",
         "rehype-katex": "^7.0.1",
+        "remark-breaks": "^4.0.0",
         "remark-math": "^6.0.0"
       },
       "devDependencies": {
@@ -13796,7 +13797,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
       "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -13813,7 +13813,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14029,6 +14028,20 @@
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -16348,6 +16361,21 @@
         "katex": "^0.16.0",
         "unist-util-visit-parents": "^6.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-day-picker": "^9.14.0",
     "react-force-graph-2d": "^1.29.1",
     "rehype-katex": "^7.0.1",
+    "remark-breaks": "^4.0.0",
     "remark-math": "^6.0.0"
   },
   "devDependencies": {

--- a/scripts/generate-licenses.js
+++ b/scripts/generate-licenses.js
@@ -4,7 +4,7 @@
  *
  * Reads all dependencies from package.json, resolves their installed version
  * and license from node_modules/<pkg>/package.json, maps each to a human-
- * readable role, and writes src/generated/licenses.json.
+ * readable role and category, and writes src/generated/licenses.json.
  *
  * Run automatically by build.js before the Next.js build step.
  * Can also be run standalone: node scripts/generate-licenses.js
@@ -16,45 +16,77 @@ const path = require("path");
 const root = path.resolve(__dirname, "..");
 const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf-8"));
 
-// ── Role map: package name → human label ─────────────────────────────────────
+// ── Role map: package name → [label, role, category] ─────────────────────────
 // Covers the packages we actually ship in the UI. Anything not listed here
-// is treated as "infrastructure" and still included in the full license list
+// is treated as infrastructure and still included in the full license list
 // but excluded from the "Stack" display grid.
+//
+// Categories: Platform | Data | AI | UI | Editor | Visualisation
 const ROLE_MAP = {
-  "electron":                    ["Electron",              "Desktop shell"],
-  "next":                        ["Next.js",               "UI framework"],
-  "react":                       ["React",                 "Renderer"],
-  "typescript":                  ["TypeScript",            "Language"],
-  "tailwindcss":                 ["Tailwind CSS",          "Styling"],
-  "better-sqlite3":              ["better-sqlite3",        "Local database"],
-  "gray-matter":                 ["gray-matter",           "Note frontmatter"],
-  "chokidar":                    ["chokidar",              "File watcher"],
-  "zustand":                     ["Zustand",               "State"],
-  "@dnd-kit/core":               ["dnd-kit",               "Drag & drop (Kanban)"],
-  "@xyflow/react":               ["React Flow",            "Node canvas (Idea Flow)"],
-  "@dagrejs/dagre":              ["Dagre",                 "Graph auto-layout"],
-  "react-force-graph-2d":        ["react-force-graph-2d",  "Force graph (Knowledge Graph)"],
-  "d3":                          ["D3",                    "Analytics & graph visualisation"],
-  "d3-hierarchy":                ["d3-hierarchy",          "Radial tree layout"],
-  "d3-zoom":                     ["d3-zoom",               "SVG pan & zoom"],
-  "d3-selection":                ["d3-selection",          "SVG DOM helpers"],
-  "d3-sankey":                   ["d3-sankey",             "Sankey pipeline diagram"],
-  "lucide-react":                ["Lucide",                "Icons"],
-  "@modelcontextprotocol/sdk":   ["MCP SDK",               "Agent protocol"],
-  "esbuild":                     ["esbuild",               "Bundler"],
-  "react-day-picker":            ["react-day-picker",      "Date picker"],
-  "date-fns":                    ["date-fns",              "Date utilities"],
-  "react-markdown":              ["react-markdown",        "Markdown render"],
-  "remark-gfm":                  ["remark-gfm",            "GFM support"],
-  "mermaid":                     ["Mermaid",               "Diagram render"],
-  "lowlight":                    ["lowlight",              "Syntax highlighting"],
-  "@codemirror/view":            ["CodeMirror 6",          "Note editor"],
-  "electron-updater":            ["electron-updater",      "Auto-updater"],
-  "zod":                         ["Zod",                   "Schema validation"],
-  "@radix-ui/react-dialog":      ["Radix UI",              "Accessible primitives"],
-  "nanoid":                      ["nanoid",                "ID generation"],
-  "clsx":                        ["clsx",                  "Class utilities"],
+  // ── Platform ────────────────────────────────────────────────────────────────
+  "electron":                      ["Electron",            "Desktop shell",               "Platform"],
+  "next":                          ["Next.js",             "UI framework",                "Platform"],
+  "react":                         ["React",               "Renderer",                    "Platform"],
+  "typescript":                    ["TypeScript",          "Language",                    "Platform"],
+  "esbuild":                       ["esbuild",             "Bundler",                     "Platform"],
+  "electron-updater":              ["electron-updater",    "Auto-updater",                "Platform"],
+
+  // ── Data ────────────────────────────────────────────────────────────────────
+  "better-sqlite3":                ["better-sqlite3",      "Local database",              "Data"],
+  "zustand":                       ["Zustand",             "State management",            "Data"],
+  "zod":                           ["Zod",                 "Schema validation",           "Data"],
+  "nanoid":                        ["nanoid",              "ID generation",               "Data"],
+  "gray-matter":                   ["gray-matter",         "Note frontmatter",            "Data"],
+  "chokidar":                      ["chokidar",            "File watcher",                "Data"],
+  "date-fns":                      ["date-fns",            "Date utilities",              "Data"],
+
+  // ── AI ──────────────────────────────────────────────────────────────────────
+  "@modelcontextprotocol/sdk":     ["MCP SDK",             "Agent protocol",              "AI"],
+  "ai":                            ["Vercel AI SDK",       "AI streaming utilities",      "AI"],
+
+  // ── UI ──────────────────────────────────────────────────────────────────────
+  "tailwindcss":                   ["Tailwind CSS",        "Styling",                     "UI"],
+  "tailwind-merge":                ["tailwind-merge",      "Class merge utility",         "UI"],
+  "clsx":                          ["clsx",                "Class utilities",             "UI"],
+  "lucide-react":                  ["Lucide",              "Icons",                       "UI"],
+  "cmdk":                          ["cmdk",                "Command palette",             "UI"],
+  "react-day-picker":              ["react-day-picker",    "Date picker",                 "UI"],
+  "@dnd-kit/core":                 ["dnd-kit",             "Drag & drop",                 "UI"],
+  "@dnd-kit/sortable":             ["dnd-kit sortable",    "Sortable lists",              "UI"],
+  "@radix-ui/react-dialog":        ["Radix Dialog",        "Modal dialogs",               "UI"],
+  "@radix-ui/react-dropdown-menu": ["Radix Dropdown",      "Dropdown menus",              "UI"],
+  "@radix-ui/react-tooltip":       ["Radix Tooltip",       "Tooltips",                    "UI"],
+  "@radix-ui/react-popover":       ["Radix Popover",       "Popovers",                    "UI"],
+  "@radix-ui/react-select":        ["Radix Select",        "Select menus",                "UI"],
+  "@radix-ui/react-context-menu":  ["Radix Context Menu",  "Context menus",               "UI"],
+
+  // ── Editor ──────────────────────────────────────────────────────────────────
+  "@codemirror/view":              ["CodeMirror 6",        "Note editor",                 "Editor"],
+  "@codemirror/state":             ["CodeMirror state",    "Editor state model",          "Editor"],
+  "@codemirror/lang-markdown":     ["CM Markdown",         "Markdown language support",   "Editor"],
+  "@lezer/highlight":              ["Lezer",               "Syntax tree highlighter",     "Editor"],
+  "react-markdown":                ["react-markdown",      "Markdown render",             "Editor"],
+  "remark-gfm":                    ["remark-gfm",          "GFM support",                 "Editor"],
+  "remark-breaks":                 ["remark-breaks",       "Hard line breaks",            "Editor"],
+  "remark-math":                   ["remark-math",         "Math expression parsing",     "Editor"],
+  "rehype-katex":                  ["rehype-katex",        "Math render (KaTeX)",         "Editor"],
+  "katex":                         ["KaTeX",               "LaTeX math renderer",         "Editor"],
+  "mermaid":                       ["Mermaid",             "Diagram render",              "Editor"],
+  "lowlight":                      ["lowlight",            "Syntax highlighting",         "Editor"],
+
+  // ── Visualisation ───────────────────────────────────────────────────────────
+  "@xyflow/react":                 ["React Flow",          "Node canvas (Idea Flow)",     "Visualisation"],
+  "@dagrejs/dagre":                ["Dagre",               "Graph auto-layout",           "Visualisation"],
+  "react-force-graph-2d":          ["react-force-graph-2d","Force graph (Knowledge Graph)","Visualisation"],
+  "d3":                            ["D3",                  "Analytics & graph visualisation","Visualisation"],
+  "d3-hierarchy":                  ["d3-hierarchy",        "Radial tree layout",          "Visualisation"],
+  "d3-zoom":                       ["d3-zoom",             "SVG pan & zoom",              "Visualisation"],
+  "d3-selection":                  ["d3-selection",        "SVG DOM helpers",             "Visualisation"],
+  "d3-sankey":                     ["d3-sankey",           "Sankey pipeline diagram",     "Visualisation"],
 };
+
+// Canonical category order for display
+const CATEGORY_ORDER = ["Platform", "Data", "AI", "UI", "Editor", "Visualisation"];
 
 // All deps (runtime + dev) — in an Electron app there's no meaningful runtime/dev split
 const allDeps = {
@@ -63,7 +95,6 @@ const allDeps = {
 };
 
 function resolvePackage(name) {
-  // Scoped packages live at node_modules/@scope/name
   const pkgPath = path.join(root, "node_modules", name, "package.json");
   if (!fs.existsSync(pkgPath)) return null;
   try {
@@ -83,27 +114,30 @@ for (const [name] of Object.entries(allDeps)) {
   const version = resolved.version ?? "unknown";
   const license = resolved.license ?? resolved.licenses?.[0]?.type ?? "unknown";
 
-  const entry = { name, version, license };
-  allLicenses.push(entry);
+  allLicenses.push({ name, version, license });
 
   if (ROLE_MAP[name]) {
-    const [label, role] = ROLE_MAP[name];
-    stack.push({ name, label, version, role, license });
+    const [label, role, category] = ROLE_MAP[name];
+    stack.push({ name, label, version, role, category, license });
   }
 }
 
-// Sort stack by ROLE_MAP insertion order, licenses alphabetically
-stack.sort((a, b) => {
-  const keys = Object.keys(ROLE_MAP);
-  return keys.indexOf(a.name) - keys.indexOf(b.name);
-});
+// Sort stack by ROLE_MAP insertion order within each category
+const roleKeys = Object.keys(ROLE_MAP);
+stack.sort((a, b) => roleKeys.indexOf(a.name) - roleKeys.indexOf(b.name));
 allLicenses.sort((a, b) => a.name.localeCompare(b.name));
 
-const output = { stack, allLicenses, generatedAt: new Date().toISOString() };
+// Group stack by category in canonical order
+const stackByCategory = CATEGORY_ORDER.map((category) => ({
+  category,
+  entries: stack.filter((e) => e.category === category),
+})).filter((g) => g.entries.length > 0);
+
+const output = { stack, stackByCategory, allLicenses, generatedAt: new Date().toISOString() };
 
 const outDir = path.join(root, "src", "generated");
 fs.mkdirSync(outDir, { recursive: true });
 const outPath = path.join(outDir, "licenses.json");
 fs.writeFileSync(outPath, JSON.stringify(output, null, 2), "utf-8");
 
-console.log(`[generate-licenses] Written ${stack.length} stack entries and ${allLicenses.length} license entries to src/generated/licenses.json`);
+console.log(`[generate-licenses] Written ${stack.length} stack entries across ${stackByCategory.length} categories and ${allLicenses.length} license entries to src/generated/licenses.json`);

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -10,6 +10,7 @@ import { Tooltip } from "@/components/ui/tooltip";
 import { ChatMessageBubble } from "./chat-panel/ChatMessageBubble";
 import { SuggestedPrompts } from "./chat-panel/SuggestedPrompts";
 import { ToolCallIndicator } from "./chat-panel/ToolCallIndicator";
+import { QuestionForm } from "./chat-panel/QuestionForm";
 
 interface ChatPanelProps {
   prefill?: string | null;
@@ -35,7 +36,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef       = useRef<HTMLTextAreaElement>(null);
 
-  const { isLoading, toolCalls, streamingContent, sendStream, stopStream } = useChatStream(threadId);
+  const { isLoading, toolCalls, streamingContent, pendingQuestions, sendStream, stopStream } = useChatStream(threadId);
 
   // Track isLoading in a ref so the thread-init effect can read it without
   // being listed as a dependency (we never want a loading-state change to
@@ -222,6 +223,13 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
               />
             ))
         }
+        {pendingQuestions && (
+          <QuestionForm
+            questions={pendingQuestions}
+            onSubmit={(text) => handleSend(text)}
+            disabled={isLoading && !pendingQuestions}
+          />
+        )}
         {isLoading && <ToolCallIndicator toolCalls={toolCalls} streamingContent={streamingContent} />}
         <div ref={messagesEndRef} />
       </div>

--- a/src/components/chat/chat-panel/ChatMessageBubble.tsx
+++ b/src/components/chat/chat-panel/ChatMessageBubble.tsx
@@ -31,7 +31,7 @@ export function ChatMessageBubble({ message, onRetry }: ChatMessageBubbleProps) 
       <div className={cn("flex-1 min-w-0 space-y-1.5", isUser && "items-end flex flex-col")}>
         <div className={cn("px-3 py-2.5 rounded-xl text-xs leading-relaxed max-w-full",
           isUser ? "bg-[var(--accent)] text-white rounded-tr-sm" : "bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-secondary)] rounded-tl-sm")}>
-          {isUser ? <span className="whitespace-pre-wrap">{message.content}</span> : <MarkdownContent content={message.content} />}
+          <MarkdownContent content={message.content} />
         </div>
         {message.contextRefs && message.contextRefs.length > 0 && (
           <div className="flex flex-wrap gap-1">

--- a/src/components/chat/chat-panel/MarkdownContent.tsx
+++ b/src/components/chat/chat-panel/MarkdownContent.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
 import { MermaidDiagram } from "@/components/notes/MermaidDiagram";
 import { CodeBlock } from "@/components/notes/CodeBlock";
 
@@ -10,7 +11,7 @@ import { CodeBlock } from "@/components/notes/CodeBlock";
 export function MarkdownContent({ content }: { content: string }) {
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={[remarkGfm, remarkBreaks]}
       components={{
         p: ({ children }) => <p className="mb-1.5 last:mb-0 leading-relaxed">{children}</p>,
         strong: ({ children }) => <strong className="font-semibold text-[var(--text-primary)]">{children}</strong>,

--- a/src/components/chat/chat-panel/QuestionForm.tsx
+++ b/src/components/chat/chat-panel/QuestionForm.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React, { useState } from "react";
+import { Bot } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { PendingQuestion } from "@/hooks/useChatStream";
+
+interface QuestionFormProps {
+  questions: PendingQuestion[];
+  /** Called with a formatted answer string ready to send as a user message. */
+  onSubmit: (answersText: string) => void;
+  disabled?: boolean;
+}
+
+export function QuestionForm({ questions, onSubmit, disabled = false }: QuestionFormProps) {
+  const [answers, setAnswers]   = useState<Record<string, string>>({});
+  const [submitted, setSubmitted] = useState(false);
+
+  const allFilled = questions.every((q) => (answers[q.id] ?? "").trim().length > 0);
+
+  function handleSubmit() {
+    if (!allFilled || submitted || disabled) return;
+    setSubmitted(true);
+    const text = questions
+      .map((q) => `**${q.label}:** ${answers[q.id]?.trim() ?? ""}`)
+      .join("\n");
+    onSubmit(text);
+  }
+
+  return (
+    <div className="flex gap-2 items-start">
+      {/* Bot avatar — mirrors ChatMessageBubble assistant style */}
+      <div className="w-6 h-6 rounded-full bg-[var(--accent-dim)] border border-[var(--accent)]/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+        <Bot size={11} className="text-[var(--accent)]" />
+      </div>
+
+      <div className={cn(
+        "flex-1 min-w-0 rounded-xl rounded-tl-sm border px-3 py-2.5 flex flex-col gap-2.5 transition-opacity",
+        submitted ? "bg-[var(--surface)] border-[var(--border)] opacity-60" : "bg-[var(--surface-2)] border-[var(--border)]",
+      )}>
+        {questions.map((q) => (
+          <div key={q.id} className="flex flex-col gap-1">
+            <label className="text-[0.786rem] font-semibold text-[var(--text-primary)]">{q.label}</label>
+            <textarea
+              value={answers[q.id] ?? ""}
+              onChange={(e) => setAnswers((prev) => ({ ...prev, [q.id]: e.target.value }))}
+              onKeyDown={(e) => {
+                // Ctrl/Cmd+Enter submits the form
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); handleSubmit(); }
+              }}
+              placeholder={q.prompt}
+              disabled={disabled || submitted}
+              rows={2}
+              className="w-full px-2.5 py-1.5 text-xs rounded-md bg-[var(--surface)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent-dim)] resize-none disabled:opacity-50 transition-colors leading-relaxed"
+            />
+          </div>
+        ))}
+
+        {submitted ? (
+          <p className="text-[0.714rem] text-[var(--text-tertiary)]">Answers submitted</p>
+        ) : (
+          <div className="flex items-center justify-between">
+            <p className="text-[0.714rem] text-[var(--text-tertiary)]">⌘↩ to submit</p>
+            <Button
+              variant="accent" size="sm"
+              onClick={handleSubmit}
+              disabled={disabled || !allFilled}
+            >
+              Continue →
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -3,11 +3,10 @@
 import React, { useState, useRef, useEffect } from "react";
 import {
   FileText, Kanban, Settings, Search, MessageSquare,
-  ChevronDown, ChevronRight, Plus, Pin, MoreHorizontal,
+  ChevronDown, ChevronRight, Plus, MoreHorizontal,
   FolderOpen, Hash, Layers, Pencil, Trash2, GitBranch, BarChart2, Workflow,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { CairnEvents } from "@/lib/events";
 import { useCairnStore } from "@/store";
 import { ProjectIcon } from "@/lib/workspace-icons";
 import { Tooltip } from "@/components/ui/tooltip";
@@ -19,13 +18,13 @@ import {
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogClose } from "@/components/ui/dialog";
 import { WorkspaceSwitcher } from "./sidebar/WorkspaceSwitcher";
 import { ProjectCreateForm } from "./sidebar/ProjectCreateForm";
-import type { Project, Note } from "@/types";
+import type { Project } from "@/types";
 
 export function Sidebar() {
   const {
     sidebarCollapsed, toggleSidebar,
     activeWorkspaceId, activeProjectId, activeView,
-    workspaces, getWorkspaceProjects, getProjectNotes,
+    workspaces, getWorkspaceProjects,
     setActiveProject, setView, toggleSearch, toggleChat,
     createProject, updateProject, deleteProject,
     chatOpen, searchOpen,
@@ -144,7 +143,6 @@ export function Sidebar() {
               onSelectProject={() => { setActiveProject(project.id); setView("overview"); if (!expandedProjects.has(project.id)) toggleProjectExpand(project.id); }}
               activeView={activeView}
               onSelectView={(view) => { setActiveProject(project.id); setView(view); }}
-              notes={getProjectNotes(project.id).slice(0, 5)}
               onRename={(name) => updateProject(project.id, { name })}
               onDelete={() => deleteProject(project.id)}
             />
@@ -202,10 +200,10 @@ interface ProjectItemProps {
   onToggleExpand: () => void; onSelectProject: () => void;
   activeView: string;
   onSelectView: (view: "overview" | "notes" | "board" | "flow" | "graph" | "chat") => void;
-  notes: Note[]; onRename: (name: string) => void; onDelete: () => void;
+  onRename: (name: string) => void; onDelete: () => void;
 }
 
-function ProjectItem({ project, isActive, isExpanded, onToggleExpand, onSelectProject, activeView, onSelectView, notes, onRename, onDelete }: ProjectItemProps) {
+function ProjectItem({ project, isActive, isExpanded, onToggleExpand, onSelectProject, activeView, onSelectView, onRename, onDelete }: ProjectItemProps) {
   const [renaming, setRenaming]             = useState(false);
   const [renameValue, setRenameValue]       = useState(project.name);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -289,17 +287,6 @@ function ProjectItem({ project, isActive, isExpanded, onToggleExpand, onSelectPr
             <NavItem icon={<FileText size={11} />} label="Notes" isActive={isActive && activeView === "notes"} onClick={() => onSelectView("notes")} />
             <NavItem icon={<Kanban size={11} />} label="Board" isActive={isActive && activeView === "board"} onClick={() => onSelectView("board")} />
             <NavItem icon={<Workflow size={11} />} label="Idea Flow" isActive={isActive && activeView === "flow"} onClick={() => onSelectView("flow")} />
-            {isActive && activeView === "notes" && notes.length > 0 && (
-              <div className="mt-1 space-y-0.5">
-                {notes.map((note) => (
-                  <button key={note.id} onClick={() => window.dispatchEvent(CairnEvents.selectNote(note.id))}
-                    className="flex items-center gap-1.5 w-full px-1.5 py-1 rounded text-[0.786rem] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-2)] transition-colors text-left">
-                    {note.isPinned && <Pin size={9} className="text-[var(--accent)] flex-shrink-0" />}
-                    <span className="truncate">{note.title}</span>
-                  </button>
-                ))}
-              </div>
-            )}
           </div>
         )}
       </div>

--- a/src/components/notes/note-editor.tsx
+++ b/src/components/notes/note-editor.tsx
@@ -258,6 +258,7 @@ function MDPreviewPanel({ text, onDismiss }: MDPreviewPanelProps) {
         <ReactMarkdown
           remarkPlugins={PREVIEW_REMARK_PLUGINS}
           rehypePlugins={[previewCapture, rehypeKatex, previewMerge]}
+          urlTransform={(url) => url.startsWith("asset://") ? url : defaultUrlTransform(url)}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           components={({
             mark({ children }: any) {

--- a/src/components/notes/note-editor.tsx
+++ b/src/components/notes/note-editor.tsx
@@ -3,6 +3,7 @@
 import React, { useRef, useCallback, useState, useEffect, useMemo } from "react";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
@@ -217,7 +218,7 @@ function InlineCode({ className, children }: { className?: string; children?: Re
 // the full pipeline and displays it as a collapsible bottom panel.
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const PREVIEW_REMARK_PLUGINS: any[] = [remarkGfm, remarkMath, remarkPromoteDisplayMath, remarkCallout];
+const PREVIEW_REMARK_PLUGINS: any[] = [remarkGfm, remarkBreaks, remarkMath, remarkPromoteDisplayMath, remarkCallout];
 
 interface MDPreviewPanelProps {
   text: string;
@@ -704,7 +705,7 @@ export function NoteEditor({ note }: NoteEditorProps) {
               {note.content ? (
                 <div className="prose-cairn">
                   <ReactMarkdown
-                     remarkPlugins={[remarkGfm, remarkMath, remarkPromoteDisplayMath, remarkCallout]}
+                     remarkPlugins={[remarkGfm, remarkBreaks, remarkMath, remarkPromoteDisplayMath, remarkCallout]}
                      rehypePlugins={[rehypeCaptureLatex, rehypeKatex, rehypeMergedPass]}
                      urlTransform={(url) => url.startsWith("asset://") ? url : defaultUrlTransform(url)}
                      components={({

--- a/src/components/notes/notes-view.tsx
+++ b/src/components/notes/notes-view.tsx
@@ -82,7 +82,7 @@ export function NotesView() {
     getProjectNotes, getArchivedProjectNotes,
     createNote, updateNote, deleteNote,
     archiveNote, restoreNote, moveNoteToProject, moveNoteToFolder,
-    revealNote, generatePrd,
+    revealNote,
     getTagById,
     getWorkspaceProjects,
     notes: allNotes,
@@ -456,8 +456,8 @@ export function NotesView() {
         )}
       </div>
 
-      {prdModalOpen && activeProjectId && (
-        <PrdModal projectId={activeProjectId} generatePrd={generatePrd} onClose={() => setPrdModalOpen(false)} />
+      {prdModalOpen && activeProjectId && activeWorkspaceId && (
+        <PrdModal projectId={activeProjectId} workspaceId={activeWorkspaceId} onClose={() => setPrdModalOpen(false)} />
       )}
 
       {dashboardTemplateOpen && (

--- a/src/components/notes/notes-view.tsx
+++ b/src/components/notes/notes-view.tsx
@@ -107,6 +107,34 @@ export function NotesView() {
   const [folderMoveNoteId, setFolderMoveNoteId]  = useState<string | null>(null);
   const [folderMoveDest, setFolderMoveDest]       = useState("");
 
+  // Drag-and-drop: note → folder
+  const dragNoteIdRef = useRef<string | null>(null);
+  const [dropTarget, setDropTarget]              = useState<string | null>(null); // folder path or "__root__"
+
+  const handleNoteDragStart = useCallback((noteId: string) => {
+    dragNoteIdRef.current = noteId;
+  }, []);
+
+  const handleNoteDragEnd = useCallback(() => {
+    dragNoteIdRef.current = null;
+    setDropTarget(null);
+  }, []);
+
+  const handleFolderDragOver = useCallback((folderPath: string) => {
+    setDropTarget(folderPath);
+  }, []);
+
+  const handleFolderDragLeave = useCallback(() => {
+    setDropTarget(null);
+  }, []);
+
+  const handleFolderDrop = useCallback((folderPath: string) => {
+    const noteId = dragNoteIdRef.current;
+    if (noteId) moveNoteToFolder(noteId, folderPath);
+    dragNoteIdRef.current = null;
+    setDropTarget(null);
+  }, [moveNoteToFolder]);
+
   // Subscribe to allNotes directly so this component re-renders when note
   // content changes (e.g. while typing). The selector functions are stable
   // references and don't trigger re-renders on content updates.
@@ -314,6 +342,8 @@ export function NotesView() {
                   onMove={() => setMoveNoteId(note.id)}
                   onMoveToFolder={() => setFolderMoveNoteId(note.id)}
                   onReveal={() => revealNote(note.id, note.projectId)}
+                  onDragStart={handleNoteDragStart}
+                  onDragEnd={handleNoteDragEnd}
                 />
               ))
             )
@@ -336,8 +366,30 @@ export function NotesView() {
                   onNoteMoveToFolder={(note) => setFolderMoveNoteId(note.id)}
                   onNoteReveal={(note) => revealNote(note.id, note.projectId)}
                   onCreateInFolder={(folder) => handleCreateNote(folder)}
+                  dropTarget={dropTarget}
+                  onNoteDragStart={handleNoteDragStart}
+                  onNoteDragEnd={handleNoteDragEnd}
+                  onFolderDragOver={handleFolderDragOver}
+                  onFolderDragLeave={handleFolderDragLeave}
+                  onFolderDrop={handleFolderDrop}
                 />
               ))}
+              {/* Root drop zone — visible only while dragging, when folders exist */}
+              {folderTree.length > 0 && dropTarget !== null && (
+                <div
+                  className={cn(
+                    "mx-2 my-1 px-3 py-1.5 rounded text-[0.714rem] text-center transition-colors border border-dashed",
+                    dropTarget === "__root__"
+                      ? "border-[var(--accent)] bg-[color-mix(in_srgb,var(--accent)_12%,transparent)] text-[var(--accent)]"
+                      : "border-[var(--border)] text-[var(--text-tertiary)]",
+                  )}
+                  onDragOver={(e) => { e.preventDefault(); setDropTarget("__root__"); }}
+                  onDragLeave={() => setDropTarget(null)}
+                  onDrop={(e) => { e.preventDefault(); handleFolderDrop(""); }}
+                >
+                  Move to root
+                </div>
+              )}
               {/* Root notes (no folder) */}
               {rootNotes.map((note) => (
                 <NoteListItem
@@ -351,6 +403,8 @@ export function NotesView() {
                   onMove={() => setMoveNoteId(note.id)}
                   onMoveToFolder={() => setFolderMoveNoteId(note.id)}
                   onReveal={() => revealNote(note.id, note.projectId)}
+                  onDragStart={handleNoteDragStart}
+                  onDragEnd={handleNoteDragEnd}
                 />
               ))}
             </>
@@ -494,23 +548,40 @@ interface FolderTreeNodeProps {
   onNoteMoveToFolder: (note: Note) => void;
   onNoteReveal: (note: Note) => void;
   onCreateInFolder: (folder: string) => void;
+  // drag-and-drop
+  dropTarget: string | null;
+  onNoteDragStart: (noteId: string) => void;
+  onNoteDragEnd: () => void;
+  onFolderDragOver: (folderPath: string) => void;
+  onFolderDragLeave: () => void;
+  onFolderDrop: (folderPath: string) => void;
 }
 
 const FolderTreeNode = memo(function FolderTreeNode({
   node, activeNoteId, collapsed, depth = 0,
   onToggle, onNoteClick, onNotePin, onNoteDelete,
   onNoteArchive, onNoteMove, onNoteMoveToFolder, onNoteReveal, onCreateInFolder,
+  dropTarget, onNoteDragStart, onNoteDragEnd, onFolderDragOver, onFolderDragLeave, onFolderDrop,
 }: FolderTreeNodeProps) {
   const isCollapsed = collapsed[node.path];
   const indent = depth * 10;
+  const isDragOver = dropTarget === node.path;
 
   return (
     <div>
       {/* Folder row */}
       <div
-        className="group flex items-center gap-1 px-2 py-1.5 cursor-pointer hover:bg-[var(--surface-2)] transition-colors"
+        className={cn(
+          "group flex items-center gap-1 px-2 py-1.5 cursor-pointer transition-colors",
+          isDragOver
+            ? "bg-[color-mix(in_srgb,var(--accent)_15%,transparent)] outline outline-1 outline-[var(--accent)] outline-offset-[-1px] rounded"
+            : "hover:bg-[var(--surface-2)]",
+        )}
         style={{ paddingLeft: `${8 + indent}px` }}
         onClick={() => onToggle(node.path)}
+        onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); onFolderDragOver(node.path); }}
+        onDragLeave={(e) => { e.stopPropagation(); onFolderDragLeave(); }}
+        onDrop={(e) => { e.preventDefault(); e.stopPropagation(); onFolderDrop(node.path); }}
       >
         {isCollapsed
           ? <ChevronRight size={11} className="text-[var(--text-tertiary)] flex-shrink-0" />
@@ -548,6 +619,12 @@ const FolderTreeNode = memo(function FolderTreeNode({
               onNoteMoveToFolder={onNoteMoveToFolder}
               onNoteReveal={onNoteReveal}
               onCreateInFolder={onCreateInFolder}
+              dropTarget={dropTarget}
+              onNoteDragStart={onNoteDragStart}
+              onNoteDragEnd={onNoteDragEnd}
+              onFolderDragOver={onFolderDragOver}
+              onFolderDragLeave={onFolderDragLeave}
+              onFolderDrop={onFolderDrop}
             />
           ))}
           {/* Notes in this folder */}
@@ -564,6 +641,8 @@ const FolderTreeNode = memo(function FolderTreeNode({
               onMove={() => onNoteMove(note)}
               onMoveToFolder={() => onNoteMoveToFolder(note)}
               onReveal={() => onNoteReveal(note)}
+              onDragStart={onNoteDragStart}
+              onDragEnd={onNoteDragEnd}
             />
           ))}
           {/* Empty folder state */}
@@ -589,11 +668,16 @@ interface NoteListItemProps {
   note: Note; isActive: boolean; indent?: number;
   onClick: () => void; onPin: () => void; onDelete: () => void;
   onArchive: () => void; onMove: () => void; onMoveToFolder: () => void; onReveal: () => void;
+  onDragStart?: (noteId: string) => void;
+  onDragEnd?: () => void;
 }
 
-function NoteListItem({ note, isActive, indent = 0, onClick, onPin, onDelete, onArchive, onMove, onMoveToFolder, onReveal }: NoteListItemProps) {
+function NoteListItem({ note, isActive, indent = 0, onClick, onPin, onDelete, onArchive, onMove, onMoveToFolder, onReveal, onDragStart, onDragEnd }: NoteListItemProps) {
   return (
     <div onClick={onClick}
+      draggable={!!onDragStart}
+      onDragStart={(e) => { e.stopPropagation(); onDragStart?.(note.id); }}
+      onDragEnd={(e) => { e.stopPropagation(); onDragEnd?.(); }}
       className={cn("group relative flex flex-col gap-0.5 py-2.5 cursor-pointer transition-colors pr-3",
         isActive ? "bg-[var(--surface-2)] border-l-2 border-[var(--accent)]" : "hover:bg-[var(--surface-2)] border-l-2 border-transparent")}
       style={{ paddingLeft: `${12 + indent}px` }}

--- a/src/components/notes/notes-view/PrdModal.tsx
+++ b/src/components/notes/notes-view/PrdModal.tsx
@@ -1,42 +1,139 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
-import { Wand2, Loader2 } from "lucide-react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { Wand2, Loader2, Send, Wrench, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useCairnStore } from "@/store";
+import { useChatStream } from "@/hooks/useChatStream";
+import { MarkdownContent } from "@/components/chat/chat-panel/MarkdownContent";
+import { QuestionForm } from "@/components/chat/chat-panel/QuestionForm";
+import { cn } from "@/lib/utils";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
 
 interface PrdModalProps {
   projectId: string;
-  generatePrd: (projectId: string, title: string, requirements: string) => Promise<{ error: string } | void>;
+  workspaceId: string;
   onClose: () => void;
 }
 
-export function PrdModal({ projectId, generatePrd, onClose }: PrdModalProps) {
-  const [title, setTitle] = useState("");
-  const [requirements, setRequirements] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const titleRef = useRef<HTMLInputElement>(null);
+type Message =
+  | { role: "user";      content: string }
+  | { role: "assistant"; content: string };
 
-  useEffect(() => { setTimeout(() => titleRef.current?.focus(), 50); }, []);
+// ── Component ─────────────────────────────────────────────────────────────────
 
-  async function handleGenerate() {
-    if (!title.trim() || !requirements.trim()) return;
-    setLoading(true);
-    setError(null);
-    try {
-      const result = await generatePrd(projectId, title.trim(), requirements.trim());
-      if (result?.error) setError(result.error);
-      else onClose();
-    } catch (err) {
-      setError((err as Error).message ?? "Failed to generate PRD");
-    } finally {
-      setLoading(false);
+export function PrdModal({ projectId, workspaceId, onClose }: PrdModalProps) {
+  const { aiConfig } = useCairnStore();
+
+  // Use a stable ephemeral thread ID scoped to this modal session
+  const threadId = `prd-${projectId}`;
+
+  const {
+    isLoading, toolCalls, streamingContent,
+    pendingQuestions, sendStream, stopStream,
+  } = useChatStream(threadId);
+
+  const [input, setInput]     = useState("");
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [done, setDone]       = useState(false);
+
+  const inputRef   = useRef<HTMLTextAreaElement>(null);
+  const scrollRef  = useRef<HTMLDivElement>(null);
+  const historyRef = useRef<Message[]>([]);
+
+  useEffect(() => { historyRef.current = messages; }, [messages]);
+
+  // Auto-scroll on any content change
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+  }, [messages, streamingContent, toolCalls, pendingQuestions]);
+
+  // Focus input on mount
+  useEffect(() => { setTimeout(() => inputRef.current?.focus(), 80); }, []);
+
+  // Capture completed assistant turns to build local message history
+  useEffect(() => {
+    if (!isLoading && streamingContent === "" && toolCalls.length === 0) return;
+  }, [isLoading, streamingContent, toolCalls]);
+
+  // Track when agent finishes — detect PRD save confirmation
+  const prevIsLoading = useRef(false);
+  useEffect(() => {
+    if (prevIsLoading.current && !isLoading) {
+      const last = historyRef.current[historyRef.current.length - 1];
+      if (last?.role === "assistant") {
+        const lower = last.content.toLowerCase();
+        if (lower.includes("saved") || lower.includes("created") || lower.includes("prd")) {
+          if (last.content.length < 500 && !last.content.includes("\n## ")) {
+            setDone(true);
+          }
+        }
+      }
     }
-  }
+    prevIsLoading.current = isLoading;
+  }, [isLoading]);
+
+  const send = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed || isLoading) return;
+
+    const userMsg: Message = { role: "user", content: trimmed };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
+
+    const history = historyRef.current.map((m) => ({ role: m.role, content: m.content }));
+
+    sendStream({
+      message: trimmed,
+      threadId,
+      projectId,
+      workspaceId,
+      history,
+      config: {
+        baseUrl:  aiConfig.baseUrl  || "https://api.openai.com",
+        model:    aiConfig.model    || "gpt-4o-mini",
+        apiKey:   aiConfig.apiKey   || "",
+        maxSteps: aiConfig.maxSteps ?? 20,
+      },
+      systemPrompt: buildPrdSystemPrompt(projectId),
+    });
+  }, [isLoading, threadId, projectId, workspaceId, aiConfig, sendStream]);
+
+  // Mirror completed assistant turns into local message list so we can
+  // show the full conversation history. We listen to the done event via
+  // the isLoading transition and read the streamingContent snapshot.
+  const lastStreamRef = useRef("");
+  useEffect(() => { lastStreamRef.current = streamingContent; }, [streamingContent]);
+  useEffect(() => {
+    if (prevIsLoading.current && !isLoading && lastStreamRef.current === "" ) {
+      // Content was committed by useChatStream's onDone — re-read from history
+      // We can't access it here, so we track via a separate effect below
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading]);
+
+  // Simpler: subscribe to onDone ourselves just to capture assistant content
+  // into local messages (useChatStream already persists to the thread store,
+  // but we need it in our local messages array for display in this modal).
+  useEffect(() => {
+    const electron = window.electron;
+    if (!electron) return;
+    const unsub = electron.chat.onDone((e) => {
+      if (e.content) {
+        setMessages((prev) => [...prev, { role: "assistant", content: e.content }]);
+      }
+    });
+    return () => { unsub(); };
+  }, []);
+
+  const isEmpty = messages.length === 0 && !isLoading;
+  const waitingForUser = !isLoading && !done && messages.some((m) => m.role === "assistant");
 
   return (
-    <Dialog open onOpenChange={(o) => { if (!o && !loading) onClose(); }}>
+    <Dialog open onOpenChange={(o) => { if (!o && !isLoading) { stopStream(); onClose(); } }}>
       <DialogContent size="md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
@@ -44,47 +141,170 @@ export function PrdModal({ projectId, generatePrd, onClose }: PrdModalProps) {
             Generate PRD
           </DialogTitle>
         </DialogHeader>
-        <div className="px-5 py-4 flex flex-col gap-4">
-          <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium text-[var(--text-secondary)]">PRD title</label>
-            <input
-              ref={titleRef}
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) e.currentTarget.blur(); }}
-              placeholder="e.g. PRD — User Authentication"
-              disabled={loading}
-              className="w-full px-3 py-2 text-sm rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent-dim)] disabled:opacity-50"
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium text-[var(--text-secondary)]">Describe what you want to build</label>
-            <textarea
-              value={requirements}
-              onChange={(e) => setRequirements(e.target.value)}
-              placeholder="e.g. I want to build a login system with email/password and Google OAuth…"
-              disabled={loading}
-              rows={5}
-              className="w-full px-3 py-2 text-sm rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent-dim)] resize-none disabled:opacity-50"
-            />
-          </div>
-          {error && (
-            <p className="text-xs text-[var(--danger)] bg-[var(--danger)]/10 rounded-md px-3 py-2">{error}</p>
+
+        {/* ── Conversation area ── */}
+        <div
+          ref={scrollRef}
+          className="px-4 overflow-y-auto flex flex-col gap-3 py-2"
+          style={{ minHeight: "200px", maxHeight: "54vh" }}
+        >
+          {isEmpty && (
+            <div className="flex-1 flex items-center justify-center py-10">
+              <p className="text-xs text-[var(--text-tertiary)] text-center max-w-[260px] leading-relaxed">
+                Describe what you want to build. The agent will read your project context, ask a few questions, then write and save the PRD.
+              </p>
+            </div>
           )}
-          <div className="flex items-center justify-end gap-2">
-            <Button variant="ghost" size="sm" onClick={onClose} disabled={loading}>Cancel</Button>
-            <Button
-              variant="accent" size="sm"
-              onClick={handleGenerate}
-              disabled={loading || !title.trim() || !requirements.trim()}
-            >
-              {loading
-                ? <><Loader2 size={12} className="animate-spin" />Generating…</>
-                : <><Wand2 size={12} />Generate PRD</>}
-            </Button>
-          </div>
+
+          {messages.map((msg, i) => (
+            msg.role === "user" ? (
+              <div key={i} className="flex justify-end">
+                <div className="max-w-[88%] px-3 py-2 rounded-xl rounded-tr-sm text-sm bg-[var(--accent)] text-white">
+                  <MarkdownContent content={msg.content} />
+                </div>
+              </div>
+            ) : (
+              <div key={i} className="flex justify-start">
+                <div className="max-w-[88%] px-3 py-2 rounded-xl rounded-tl-sm text-sm bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)]">
+                  <MarkdownContent content={msg.content} />
+                </div>
+              </div>
+            )
+          ))}
+
+          {/* ── Inline question form ── */}
+          {pendingQuestions && (
+            <QuestionForm
+              questions={pendingQuestions}
+              onSubmit={(text) => send(text)}
+              disabled={isLoading}
+            />
+          )}
+
+          {/* ── Live indicator while agent is working ── */}
+          {isLoading && (
+            <div className="flex justify-start">
+              <div className="max-w-[88%] bg-[var(--surface-2)] border border-[var(--border)] rounded-xl rounded-tl-sm px-3 py-2 flex flex-col gap-1.5">
+                {toolCalls.map((tc, i) => (
+                  <div key={i} className="flex items-center gap-1.5 text-[0.714rem] text-[var(--text-tertiary)]">
+                    <CheckCircle2 size={10} className="text-[var(--accent)] flex-shrink-0" />
+                    <span>{tc.label}</span>
+                  </div>
+                ))}
+                {streamingContent ? (
+                  <div className="text-sm text-[var(--text-primary)]">
+                    <MarkdownContent content={streamingContent} />
+                    <span className="inline-block w-0.5 h-3 bg-[var(--accent)] animate-pulse ml-0.5 align-middle" />
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-1.5 text-[0.714rem] text-[var(--text-tertiary)]">
+                    {toolCalls.length > 0
+                      ? <Wrench size={10} className="animate-pulse flex-shrink-0" />
+                      : <Loader2 size={10} className="animate-spin flex-shrink-0" />}
+                    <span>{toolCalls.length > 0 ? "Working…" : "Thinking…"}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* ── Input row ── */}
+        <div className="px-4 pb-4 pt-2 border-t border-[var(--border-subtle)]">
+          {done ? (
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-[var(--text-tertiary)]">PRD saved to your notes.</span>
+              <Button variant="accent" size="sm" onClick={onClose}>Open notes</Button>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              {waitingForUser && (
+                <p className="text-[0.714rem] text-[var(--accent)] font-medium">Your turn ↓</p>
+              )}
+              <div className="flex items-end gap-2">
+                <textarea
+                  ref={inputRef}
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(input); }
+                  }}
+                  placeholder={messages.length === 0 ? "Describe what you want to build…" : "Reply…"}
+                  disabled={isLoading}
+                  rows={1}
+                  className={cn(
+                    "flex-1 px-3 py-2 text-sm rounded-lg bg-[var(--surface-2)] border text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-dim)] resize-none disabled:opacity-50 transition-colors",
+                    waitingForUser
+                      ? "border-[var(--accent)]"
+                      : "border-[var(--border)] focus:border-[var(--accent)]",
+                  )}
+                  style={{ minHeight: "36px", maxHeight: "120px" }}
+                  onInput={(e) => {
+                    const el = e.currentTarget;
+                    el.style.height = "auto";
+                    el.style.height = Math.min(el.scrollHeight, 120) + "px";
+                  }}
+                />
+                <Button
+                  variant="accent" size="sm"
+                  onClick={() => send(input)}
+                  disabled={isLoading || !input.trim()}
+                  className="flex-shrink-0"
+                >
+                  {isLoading ? <Loader2 size={13} className="animate-spin" /> : <Send size={13} />}
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
       </DialogContent>
     </Dialog>
   );
+}
+
+// ── PRD system prompt ─────────────────────────────────────────────────────────
+
+function buildPrdSystemPrompt(projectId: string): string {
+  return `You are an expert product manager helping write a Product Requirements Document (PRD).
+
+## Your workflow — follow this order exactly
+
+1. **Gather context first.**
+   Call get_project_context_pack with projectId="${projectId}" immediately.
+   Scan the returned notes for architecture docs, tech specs, or anything describing the product or stack.
+   Call get_note on any relevant notes to read their full content.
+
+2. **Ask clarifying questions using the ask_questions tool.**
+   Do NOT write questions as prose. You MUST call the ask_questions tool with 2–4 targeted questions.
+   Each question needs: id (short snake_case key), label (short title), prompt (one-sentence question as placeholder text).
+   Be specific — do not ask things you can already infer from context.
+
+3. **Wait for answers.**
+   The user will fill in each question inline and submit them together as a single message.
+   Do not write the PRD until you receive their answers. If they say "skip", proceed immediately.
+
+4. **Write the PRD** as a thorough markdown document with these sections:
+   # <title>
+   ## Overview
+   ## Problem Statement
+   ## Goals & Non-Goals
+   ## User Stories
+   ## Functional Requirements
+   ## Non-Functional Requirements
+   ## Acceptance Criteria
+   ## Open Questions
+
+5. **Save it** by calling create_note with:
+   - projectId: "${projectId}"
+   - title: the PRD title
+   - content: the full markdown
+   - folder: "PRDs"
+   After saving, reply with one short sentence confirming the note title. Do not repeat the markdown.
+
+## Constraints
+- Never ask the user for IDs.
+- Always use the ask_questions tool — never write questions as prose.
+- PRD content must be specific and actionable, not generic boilerplate.
+
+Tone: direct and concise, like a senior PM pairing with the user.`;
 }

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -11,7 +11,9 @@ export function AboutSection() {
   const [licensesOpen, setLicensesOpen] = useState(false);
   const [changelogOpen, setChangelogOpen] = useState(true);
   const [changelog, setChangelog] = useState<string | null>(null);
-  const { stack, allLicenses } = licensesData;
+  const { stackByCategory, allLicenses } = licensesData as typeof licensesData & {
+    stackByCategory: { category: string; entries: typeof licensesData.stack }[];
+  };
 
   useEffect(() => {
     if (typeof window !== "undefined" && window.electron?.latestChangelog) {
@@ -47,22 +49,27 @@ export function AboutSection() {
         )}
 
         {/* Stack */}
-        <div className="space-y-2">
+        <div className="space-y-3">
           <div className="text-xs font-semibold uppercase tracking-wider text-[var(--text-tertiary)]">Stack</div>
-          <div className="grid grid-cols-2 gap-2">
-            {stack.map((entry) => (
-              <div
-                key={entry.name}
-                className="flex items-center justify-between px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--surface)]"
-              >
-                <div>
-                  <span className="text-xs font-medium text-[var(--text-primary)]">{entry.label}</span>
-                  <span className="text-[0.714rem] text-[var(--text-tertiary)] ml-1.5">{entry.version}</span>
-                </div>
-                <span className="text-[0.786rem] text-[var(--text-tertiary)]">{entry.role}</span>
+          {stackByCategory.map(({ category, entries }) => (
+            <div key={category} className="space-y-1.5">
+              <div className="text-[0.714rem] font-semibold uppercase tracking-wider text-[var(--text-tertiary)] opacity-60">{category}</div>
+              <div className="grid grid-cols-2 gap-1.5">
+                {entries.map((entry) => (
+                  <div
+                    key={entry.name}
+                    className="flex items-center justify-between px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--surface)]"
+                  >
+                    <div>
+                      <span className="text-xs font-medium text-[var(--text-primary)]">{entry.label}</span>
+                      <span className="text-[0.714rem] text-[var(--text-tertiary)] ml-1.5">{entry.version}</span>
+                    </div>
+                    <span className="text-[0.714rem] text-[var(--text-tertiary)]">{entry.role}</span>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
+            </div>
+          ))}
         </div>
 
         {/* Licenses */}

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
 import licensesData from "@/generated/licenses.json";
 import { SettingsGroup } from "./shared";
 
@@ -37,7 +38,7 @@ export function AboutSection() {
             </button>
             {changelogOpen && (
               <div className="border-t border-[var(--border)] px-4 py-3 prose-cairn max-h-96 overflow-y-auto">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                   {changelog}
                 </ReactMarkdown>
               </div>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -17,12 +17,14 @@ export function DialogContent({
   className,
   children,
   size = "md",
+  "aria-describedby": ariaDescribedBy,
   ...props
 }: DialogContentProps) {
   return (
     <RadixDialog.Portal>
       <RadixDialog.Overlay className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 animate-fade-in" />
       <RadixDialog.Content
+        aria-describedby={ariaDescribedBy ?? undefined}
         className={cn(
           "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50",
           "bg-[var(--surface)] border border-[var(--border)] rounded-xl shadow-2xl",

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -4,7 +4,8 @@
  * useChatStream — manages the AI chat streaming lifecycle.
  *
  * Subscribes to the Electron chat events (onToken, onDone, onToolCall)
- * and exposes loading state, tool-call list, and streaming content.
+ * and exposes loading state, tool-call list, streaming content, and any
+ * pending ask_questions form emitted by the agent.
  *
  * The component calls `sendStream()` to fire a request and reads back
  * the state updates as tokens/tool calls arrive.
@@ -16,6 +17,12 @@ import { useCairnStore } from "@/store";
 export interface ChatToolCall {
   tool: string;
   label: string;
+}
+
+export interface PendingQuestion {
+  id: string;
+  label: string;
+  prompt: string;
 }
 
 export interface ChatStreamRequest {
@@ -30,22 +37,27 @@ export interface ChatStreamRequest {
     apiKey?: string;
     maxSteps?: number;
   };
+  systemPrompt?: string;
 }
 
 export interface UseChatStreamResult {
   isLoading: boolean;
   toolCalls: ChatToolCall[];
   streamingContent: string;
+  /** Non-null when the agent has called ask_questions — cleared on submit or done. */
+  pendingQuestions: PendingQuestion[] | null;
   sendStream: (req: ChatStreamRequest) => void;
   stopStream: () => void;
+  clearQuestions: () => void;
 }
 
 export function useChatStream(threadId: string | null): UseChatStreamResult {
   const addMessage = useCairnStore((s) => s.addMessage);
 
-  const [isLoading, setIsLoading] = useState(false);
-  const [toolCalls, setToolCalls] = useState<ChatToolCall[]>([]);
+  const [isLoading, setIsLoading]               = useState(false);
+  const [toolCalls, setToolCalls]               = useState<ChatToolCall[]>([]);
   const [streamingContent, setStreamingContent] = useState("");
+  const [pendingQuestions, setPendingQuestions] = useState<PendingQuestion[] | null>(null);
 
   // Keep a stable ref so the onDone handler always reads the latest threadId
   const threadIdRef = useRef<string | null>(null);
@@ -56,7 +68,13 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
     if (!electron) return;
 
     const unsubTool = electron.chat.onToolCall((e) => {
-      setToolCalls((prev) => [...prev, { tool: e.tool, label: e.label }]);
+      if (e.tool === "ask_questions") {
+        // Intercept: surface as an inline form rather than a chip
+        const qs = (e.args.questions as PendingQuestion[] | undefined) ?? [];
+        setPendingQuestions(qs);
+      } else {
+        setToolCalls((prev) => [...prev, { tool: e.tool, label: e.label }]);
+      }
     });
 
     const unsubToken = electron.chat.onToken((e) => {
@@ -72,6 +90,8 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
       setStreamingContent("");
       setIsLoading(false);
       setToolCalls([]);
+      // Do NOT clear pendingQuestions here — the form must stay visible until
+      // the user submits their answers. It is cleared in sendStream() instead.
     });
 
     return () => {
@@ -86,6 +106,7 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
   function sendStream(req: ChatStreamRequest) {
     setIsLoading(true);
     setToolCalls([]);
+    setPendingQuestions(null);
     window.electron?.chat.stream(req);
   }
 
@@ -94,7 +115,12 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
     setIsLoading(false);
     setToolCalls([]);
     setStreamingContent("");
+    // Keep pendingQuestions — user may still want to answer after stopping
   }
 
-  return { isLoading, toolCalls, streamingContent, sendStream, stopStream };
+  function clearQuestions() {
+    setPendingQuestions(null);
+  }
+
+  return { isLoading, toolCalls, streamingContent, pendingQuestions, sendStream, stopStream, clearQuestions };
 }


### PR DESCRIPTION
## What does this PR do?

Replaces the one-shot PRD modal with an interactive micro-chat session: the agent reads project context, asks clarifying questions via a new `ask_questions` tool that renders as an inline form (available in both the PRD modal and main chat panel), then writes and saves the PRD. Also adds drag-and-drop for moving notes into sidebar folders, fixes single-newline rendering across all markdown surfaces with `remark-breaks`, renders user chat messages through the markdown pipeline, and fixes `asset://` image stripping in the note selection preview. Includes changelog, README, and About screen stack category updates for v0.9.6.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [x] Docs / changelog
- [ ] Tests

## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts`
- [ ] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

The `ask_questions` tool is chat-only (not exposed via MCP) and has a no-op executor — all rendering logic lives in the renderer via `useChatStream`'s new `pendingQuestions` state. The `systemPrompt` field added to `ChatRequest` is backwards-compatible; `buildSystemPrompt` falls back to the default prompt when it is absent. The two unchecked checklist items are not applicable — no new IPC handlers or DB migrations were added, and `mcp-server.ts` was not touched.