### PR TITLE
Per Device Function Visibility

### DIFF
--- a/changelogs/v1.0.1.md
+++ b/changelogs/v1.0.1.md
@@ -1,0 +1,61 @@
+# v1.0.1
+
+## What's new
+
+### View visibility
+Choose which views appear in your sidebar. Toggle **Board**, **Idea Flow**, **Agent**, **Knowledge Graph**, **Insights**, and **AI Chat** on or off from **Settings → General**. Overview and Notes are always visible.
+
+Keyboard shortcuts repack automatically — visible views get ⌘3, ⌘4… in order, so there are never gaps in the sequence.
+
+### Onboarding: choose your workspace
+A new **Views** step in the setup wizard lets new users pick which views to enable before they reach the app for the first time. All views are on by default; uncheck what you don't need. Can be changed any time in Settings.
+
+---
+
+## What's in this release (includes all of v1.0.0)
+
+### Inline coding agent workspace
+A new **Agent** view lets you run AI coding tools — Claude Code, OpenCode, Aider, Gemini CLI, or any custom CLI binary — directly inside Cairn, connected to your project tasks.
+
+Register agents in **Settings → Coding Agents** (name, binary path, args, default flag). Set a **code directory** per project to give each agent its filesystem root.
+
+### Spawn agents from task cards
+A **Spawn Agent** button in the Kanban card detail panel opens a prompt editor pre-filled from the card title and description. Pick an agent, confirm, and a terminal session opens immediately in the Agent view.
+
+### Three-pane agent workspace
+The Agent view is a resizable three-pane layout:
+
+- **File tree** — lazily-expanding directory browser with type-aware icons; click to open in the editor.
+- **Editor** — multi-file tabbed CodeMirror 6 editor with auto-detected syntax highlighting, dirty-state indicator, ⌘S save, markdown preview toggle, and undo/redo history.
+- **Terminal** — tabbed xterm.js sessions with a live status dot, exit code badge, and full scroll history preserved when switching tabs.
+
+### Git diff viewer
+A **Diff** tab in the editor pane polls `git diff` for the project's code directory and renders unified, split, or changes-only views with syntax highlighting and collapsible file sections. A **Copy patch** button copies the raw diff.
+
+### PTY session management
+Agent processes run via `node-pty` in the Electron main process. Sessions survive navigation away from the Agent view. All binary paths are validated before execution. Resize events reflow the terminal in real time.
+
+## Improvements
+
+- **Quick settings** — theme (Dark / Light / System) and font size (XS → XL) are now accessible from a compact popover in the top-right corner of every view, no longer requiring a trip to Settings.
+- Agent CLI arg hints corrected: Claude Code uses `-p {prompt}`, OpenCode uses `--prompt {prompt}`, Aider uses `--message {prompt}`, Gemini CLI uses `-p {prompt}`.
+- Agent prompts now support a `{prompt}` placeholder in the args string, filled at spawn time from the card context.
+- Prompts are passed via `exec sh -c '...'` with platform-specific single-quote escaping — no temp files required.
+- Terminal tab close buttons now have tooltips.
+- CM6 editor theming tracks the active Cairn theme via CSS custom properties.
+
+## Database migrations
+
+| Version | Change |
+|---------|--------|
+| v9 | New `coding_agents` table (`id`, `name`, `binary_path`, `args`, `is_default`, `created_at`, `updated_at`) |
+| v10 | `ALTER TABLE projects ADD COLUMN code_directory TEXT` |
+
+## New dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `node-pty` | `^1.1.0` | Native PTY process spawning |
+| `@xterm/xterm` | `^6.0.0` | Terminal emulator |
+| `@xterm/addon-fit` | `^0.11.0` | Auto-resize terminal to container |
+| `@xterm/addon-unicode11` | `^0.9.0` | Unicode 11 / emoji support |

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,8 +67,14 @@ export default function Home() {
     createNote,
     activeProjectId,
     aiConfig,
+    hiddenViews,
   } = useCairnStore();
   const aiEnabled = aiConfig.aiEnabled ?? true;
+
+  // All navigable views in shortcut order; overview=⌘1, notes=⌘2, then visible extras
+  const ORDERED_VIEWS = (["board", "flow", "agent", "graph", "insights"] as const).filter(
+    (v) => !hiddenViews.has(v)
+  );
 
   // null = still loading
   // "workspace" = needs workspace folder setup (existing or new user)
@@ -152,11 +158,11 @@ export default function Home() {
       else if (mod && key === "\\") { e.preventDefault(); toggleSidebar(); }
       else if (mod && key === "1") { e.preventDefault(); setView("overview"); }
       else if (mod && key === "2") { e.preventDefault(); setView("notes"); }
-      else if (mod && key === "3") { e.preventDefault(); setView("board"); }
-      else if (mod && key === "4") { e.preventDefault(); setView("flow"); }
-      else if (mod && key === "5") { e.preventDefault(); setView("agent"); }
-      else if (mod && key === "6") { e.preventDefault(); setView("graph"); }
-      else if (mod && key === "7") { e.preventDefault(); setView("insights"); }
+      else if (mod && /^[3-9]$/.test(key)) {
+        const idx = parseInt(key, 10) - 3; // 0-based index into ORDERED_VIEWS
+        const view = ORDERED_VIEWS[idx];
+        if (view) { e.preventDefault(); setView(view); }
+      }
       else if (mod && key === "n" && !inInput) {
         e.preventDefault();
         if (activeProjectId) {
@@ -193,7 +199,7 @@ export default function Home() {
       window.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("cairn:open-chat", handleOpenChat);
     };
-  }, [toggleSearch, toggleChat, toggleSidebar, setView, activeProjectId, createNote, chatOpen, aiEnabled]);
+  }, [toggleSearch, toggleChat, toggleSidebar, setView, activeProjectId, createNote, chatOpen, aiEnabled, hiddenViews]);
 
   // Still loading
   if (onboardingState === null) {

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -20,6 +20,27 @@ import { WorkspaceSwitcher } from "./sidebar/WorkspaceSwitcher";
 import { ProjectCreateForm } from "./sidebar/ProjectCreateForm";
 import type { Project } from "@/types";
 
+// ── View nav config ───────────────────────────────────────────────────────────
+
+interface ViewNavItem {
+  view: "board" | "flow" | "agent" | "graph" | "insights";
+  label: string;
+  icon: React.ReactNode;
+  iconSm: React.ReactNode;
+  /** Which hiddenView key this maps to */
+  hiddenKey: "board" | "flow" | "agent" | "graph" | "insights";
+  /** Whether it lives inside the project tree (true) or bottom bar (false) */
+  inProject: boolean;
+}
+
+const VIEW_NAV: ViewNavItem[] = [
+  { view: "board",    label: "Board",           icon: <Kanban size={13} />,   iconSm: <Kanban size={15} />,   hiddenKey: "board",    inProject: true  },
+  { view: "flow",     label: "Idea Flow",        icon: <Workflow size={11} />, iconSm: <Workflow size={15} />, hiddenKey: "flow",     inProject: true  },
+  { view: "agent",    label: "Agent",            icon: <Terminal size={11} />, iconSm: <Terminal size={15} />, hiddenKey: "agent",   inProject: true  },
+  { view: "graph",    label: "Knowledge Graph",  icon: <GitBranch size={13} />,iconSm: <GitBranch size={15} />,hiddenKey: "graph",    inProject: false },
+  { view: "insights", label: "Insights",         icon: <BarChart2 size={13} />,iconSm: <BarChart2 size={15} />,hiddenKey: "insights", inProject: false },
+];
+
 export function Sidebar() {
   const {
     sidebarCollapsed, toggleSidebar,
@@ -28,7 +49,18 @@ export function Sidebar() {
     setActiveProject, setView, toggleSearch, toggleChat,
     createProject, updateProject, deleteProject,
     chatOpen, searchOpen,
+    hiddenViews,
   } = useCairnStore();
+
+  // All navigable views in order (overview + notes always first)
+  const visibleNavItems = VIEW_NAV.filter((item) => !hiddenViews.has(item.hiddenKey));
+  // ⌘1 = overview, ⌘2 = notes, then visible views in order
+  const shortcutBase = 3; // first view after overview+notes
+  function shortcutLabel(item: ViewNavItem): string {
+    const idx = visibleNavItems.indexOf(item);
+    const num = idx + shortcutBase;
+    return num <= 9 ? `⌘${num}` : "";
+  }
 
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set([activeProjectId ?? ""]));
   const [creatingProject, setCreatingProject]   = useState(false);
@@ -70,36 +102,22 @@ export function Sidebar() {
             <Search size={15} />
           </button>
         </Tooltip>
-        <Tooltip content="AI Chat (⌘/)" side="right">
-          <button onClick={toggleChat}
-            className={cn("p-2 rounded-md transition-colors", chatOpen ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
-            <MessageSquare size={15} />
-          </button>
-        </Tooltip>
-        <Tooltip content="Idea Flow (⌘4)" side="right">
-          <button onClick={() => setView("flow")}
-            className={cn("p-2 rounded-md transition-colors", activeView === "flow" ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
-            <Workflow size={15} />
-          </button>
-        </Tooltip>
-        <Tooltip content="Agent (⌘5)" side="right">
-          <button onClick={() => setView("agent")}
-            className={cn("p-2 rounded-md transition-colors", activeView === "agent" ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
-            <Terminal size={15} />
-          </button>
-        </Tooltip>
-        <Tooltip content="Knowledge Graph (⌘6)" side="right">
-          <button onClick={() => setView("graph")}
-            className={cn("p-2 rounded-md transition-colors", activeView === "graph" ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
-            <GitBranch size={15} />
-          </button>
-        </Tooltip>
-        <Tooltip content="Insights (⌘7)" side="right">
-          <button onClick={() => setView("insights")}
-            className={cn("p-2 rounded-md transition-colors", activeView === "insights" ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
-            <BarChart2 size={15} />
-          </button>
-        </Tooltip>
+        {!hiddenViews.has("chat") && (
+          <Tooltip content="AI Chat (⌘/)" side="right">
+            <button onClick={toggleChat}
+              className={cn("p-2 rounded-md transition-colors", chatOpen ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
+              <MessageSquare size={15} />
+            </button>
+          </Tooltip>
+        )}
+        {visibleNavItems.map((item) => (
+          <Tooltip key={item.view} content={`${item.label} (${shortcutLabel(item)})`} side="right">
+            <button onClick={() => setView(item.view)}
+              className={cn("p-2 rounded-md transition-colors", activeView === item.view ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
+              {item.iconSm}
+            </button>
+          </Tooltip>
+        ))}
       </aside>
     );
   }
@@ -118,12 +136,14 @@ export function Sidebar() {
             <span className="ml-auto text-[0.714rem] text-[var(--text-tertiary)] font-mono">⌘K</span>
           </button>
         </Tooltip>
-        <Tooltip content="AI Chat (⌘/)">
-          <button onClick={toggleChat}
-            className={cn("p-1.5 rounded-md transition-colors", chatOpen ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
-            <MessageSquare size={13} />
-          </button>
-        </Tooltip>
+        {!hiddenViews.has("chat") && (
+          <Tooltip content="AI Chat (⌘/)">
+            <button onClick={toggleChat}
+              className={cn("p-1.5 rounded-md transition-colors", chatOpen ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
+              <MessageSquare size={13} />
+            </button>
+          </Tooltip>
+        )}
       </div>
 
       {/* Projects list */}
@@ -151,6 +171,8 @@ export function Sidebar() {
               onSelectView={(view) => { setActiveProject(project.id); setView(view); }}
               onRename={(name) => updateProject(project.id, { name })}
               onDelete={() => deleteProject(project.id)}
+              hiddenViews={hiddenViews}
+              visibleNavItems={visibleNavItems}
             />
           ))}
 
@@ -175,20 +197,18 @@ export function Sidebar() {
         )}
       </nav>
 
-      {/* Graph + Settings */}
+      {/* Bottom nav: workspace-level views + Settings */}
       <div className="border-t border-[var(--border)] p-2 space-y-0.5">
-        <button onClick={() => setView("graph")}
-          className={cn("flex items-center gap-2 w-full rounded-md px-2 py-1.5 text-xs transition-colors",
-            activeView === "graph" ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
-          <GitBranch size={13} /><span>Knowledge Graph</span>
-          <span className="ml-auto text-[0.714rem] font-mono text-[var(--text-tertiary)]">⌘6</span>
-        </button>
-        <button onClick={() => setView("insights")}
-          className={cn("flex items-center gap-2 w-full rounded-md px-2 py-1.5 text-xs transition-colors",
-            activeView === "insights" ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
-          <BarChart2 size={13} /><span>Insights</span>
-          <span className="ml-auto text-[0.714rem] font-mono text-[var(--text-tertiary)]">⌘7</span>
-        </button>
+        {visibleNavItems.filter((item) => !item.inProject).map((item) => (
+          <button key={item.view} onClick={() => setView(item.view)}
+            className={cn("flex items-center gap-2 w-full rounded-md px-2 py-1.5 text-xs transition-colors",
+              activeView === item.view ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
+            {item.icon}<span>{item.label}</span>
+            {shortcutLabel(item) && (
+              <span className="ml-auto text-[0.714rem] font-mono text-[var(--text-tertiary)]">{shortcutLabel(item)}</span>
+            )}
+          </button>
+        ))}
         <button onClick={() => setView("settings")}
           className={cn("flex items-center gap-2 w-full rounded-md px-2 py-1.5 text-xs transition-colors",
             activeView === "settings" ? "text-[var(--text-primary)] bg-[var(--surface-2)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
@@ -207,9 +227,11 @@ interface ProjectItemProps {
   activeView: string;
   onSelectView: (view: "overview" | "notes" | "board" | "flow" | "graph" | "chat" | "agent") => void;
   onRename: (name: string) => void; onDelete: () => void;
+  hiddenViews: Set<string>;
+  visibleNavItems: ViewNavItem[];
 }
 
-function ProjectItem({ project, isActive, isExpanded, onToggleExpand, onSelectProject, activeView, onSelectView, onRename, onDelete }: ProjectItemProps) {
+function ProjectItem({ project, isActive, isExpanded, onToggleExpand, onSelectProject, activeView, onSelectView, onRename, onDelete, hiddenViews, visibleNavItems }: ProjectItemProps) {
   const [renaming, setRenaming]             = useState(false);
   const [renameValue, setRenameValue]       = useState(project.name);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -291,9 +313,15 @@ function ProjectItem({ project, isActive, isExpanded, onToggleExpand, onSelectPr
           <div className="ml-4 mt-0.5 space-y-0.5 border-l border-[var(--border)] pl-2">
             <NavItem icon={<Hash size={11} />} label="Overview" isActive={isActive && activeView === "overview"} onClick={() => onSelectView("overview")} />
             <NavItem icon={<FileText size={11} />} label="Notes" isActive={isActive && activeView === "notes"} onClick={() => onSelectView("notes")} />
-            <NavItem icon={<Kanban size={11} />} label="Board" isActive={isActive && activeView === "board"} onClick={() => onSelectView("board")} />
-            <NavItem icon={<Workflow size={11} />} label="Idea Flow" isActive={isActive && activeView === "flow"} onClick={() => onSelectView("flow")} />
-            <NavItem icon={<Terminal size={11} />} label="Agent" isActive={isActive && activeView === "agent"} onClick={() => onSelectView("agent")} />
+            {visibleNavItems.filter((item) => item.inProject).map((item) => (
+              <NavItem
+                key={item.view}
+                icon={item.icon}
+                label={item.label}
+                isActive={isActive && activeView === item.view}
+                onClick={() => onSelectView(item.view as "board" | "flow" | "agent")}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/src/components/onboarding/StepViews.tsx
+++ b/src/components/onboarding/StepViews.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+/**
+ * StepViews — onboarding step to choose which views to enable.
+ * All views are on by default. Users uncheck what they don't want.
+ */
+
+import { Kanban, Workflow, Terminal, GitBranch, BarChart2, MessageSquare } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ToggleableView } from "@/store/slices/ui";
+import { Shell, NavRow } from "./shared";
+
+interface ViewChoice {
+  view: ToggleableView;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+const VIEW_CHOICES: ViewChoice[] = [
+  { view: "board",    label: "Board",          description: "Kanban board to track tasks and progress",    icon: <Kanban size={15} /> },
+  { view: "flow",     label: "Idea Flow",       description: "Visual node canvas to connect your ideas",    icon: <Workflow size={15} /> },
+  { view: "agent",    label: "Agent",           description: "Spawn and interact with coding agents",       icon: <Terminal size={15} /> },
+  { view: "graph",    label: "Knowledge Graph", description: "See connections across your entire workspace", icon: <GitBranch size={15} /> },
+  { view: "insights", label: "Insights",        description: "Analytics: velocity, activity, and trends",   icon: <BarChart2 size={15} /> },
+  { view: "chat",     label: "AI Chat",         description: "Ask your AI assistant anything in-app",       icon: <MessageSquare size={15} /> },
+];
+
+interface Props {
+  hidden: Set<ToggleableView>;
+  onToggle: (view: ToggleableView) => void;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+export function StepViews({ hidden, onToggle, onBack, onNext }: Props) {
+  return (
+    <Shell step="views">
+      <div className="w-full max-w-md bg-[var(--surface)] border border-[var(--border)] rounded-xl p-6 flex flex-col gap-5">
+        <div>
+          <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-0.5">Choose your workspace</h2>
+          <p className="text-xs text-[var(--text-tertiary)]">
+            Enable the views you want. You can change this any time in Settings → General.
+          </p>
+        </div>
+
+        {/* Always-on notice */}
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--surface-2)] border border-[var(--border-subtle)]">
+          <span className="text-[0.714rem] text-[var(--text-tertiary)]">
+            <strong className="text-[var(--text-secondary)]">Overview</strong> and{" "}
+            <strong className="text-[var(--text-secondary)]">Notes</strong> are always visible.
+          </span>
+        </div>
+
+        {/* View toggles */}
+        <div className="space-y-1.5">
+          {VIEW_CHOICES.map(({ view, label, description, icon }) => {
+            const enabled = !hidden.has(view);
+            return (
+              <button
+                key={view}
+                type="button"
+                onClick={() => onToggle(view)}
+                className={cn(
+                  "flex items-center gap-3 w-full rounded-xl border px-4 py-3 text-left transition-all",
+                  enabled
+                    ? "border-[var(--accent)] bg-[var(--accent-dim)]"
+                    : "border-[var(--border)] hover:border-[var(--accent)]/40 hover:bg-[var(--surface-2)]"
+                )}
+              >
+                <span className={cn("flex-shrink-0", enabled ? "text-[var(--accent)]" : "text-[var(--text-tertiary)]")}>
+                  {icon}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <p className={cn("text-xs font-medium", enabled ? "text-[var(--accent)]" : "text-[var(--text-primary)]")}>
+                    {label}
+                  </p>
+                  <p className="text-[0.714rem] text-[var(--text-tertiary)] truncate">{description}</p>
+                </div>
+                {/* Checkbox indicator */}
+                <span
+                  className={cn(
+                    "w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center transition-colors",
+                    enabled
+                      ? "bg-[var(--accent)] border-[var(--accent)]"
+                      : "border-[var(--border)] bg-[var(--surface)]"
+                  )}
+                >
+                  {enabled && (
+                    <svg width="8" height="6" viewBox="0 0 8 6" fill="none">
+                      <path d="M1 3L3 5L7 1" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <NavRow onBack={onBack} onNext={onNext} />
+      </div>
+    </Shell>
+  );
+}

--- a/src/components/onboarding/index.tsx
+++ b/src/components/onboarding/index.tsx
@@ -9,7 +9,9 @@ import { StepWorkspaceDetails } from "./StepWorkspaceDetails";
 import { StepAppearance } from "./StepAppearance";
 import { StepAISetup } from "./StepAISetup";
 import { StepMCP } from "./StepMCP";
+import { StepViews } from "./StepViews";
 import { StepDone } from "./StepDone";
+import type { ToggleableView } from "@/store/slices/ui";
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -27,6 +29,7 @@ export function Onboarding({ onComplete, initialStep = "choose-folder" }: Props)
     theme, setTheme,
     fontScale, setFontScale,
     aiConfig, setAIConfig,
+    hiddenViews, toggleViewVisibility, setHiddenViews,
   } = useCairnStore();
 
   // ── Wizard step ──────────────────────────────────────────────────────────────
@@ -37,6 +40,17 @@ export function Onboarding({ onComplete, initialStep = "choose-folder" }: Props)
   const [wsName, setWsName] = useState("");
   const [wsIcon, setWsIcon] = useState(DEFAULT_WORKSPACE_ICON);
   const [submitting, setSubmitting] = useState(false);
+
+  // ── View visibility (local copy; committed when user hits Next on StepViews) ─
+  const [localHidden, setLocalHidden] = useState<Set<ToggleableView>>(new Set(hiddenViews));
+
+  function toggleLocalView(view: ToggleableView) {
+    setLocalHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(view)) { next.delete(view); } else { next.add(view); }
+      return next;
+    });
+  }
 
   // ── AI ───────────────────────────────────────────────────────────────────────
   const [aiEnabled, setAiEnabled] = useState(aiConfig.aiEnabled ?? true);
@@ -150,7 +164,21 @@ export function Onboarding({ onComplete, initialStep = "choose-folder" }: Props)
     return (
       <StepMCP
         onBack={() => setStep("ai-setup")}
-        onNext={() => setStep("done")}
+        onNext={() => setStep("views")}
+      />
+    );
+  }
+
+  if (step === "views") {
+    return (
+      <StepViews
+        hidden={localHidden}
+        onToggle={toggleLocalView}
+        onBack={() => setStep("mcp")}
+        onNext={() => {
+          setHiddenViews([...localHidden]);
+          setStep("done");
+        }}
       />
     );
   }
@@ -158,7 +186,7 @@ export function Onboarding({ onComplete, initialStep = "choose-folder" }: Props)
   // step === "done"
   return (
     <StepDone
-      onBack={() => setStep("mcp")}
+      onBack={() => setStep("views")}
       onComplete={onComplete}
     />
   );

--- a/src/components/onboarding/shared.tsx
+++ b/src/components/onboarding/shared.tsx
@@ -13,10 +13,11 @@ export type OnboardingStep =
   | "appearance"
   | "ai-setup"
   | "mcp"
+  | "views"
   | "done";
 
 /** Steps that show the progress dots (post-workspace steps only). */
-export const PROGRESS_STEPS: OnboardingStep[] = ["appearance", "ai-setup", "mcp", "done"];
+export const PROGRESS_STEPS: OnboardingStep[] = ["appearance", "ai-setup", "mcp", "views", "done"];
 
 // ── Font scale options ────────────────────────────────────────────────────────
 

--- a/src/components/settings/GeneralSettings.tsx
+++ b/src/components/settings/GeneralSettings.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { useCairnStore, type Theme, type FontScale } from "@/store";
 import { cn } from "@/lib/utils";
 import { SettingsGroup, SettingsRow } from "./shared";
+import { ViewVisibilitySettings } from "./ViewVisibilitySettings";
 
 const FONT_SCALE_OPTIONS: { value: FontScale; label: string; description: string }[] = [
   { value: 1,   label: "XS", description: "100%" },
@@ -27,6 +28,7 @@ export function GeneralSettings() {
   ];
 
   return (
+    <>
     <SettingsGroup title="General" description="Basic app preferences">
       <SettingsRow label="Workspace name" description="Name shown in the sidebar">
         <Input
@@ -81,6 +83,8 @@ export function GeneralSettings() {
       </SettingsRow>
       <ChangeWorkspaceRow />
     </SettingsGroup>
+    <ViewVisibilitySettings />
+    </>
   );
 }
 

--- a/src/components/settings/ViewVisibilitySettings.tsx
+++ b/src/components/settings/ViewVisibilitySettings.tsx
@@ -48,7 +48,9 @@ export function ViewVisibilitySettings() {
               <p className="text-[0.714rem] text-[var(--text-tertiary)]">Always visible</p>
             </div>
           </div>
-          <div className="w-8 h-4 rounded-full bg-[var(--accent)] opacity-40 flex-shrink-0" />
+          <div className="relative w-8 h-4 rounded-full bg-[var(--accent)] opacity-40 flex-shrink-0 overflow-hidden">
+              <span className="absolute top-0.5 w-3 h-3 rounded-full bg-white shadow translate-x-[18px]" />
+            </div>
         </div>
       ))}
 
@@ -72,14 +74,14 @@ export function ViewVisibilitySettings() {
               aria-checked={visible}
               onClick={() => toggleViewVisibility(view)}
               className={cn(
-                "relative w-8 h-4 rounded-full transition-colors flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]",
-                visible ? "bg-[var(--accent)]" : "bg-[var(--surface-3)]"
-              )}
+                  "relative w-8 h-4 rounded-full transition-colors flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] overflow-hidden",
+                  visible ? "bg-[var(--accent)]" : "bg-[var(--surface-3)]"
+                )}
             >
               <span
                 className={cn(
                   "absolute top-0.5 w-3 h-3 rounded-full bg-white shadow transition-transform",
-                  visible ? "translate-x-4" : "translate-x-0.5"
+                  visible ? "translate-x-[18px]" : "translate-x-0.5"
                 )}
               />
             </button>

--- a/src/components/settings/ViewVisibilitySettings.tsx
+++ b/src/components/settings/ViewVisibilitySettings.tsx
@@ -11,6 +11,25 @@ import type { ToggleableView } from "@/store/slices/ui";
 import { cn } from "@/lib/utils";
 import { SettingsGroup } from "./shared";
 
+function Toggle({ on, disabled, onClick }: { on: boolean; disabled?: boolean; onClick?: () => void }) {
+  return (
+    <button
+      role="switch"
+      aria-checked={on}
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "flex items-center w-9 h-5 rounded-full px-0.5 transition-colors flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]",
+        on ? "bg-[var(--accent)]" : "bg-[var(--surface-3)]",
+        disabled && "opacity-40 cursor-default",
+        on ? "justify-end" : "justify-start"
+      )}
+    >
+      <span className="w-4 h-4 rounded-full bg-white shadow-sm flex-shrink-0" />
+    </button>
+  );
+}
+
 interface ViewOption {
   view: ToggleableView;
   label: string;
@@ -48,9 +67,7 @@ export function ViewVisibilitySettings() {
               <p className="text-[0.714rem] text-[var(--text-tertiary)]">Always visible</p>
             </div>
           </div>
-          <div className="relative w-8 h-4 rounded-full bg-[var(--accent)] opacity-40 flex-shrink-0 overflow-hidden">
-              <span className="absolute top-0.5 w-3 h-3 rounded-full bg-white shadow translate-x-[18px]" />
-            </div>
+          <Toggle on disabled />
         </div>
       ))}
 
@@ -69,22 +86,7 @@ export function ViewVisibilitySettings() {
                 <p className="text-[0.714rem] text-[var(--text-tertiary)]">{description}</p>
               </div>
             </div>
-            <button
-              role="switch"
-              aria-checked={visible}
-              onClick={() => toggleViewVisibility(view)}
-              className={cn(
-                  "relative w-8 h-4 rounded-full transition-colors flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] overflow-hidden",
-                  visible ? "bg-[var(--accent)]" : "bg-[var(--surface-3)]"
-                )}
-            >
-              <span
-                className={cn(
-                  "absolute top-0.5 w-3 h-3 rounded-full bg-white shadow transition-transform",
-                  visible ? "translate-x-[18px]" : "translate-x-0.5"
-                )}
-              />
-            </button>
+            <Toggle on={visible} onClick={() => toggleViewVisibility(view)} />
           </div>
         );
       })}

--- a/src/components/settings/ViewVisibilitySettings.tsx
+++ b/src/components/settings/ViewVisibilitySettings.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * ViewVisibilitySettings — toggle which views are shown in the sidebar.
+ * Overview and Notes are always visible and shown as locked.
+ */
+
+import { Kanban, Workflow, Terminal, GitBranch, BarChart2, MessageSquare, Lock } from "lucide-react";
+import { useCairnStore } from "@/store";
+import type { ToggleableView } from "@/store/slices/ui";
+import { cn } from "@/lib/utils";
+import { SettingsGroup } from "./shared";
+
+interface ViewOption {
+  view: ToggleableView;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+const VIEW_OPTIONS: ViewOption[] = [
+  { view: "board",    label: "Board",           description: "Kanban task board",               icon: <Kanban size={13} /> },
+  { view: "flow",     label: "Idea Flow",        description: "Visual node graph for ideas",     icon: <Workflow size={13} /> },
+  { view: "agent",    label: "Agent",            description: "Embedded coding agent terminal",  icon: <Terminal size={13} /> },
+  { view: "graph",    label: "Knowledge Graph",  description: "Workspace-wide connection graph", icon: <GitBranch size={13} /> },
+  { view: "insights", label: "Insights",         description: "Analytics and progress charts",   icon: <BarChart2 size={13} /> },
+  { view: "chat",     label: "AI Chat",          description: "In-app AI chat panel",            icon: <MessageSquare size={13} /> },
+];
+
+export function ViewVisibilitySettings() {
+  const { hiddenViews, toggleViewVisibility } = useCairnStore();
+
+  return (
+    <SettingsGroup
+      title="Views"
+      description="Choose which views appear in the sidebar. Overview and Notes are always shown."
+    >
+      {/* Always-on rows */}
+      {(["Overview", "Notes"] as const).map((label) => (
+        <div
+          key={label}
+          className="flex items-center justify-between py-2.5 border-b border-[var(--border-subtle)] last:border-0"
+        >
+          <div className="flex items-center gap-2.5">
+            <Lock size={12} className="text-[var(--text-tertiary)]" />
+            <div>
+              <p className="text-xs font-medium text-[var(--text-secondary)]">{label}</p>
+              <p className="text-[0.714rem] text-[var(--text-tertiary)]">Always visible</p>
+            </div>
+          </div>
+          <div className="w-8 h-4 rounded-full bg-[var(--accent)] opacity-40 flex-shrink-0" />
+        </div>
+      ))}
+
+      {/* Toggleable rows */}
+      {VIEW_OPTIONS.map(({ view, label, description, icon }) => {
+        const visible = !hiddenViews.has(view);
+        return (
+          <div
+            key={view}
+            className="flex items-center justify-between py-2.5 border-b border-[var(--border-subtle)] last:border-0"
+          >
+            <div className="flex items-center gap-2.5">
+              <span className="text-[var(--text-tertiary)]">{icon}</span>
+              <div>
+                <p className="text-xs font-medium text-[var(--text-primary)]">{label}</p>
+                <p className="text-[0.714rem] text-[var(--text-tertiary)]">{description}</p>
+              </div>
+            </div>
+            <button
+              role="switch"
+              aria-checked={visible}
+              onClick={() => toggleViewVisibility(view)}
+              className={cn(
+                "relative w-8 h-4 rounded-full transition-colors flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]",
+                visible ? "bg-[var(--accent)]" : "bg-[var(--surface-3)]"
+              )}
+            >
+              <span
+                className={cn(
+                  "absolute top-0.5 w-3 h-3 rounded-full bg-white shadow transition-transform",
+                  visible ? "translate-x-4" : "translate-x-0.5"
+                )}
+              />
+            </button>
+          </div>
+        );
+      })}
+    </SettingsGroup>
+  );
+}

--- a/src/components/settings/ViewVisibilitySettings.tsx
+++ b/src/components/settings/ViewVisibilitySettings.tsx
@@ -19,13 +19,15 @@ function Toggle({ on, disabled, onClick }: { on: boolean; disabled?: boolean; on
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        "flex items-center w-9 h-5 rounded-full px-0.5 transition-colors flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]",
+        "flex items-center w-9 h-5 rounded-full px-0.5 transition-colors duration-200 flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]",
         on ? "bg-[var(--accent)]" : "bg-[var(--surface-3)]",
         disabled && "opacity-40 cursor-default",
-        on ? "justify-end" : "justify-start"
       )}
     >
-      <span className="w-4 h-4 rounded-full bg-white shadow-sm flex-shrink-0" />
+      <span
+        className="w-4 h-4 rounded-full bg-white shadow-sm flex-shrink-0 transition-transform duration-200"
+        style={{ transform: on ? "translateX(calc(2.25rem - 1.25rem - 0.25rem))" : "translateX(0)" }}
+      />
     </button>
   );
 }

--- a/src/components/settings/ViewVisibilitySettings.tsx
+++ b/src/components/settings/ViewVisibilitySettings.tsx
@@ -19,14 +19,14 @@ function Toggle({ on, disabled, onClick }: { on: boolean; disabled?: boolean; on
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        "flex items-center w-9 h-5 rounded-full px-0.5 transition-colors duration-200 flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]",
+        "relative inline-flex items-center w-9 h-5 rounded-full transition-colors duration-200 flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]",
         on ? "bg-[var(--accent)]" : "bg-[var(--surface-3)]",
         disabled && "opacity-40 cursor-default",
       )}
     >
       <span
-        className="w-4 h-4 rounded-full bg-white shadow-sm flex-shrink-0 transition-transform duration-200"
-        style={{ transform: on ? "translateX(calc(2.25rem - 1.25rem - 0.25rem))" : "translateX(0)" }}
+        className="absolute top-0.5 bottom-0.5 aspect-square rounded-full bg-white shadow-sm transition-[left,right] duration-200"
+        style={on ? { right: "0.125rem", left: "auto" } : { left: "0.125rem", right: "auto" }}
       />
     </button>
   );

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -22,8 +22,8 @@ import { DEFAULT_AI_CONFIG, AI_CONFIG_KEY, ACTIVE_PROJECT_KEY } from "@/lib/cons
 
 // ── Slice imports ─────────────────────────────────────────────────────────────
 import { createUISlice } from "./slices/ui";
-import type { UISlice, AIConfig, Theme } from "./slices/ui";
-import { applyTheme, THEME_KEY, applyFontScale, FONT_SCALE_KEY, DEFAULT_FONT_SCALE } from "./slices/ui";
+import type { UISlice, AIConfig, Theme, ToggleableView } from "./slices/ui";
+import { applyTheme, THEME_KEY, applyFontScale, FONT_SCALE_KEY, DEFAULT_FONT_SCALE, HIDDEN_VIEWS_KEY } from "./slices/ui";
 import type { FontScale } from "./slices/ui";
 import { createWorkspaceSlice } from "./slices/workspace";
 import type { WorkspaceSlice } from "./slices/workspace";
@@ -175,6 +175,11 @@ export const useCairnStore = create<CairnStore>()(
         a[0]({ aiConfig: { ...DEFAULT_AI_CONFIG, ...savedConfig } });
       }
 
+      const savedHidden = storage.get<ToggleableView[]>(HIDDEN_VIEWS_KEY);
+      if (savedHidden) {
+        a[0]({ hiddenViews: new Set(savedHidden) });
+      }
+
       const saved = loadPersisted();
       if (saved && saved.workspaces.length > 0) {
         a[0]({
@@ -211,6 +216,11 @@ export const useCairnStore = create<CairnStore>()(
       const savedConfig = storage.get<AIConfig>(AI_CONFIG_KEY);
       if (savedConfig) {
         set({ aiConfig: { ...DEFAULT_AI_CONFIG, ...savedConfig } });
+      }
+
+      const savedHidden = storage.get<ToggleableView[]>(HIDDEN_VIEWS_KEY);
+      if (savedHidden) {
+        set({ hiddenViews: new Set(savedHidden) });
       }
 
       const snap = (await window.electron!.snapshot()) as PersistedState;

--- a/src/store/slices/ui.ts
+++ b/src/store/slices/ui.ts
@@ -8,6 +8,16 @@ import type { ID, AppUIState } from "@/types";
 import { storage } from "@/lib/storage";
 import { DEFAULT_AI_CONFIG, AI_CONFIG_KEY, ACTIVE_PROJECT_KEY } from "@/lib/constants";
 
+// ── View visibility ───────────────────────────────────────────────────────────
+
+/** Views that can be hidden. Overview and Notes are always visible. */
+export type ToggleableView = "board" | "flow" | "agent" | "graph" | "insights" | "chat";
+
+export const HIDDEN_VIEWS_KEY = "hiddenViews";
+
+/** Views that are forcibly hidden when AI is disabled. */
+export const AI_DEPENDENT_VIEWS: ToggleableView[] = ["chat", "agent"];
+
 // ── AI / MCP config ───────────────────────────────────────────────────────────
 
 export interface AIConfig {
@@ -82,6 +92,11 @@ export interface UISlice extends AppUIState {
   fontScale: FontScale;
   setFontScale: (scale: FontScale) => void;
 
+  // View visibility
+  hiddenViews: Set<ToggleableView>;
+  toggleViewVisibility: (view: ToggleableView) => void;
+  setHiddenViews: (views: ToggleableView[]) => void;
+
   // Navigation / selections
   setActiveWorkspace: (id: ID) => void;
   setActiveProject: (id: ID | null) => void;
@@ -108,14 +123,46 @@ export const createUISlice: StateCreator<CairnStore, [], [], UISlice> = (
   aiConfig: DEFAULT_AI_CONFIG,
   theme: "dark" as Theme,
   fontScale: DEFAULT_FONT_SCALE, // 1.2 = M (~16.8px)
+  hiddenViews: new Set<ToggleableView>(),
 
   // ── AI config ──────────────────────────────────
   setAIConfig(patch) {
     set((s) => {
       const next = { ...s.aiConfig, ...patch };
       storage.set(AI_CONFIG_KEY, next);
+      // Sync AI-dependent views when aiEnabled changes
+      if (patch.aiEnabled !== undefined) {
+        const hidden = new Set(s.hiddenViews);
+        if (!patch.aiEnabled) {
+          AI_DEPENDENT_VIEWS.forEach((v) => hidden.add(v));
+        } else {
+          AI_DEPENDENT_VIEWS.forEach((v) => hidden.delete(v));
+        }
+        storage.set(HIDDEN_VIEWS_KEY, [...hidden]);
+        return { aiConfig: next, hiddenViews: hidden };
+      }
       return { aiConfig: next };
     });
+  },
+
+  // ── View visibility ─────────────────────────────
+  toggleViewVisibility(view) {
+    set((s) => {
+      const hidden = new Set(s.hiddenViews);
+      if (hidden.has(view)) {
+        hidden.delete(view);
+      } else {
+        hidden.add(view);
+      }
+      storage.set(HIDDEN_VIEWS_KEY, [...hidden]);
+      return { hiddenViews: hidden };
+    });
+  },
+
+  setHiddenViews(views) {
+    const hidden = new Set<ToggleableView>(views);
+    storage.set(HIDDEN_VIEWS_KEY, [...hidden]);
+    set({ hiddenViews: hidden });
   },
 
   // ── Theme ──────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Adds per-device view visibility — users can hide/show Board, Idea Flow, Agent, Knowledge Graph, Insights, and AI Chat from Settings → General. Hidden views disappear from the sidebar and their keyboard shortcuts repack automatically (no gaps in the ⌘1–⌘N sequence). A new onboarding step lets new users configure this before they reach the app for the first time.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [x] Docs / changelog
- [ ] Tests

## Screenshots / recording

_Toggle in Settings → General:_
<!-- screenshot of ViewVisibilitySettings -->

_Onboarding step:_
<!-- screenshot of StepViews -->

## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

**No DB changes** — `hiddenViews` is persisted to `localStorage` only (key: `hiddenViews`, serialised as a JSON array of `ToggleableView` strings). This is intentionally per-device, not per-workspace.

**Shortcut repacking** — `⌘1` = Overview, `⌘2` = Notes are fixed. `⌘3`…`⌘N` map dynamically to the ordered visible views array in `page.tsx`. Hiding a view shifts all subsequent shortcuts down.

**AI-dependent views** — when `aiEnabled` is set to `false` via `setAIConfig`, `chat` and `agent` are automatically added to `hiddenViews`. Re-enabling AI removes them.

**Toggle component** — uses `position: absolute` with `left: 2px` / `right: 2px` swap + `transition-[left,right]` for the animation. Avoids any `translateX` math that would break under font scaling.

**Overview and Notes** are always visible and cannot be hidden — enforced in `toggleViewVisibility` and shown as locked in both the settings UI and the onboarding step.