### PR TITLE
v1.1.0 - Smarter Knowledge Graph

### DIFF
--- a/changelogs/v1.1.0.md
+++ b/changelogs/v1.1.0.md
@@ -1,0 +1,93 @@
+# v1.1.0
+
+## What's new
+
+### Wikilinks — `[[Note Title]]` syntax
+Notes now support Obsidian-style `[[Note Title]]` wikilinks throughout the editor.
+
+- **Autocomplete** — typing `[[` in the editor opens a floating picker that fuzzy-searches all notes in the workspace. Navigate with ↑↓, confirm with Enter, dismiss with Esc.
+- **Toolbar button** — a **Link** button in the write-mode toolbar opens the same picker at the cursor position without needing to type `[[`.
+- **Read mode rendering** — wikilinks render as accent-coloured clickable chips in read mode. Clicking navigates to the linked note. Unresolved links (no matching note) appear in a muted strikethrough style.
+- **Backlinks** — the backlinks panel at the bottom of every note now includes a **Wikilink** section listing notes that reference the current note via `[[Title]]`, separate from explicit `linkedNoteIds` links.
+
+### Knowledge Graph — wikilink edges
+Wikilinks are now first-class edges in the Knowledge Graph.
+
+- `wikilink` is a new `GraphEdgeType`, included in graph filters and default edge set.
+- `computeAutoRelationships()` gains a wikilink pass: scans all note content for `[[Title]]` patterns, resolves them to note IDs, and upserts `type="wikilink", weight=1.0` edges into the relationship cache. This runs first, before co-mention and keyword passes.
+- Wikilink edges render in **accent colour** with directional arrows and `strokeWidth=2` in ForceGraphCanvas — visually distinct from auto-discovered edges.
+- Edge **weight** now drives line thickness for all auto-discovered edges (`strokeWidth = 0.5 + weight × 1.0`), so high-confidence co-mention edges are thicker than weak keyword edges.
+
+### AI Graph Assistant
+A new **AI** button in the Knowledge Graph toolbar opens the **Graph Assistant** panel — a chat interface that analyses the current graph and suggests missing connections.
+
+The assistant receives the full filtered graph (node IDs, titles, content snippets, all edges) as context, plus the currently selected node if any.
+
+- **Tool call visibility** — while thinking, completed tool calls (e.g. "Reading knowledge graph", "Reading active context") appear as check-mark chips above the streaming response.
+- **`suggest_connections` tool** — the AI calls this tool to emit structured actions alongside its prose analysis. Actions appear as interactive cards below the message:
+  - `add_wikilink` — inserts `[[Target Title]]` into a note's content
+  - `link_note_note` — adds a bidirectional explicit link between two notes
+  - `link_note_card` — links a note to a task card
+  - `add_tag` — applies a tag to a note or card (creates the tag if it doesn't exist)
+- Each action card shows the type icon, a label, an expand chevron with the AI's reasoning, an **Apply** button, and a **Dismiss** button.
+- **Apply all** — a single button applies every non-dismissed action in the list.
+- Applying any action triggers an automatic graph relationship recompute so the graph updates immediately.
+- Prose responses render as full markdown (headers, bold, lists, tables, code blocks).
+
+### `src/lib/wikilink-parser.ts` — shared parser utility
+New module exported for use across the codebase:
+
+- `parseWikilinks(content)` — returns all `[[Title]]` matches with index positions
+- `resolveWikilinks(content, notes)` — resolves titles to note IDs (exact, case-insensitive)
+- `segmentContent(content, notes)` — splits content into `text` / `wikilink` segments for inline rendering
+- `getActiveWikilink(content, cursorPos)` — detects a partial `[[query` being typed at the cursor, used by the editor autocomplete trigger
+
+## Improvements
+
+- **Improved co-mention scoring** — the relationship cache's co-mention pass now supports the `wikilink` edge type alongside `co-mention`, `keyword`, and `assignee`. The graph query layer (`getKnowledgeGraph`) includes wikilink edges from cache when `includeAuto` is true and `wikilink` is in `edgeTypes`.
+- **`edgeTypeLabel("wikilink")`** returns `"Wikilink"` — consistent with existing edge type labels in the graph store.
+
+## Bug fixes
+
+### Fixed: `CairnSnapshot.cards` missing `blockedByIds` and `assignee`
+The `CairnSnapshot` type in `electron/lib/read-tools.ts` declared the `cards` array without `blockedByIds` or `assignee` fields. The AI chat executor used both fields on cards read from this snapshot, causing TypeScript errors. Both fields are now included in the type.
+
+### Fixed: `ctx` undefined in `registerAppHandlers`
+`electron/ipc/handlers.ts` line 628 referenced `ctx.db` inside `registerAppHandlers`, which receives a `db` parameter directly — `ctx` is only in scope inside `registerIpcHandlers`. Changed to `db`.
+
+### Fixed: `ChatRequest` missing required `message` field in tests
+`electron/ipc/chat-executor.test.ts` and `electron/ipc/tool-parity.test.ts` both constructed `ChatRequest` objects without the required `message` field (which became required in a previous refactor). Added `message: ""` to both test fixtures.
+
+### Fixed: `Set<ToolName>.has(string)` type error in tool-parity test
+`tool-parity.test.ts` called `chatToolNames.has(name)` where `chatToolNames` was typed as `Set<ToolName>` (a narrow string union) but `name` came from a `string[]`. Widened the Set to `Set<string>`.
+
+### Fixed: `NoteFileData.folder` required but callers pass `string | undefined`
+`NoteFileData.folder` was typed as `string` (required) in both `electron/notes-files.ts` and the inlined duplicate in `electron/mcp-server.ts`, but all call sites in `mcp-server.ts` and the test suite passed `string | undefined`. Made `folder` optional (`folder?: string`) in both locations — `writeNoteFile` already defaulted it with `note.folder ?? ""`.
+
+## New files
+
+| File | Purpose |
+|------|---------|
+| `src/lib/wikilink-parser.ts` | Wikilink extraction, resolution, segmentation, and cursor-trigger detection |
+| `src/components/notes/WikilinkPicker.tsx` | Floating autocomplete picker for `[[Note Title]]` insertion |
+| `src/components/graph/GraphAIPanel.tsx` | AI Graph Assistant panel with streaming chat, tool call chips, and action cards |
+
+## Changed files
+
+| File | Change |
+|------|--------|
+| `src/types/index.ts` | Added `"wikilink"` to `GraphEdgeType` union |
+| `src/store/slices/graph.ts` | Added `"wikilink"` to `DEFAULT_GRAPH_FILTERS.edgeTypes`; added `edgeTypeLabel` case |
+| `electron/db/graph-queries.ts` | Added `"wikilink"` to `EdgeType`; new `extractWikilinkTitles()` helper; wikilink pass in `computeAutoRelationships()`; wikilink edges included in `getKnowledgeGraph()` |
+| `electron/lib/tool-schemas.ts` | Added `suggest_connections` tool schema with `z.discriminatedUnion` over four action types; added to `CHAT_ONLY_TOOLS` |
+| `electron/lib/tools.ts` | Added `suggest_connections` label to `TOOL_LABELS` |
+| `electron/ipc/chat-executor.ts` | Added `suggest_connections` no-op case (renderer-only, like `ask_questions`) |
+| `electron/lib/read-tools.ts` | Added `blockedByIds` and `assignee` to `CairnSnapshot.cards` type |
+| `electron/ipc/handlers.ts` | Fixed `ctx.db` → `db` in `registerAppHandlers` |
+| `electron/notes-files.ts` | Made `NoteFileData.folder` optional |
+| `electron/mcp-server.ts` | Made local `NoteFileData.folder` optional; added `folder` field |
+| `src/components/notes/note-editor.tsx` | `[[` trigger detection; `WikilinkPicker` integration; "Link" toolbar button; `remarkWikilinks` plugin; `wikilink` mdComponent; wikilink backlinks in `BacklinksPanel` |
+| `src/components/graph/ForceGraphCanvas.tsx` | Wikilink edge colour/weight/arrows; weight-based `linkWidth` for auto edges |
+| `src/components/graph/KnowledgeGraphView.tsx` | AI button in toolbar; `GraphAIPanel` rendered alongside detail panel |
+| `electron/ipc/chat-executor.test.ts` | Added `message: ""` to `ChatRequest` fixture |
+| `electron/ipc/tool-parity.test.ts` | Added `message: ""`; widened `Set<ToolName>` to `Set<string>` |

--- a/changelogs/v1.1.0.md
+++ b/changelogs/v1.1.0.md
@@ -42,6 +42,14 @@ New module exported for use across the codebase:
 - `segmentContent(content, notes)` — splits content into `text` / `wikilink` segments for inline rendering
 - `getActiveWikilink(content, cursorPos)` — detects a partial `[[query` being typed at the cursor, used by the editor autocomplete trigger
 
+### Table of Contents — Links section
+The floating TOC panel in note read mode now shows a **Links** section below the headings list whenever a note contains wikilinks.
+
+- Each link is a clickable entry that fires `cairn:select-note` to navigate directly to the target note.
+- Unresolved links (no matching note in the workspace) appear muted and non-interactive.
+- The TOC renders even when there are fewer than 2 headings, as long as there are wikilinks.
+- Pure logic (`headingSlug`, `extractHeadings`, `extractWikiLinks`) extracted to `src/components/notes/toc-utils.ts` so it can be unit-tested in a Node environment without pulling in React.
+
 ## Improvements
 
 - **Improved co-mention scoring** — the relationship cache's co-mention pass now supports the `wikilink` edge type alongside `co-mention`, `keyword`, and `assignee`. The graph query layer (`getKnowledgeGraph`) includes wikilink edges from cache when `includeAuto` is true and `wikilink` is in `edgeTypes`.
@@ -69,7 +77,9 @@ The `CairnSnapshot` type in `electron/lib/read-tools.ts` declared the `cards` ar
 | File | Purpose |
 |------|---------|
 | `src/lib/wikilink-parser.ts` | Wikilink extraction, resolution, segmentation, and cursor-trigger detection |
+| `src/lib/wikilink-parser.test.ts` | Unit tests: `parseWikilinks`, `resolveWikilinks`, `segmentContent`, `getActiveWikilink`, `extractHeadings`, `headingSlug`, `extractWikiLinks` (39 tests) |
 | `src/components/notes/WikilinkPicker.tsx` | Floating autocomplete picker for `[[Note Title]]` insertion |
+| `src/components/notes/toc-utils.ts` | Pure TOC helpers extracted from `TableOfContents.tsx` for testability |
 | `src/components/graph/GraphAIPanel.tsx` | AI Graph Assistant panel with streaming chat, tool call chips, and action cards |
 
 ## Changed files
@@ -89,5 +99,6 @@ The `CairnSnapshot` type in `electron/lib/read-tools.ts` declared the `cards` ar
 | `src/components/notes/note-editor.tsx` | `[[` trigger detection; `WikilinkPicker` integration; "Link" toolbar button; `remarkWikilinks` plugin; `wikilink` mdComponent; wikilink backlinks in `BacklinksPanel` |
 | `src/components/graph/ForceGraphCanvas.tsx` | Wikilink edge colour/weight/arrows; weight-based `linkWidth` for auto edges |
 | `src/components/graph/KnowledgeGraphView.tsx` | AI button in toolbar; `GraphAIPanel` rendered alongside detail panel |
+| `src/components/notes/TableOfContents.tsx` | Added Links section; re-exports from `toc-utils.ts` |
 | `electron/ipc/chat-executor.test.ts` | Added `message: ""` to `ChatRequest` fixture |
 | `electron/ipc/tool-parity.test.ts` | Added `message: ""`; widened `Set<ToolName>` to `Set<string>` |

--- a/electron/db/graph-queries.ts
+++ b/electron/db/graph-queries.ts
@@ -46,7 +46,8 @@ export type EdgeType =
   | "flow-edge"
   | "co-mention"
   | "keyword"
-  | "assignee";
+  | "assignee"
+  | "wikilink";
 
 export interface GraphEdge {
   id: string;
@@ -363,11 +364,12 @@ export function getKnowledgeGraph(
   }
 
   // ── 6. Auto relationships (relationship_cache) ─────────────────────────────
-  if (includeAuto && (wantsEdge("co-mention") || wantsEdge("keyword") || wantsEdge("assignee"))) {
+  if (includeAuto && (wantsEdge("co-mention") || wantsEdge("keyword") || wantsEdge("assignee") || wantsEdge("wikilink"))) {
     const autoTypes: string[] = [];
     if (wantsEdge("co-mention")) autoTypes.push("co-mention");
     if (wantsEdge("keyword"))    autoTypes.push("keyword");
     if (wantsEdge("assignee"))   autoTypes.push("assignee");
+    if (wantsEdge("wikilink"))   autoTypes.push("wikilink");
 
     if (autoTypes.length > 0) {
       const typePlaceholders = autoTypes.map(() => "?").join(",");
@@ -469,6 +471,18 @@ export function getNeighbours(
 
 // ── Auto-relationship computation ─────────────────────────────────────────────
 
+/** Extract [[Title]] wikilink targets from markdown content */
+function extractWikilinkTitles(content: string): string[] {
+  const results: string[] = [];
+  const re = /\[\[([^\][\n]+?)\]\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    const title = m[1].trim();
+    if (title.length > 0) results.push(title.toLowerCase());
+  }
+  return results;
+}
+
 /** Tokenise text into lowercase words, filter stop-words, min length 4 */
 function tokenise(text: string): string[] {
   const STOP = new Set([
@@ -524,6 +538,23 @@ export function computeAutoRelationships(
     // Clear stale cache for this workspace's entities
     const allIds = [...notes.map((n) => n.id as string), ...cards.map((c) => c.id as string)];
     for (const id of allIds) deleteOld.run(id, id);
+
+    // ── Wikilink: [[Title]] explicit author-written links ─────────────────
+    const noteTitleToId = new Map<string, string>(); // title_lower → noteId
+    for (const n of notes) noteTitleToId.set((n.title as string).toLowerCase(), n.id as string);
+
+    for (const n of notes) {
+      const content = (n.content_text as string) || "";
+      const targets = extractWikilinkTitles(content);
+      for (const titleLower of targets) {
+        const targetId = noteTitleToId.get(titleLower);
+        if (!targetId || targetId === (n.id as string)) continue;
+        const [src, tgt] = (n.id as string) < targetId
+          ? [n.id as string, targetId]
+          : [targetId, n.id as string];
+        upsert.run(src, tgt, "wikilink", 1.0, now);
+      }
+    }
 
     // ── Co-mention: note content mentions another note/card title ─────────
     const titleMap = new Map<string, string>(); // title_lower → id

--- a/electron/ipc/chat-executor.test.ts
+++ b/electron/ipc/chat-executor.test.ts
@@ -39,7 +39,7 @@ function makeDb(): Database.Database {
 }
 
 const llmConfig: LLMConfig = { baseUrl: "http://localhost", model: "test", apiKey: "" };
-const chatReq: ChatRequest = { workspaceId: "ws1", projectId: "proj1", threadId: "t1" };
+const chatReq: ChatRequest = { message: "", workspaceId: "ws1", projectId: "proj1", threadId: "t1" };
 
 function noEmit() {}
 

--- a/electron/ipc/chat-executor.ts
+++ b/electron/ipc/chat-executor.ts
@@ -406,6 +406,12 @@ export async function executeTool(
       // tool loop can continue after the user submits answers.
       return { ok: true, questions: args.questions };
     }
+    case "suggest_connections": {
+      // Renderer-only tool — the Graph AI panel intercepts the tool-call event
+      // and renders each action as an interactive card with an Apply button.
+      // The executor just acknowledges so streaming can continue.
+      return { ok: true, count: (args.actions as unknown[])?.length ?? 0 };
+    }
     case "generate_prd": {
       return generatePrd(db, workspacePath, {
         projectId: args.projectId as string,

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -625,7 +625,7 @@ export function registerAppHandlers(
 
   // ── MCP notification handler ───────────────────────
   ipcMain.handle("mcp:markNotificationsRead", () => handle(() => {
-    markMcpNotificationsRead(ctx.db);
+    markMcpNotificationsRead(db);
     updateTrayBadge(0);
   }));
 

--- a/electron/ipc/tool-parity.test.ts
+++ b/electron/ipc/tool-parity.test.ts
@@ -66,7 +66,7 @@ const SHARED_READ_TOOLS = [
 
 describe("Tool name parity", () => {
   it("TOOLS (chat) contains all shared read tool names", () => {
-    const chatToolNames = new Set(TOOLS.map((t) => t.function.name));
+    const chatToolNames = new Set<string>(TOOLS.map((t) => t.function.name));
     for (const name of SHARED_READ_TOOLS) {
       expect(chatToolNames.has(name), `chat TOOLS missing: ${name}`).toBe(true);
     }
@@ -195,7 +195,7 @@ describe("list_recent_activity shape consistency", () => {
 // ═════════════════════════════════════════════════════════════════════════════
 
 const llmCfg: LLMConfig = { baseUrl: "http://localhost", model: "test", apiKey: "" };
-const chatReq: ChatRequest = { workspaceId: "ws1", projectId: "proj1", threadId: "t1" };
+const chatReq: ChatRequest = { message: "", workspaceId: "ws1", projectId: "proj1", threadId: "t1" };
 function noEmit() {}
 
 function makeTmpDir() {

--- a/electron/lib/read-tools.ts
+++ b/electron/lib/read-tools.ts
@@ -40,8 +40,8 @@ export interface CairnSnapshot {
   cards: Array<{
     id: string; columnId: string; projectId: string; workspaceId: string;
     title: string; description?: string; priority: string; dueDate?: string;
-    linkedNoteIds: string[]; tagIds: string[]; order: number;
-    createdAt: string; updatedAt: string; archivedAt?: string;
+    linkedNoteIds: string[]; blockedByIds: string[]; tagIds: string[]; order: number;
+    assignee?: string; createdAt: string; updatedAt: string; archivedAt?: string;
   }>;
   tags: Array<{ id: string; workspaceId: string; name: string; color: string }>;
 }

--- a/electron/lib/tool-schemas.ts
+++ b/electron/lib/tool-schemas.ts
@@ -463,12 +463,51 @@ export const TOOL_SCHEMAS = {
     }),
   },
 
+  suggest_connections: {
+    description: "Emit a structured list of suggested connections for the Knowledge Graph Assistant panel. Call this AFTER writing your prose analysis to surface actionable items the user can apply with one click. Each action targets a specific node by its ID from the graph snapshot.",
+    schema: z.object({
+      actions: z.array(z.discriminatedUnion("type", [
+        z.object({
+          type:         z.literal("add_wikilink"),
+          sourceNoteId: z.string().describe("ID of the note to insert the wikilink into"),
+          sourceTitle:  z.string().describe("Title of the source note"),
+          targetTitle:  z.string().describe("Title of the note to link to (becomes [[targetTitle]])"),
+          reason:       z.string().describe("One sentence explaining why this link is valuable"),
+        }),
+        z.object({
+          type:         z.literal("link_note_note"),
+          sourceNoteId: z.string().describe("ID of the first note"),
+          sourceTitle:  z.string().describe("Title of the first note"),
+          targetNoteId: z.string().describe("ID of the second note"),
+          targetTitle:  z.string().describe("Title of the second note"),
+          reason:       z.string().describe("One sentence explaining why these notes should be linked"),
+        }),
+        z.object({
+          type:      z.literal("link_note_card"),
+          noteId:    z.string().describe("ID of the note"),
+          noteTitle: z.string().describe("Title of the note"),
+          cardId:    z.string().describe("ID of the task card"),
+          cardTitle: z.string().describe("Title of the task card"),
+          reason:    z.string().describe("One sentence explaining why this note-task link is valuable"),
+        }),
+        z.object({
+          type:      z.literal("add_tag"),
+          nodeId:    z.string().describe("ID of the note or card to tag"),
+          nodeTitle: z.string().describe("Title of the note or card"),
+          nodeType:  z.enum(["note", "card"]).describe("Whether the target is a note or a card"),
+          tagName:   z.string().describe("Name of the tag to apply (will be created if it doesn't exist)"),
+          reason:    z.string().describe("One sentence explaining why this tag is appropriate"),
+        }),
+      ])).describe("List of suggested connection actions, max 8"),
+    }),
+  },
+
 } as const;
 
 export type ToolName = keyof typeof TOOL_SCHEMAS;
 
 // Chat-only tools (not exposed via MCP)
-export const CHAT_ONLY_TOOLS: ToolName[] = ["get_active_context", "generate_prd", "spawn_tasks_from_note", "ask_questions"];
+export const CHAT_ONLY_TOOLS: ToolName[] = ["get_active_context", "generate_prd", "spawn_tasks_from_note", "ask_questions", "suggest_connections"];
 
 export type ToolCategory = "read" | "write" | "delete";
 

--- a/electron/lib/tools.ts
+++ b/electron/lib/tools.ts
@@ -63,6 +63,7 @@ export const TOOL_LABELS: Record<string, (args: ToolArgs) => string> = {
   get_dashboard_constants: () => "Reading dashboard API reference",
   get_idea_flow_rules:    () => "Reading Idea Flow rules",
   ask_questions:          (a) => `Asking ${(a.questions as unknown[])?.length ?? ""} question${(a.questions as unknown[])?.length !== 1 ? "s" : ""}`,
+  suggest_connections:    (a) => `Suggesting ${(a.actions as unknown[])?.length ?? ""} connection${(a.actions as unknown[])?.length !== 1 ? "s" : ""}`,
 };
 
 // Tool definitions for the AI (OpenAI function calling format)

--- a/electron/mcp-server.ts
+++ b/electron/mcp-server.ts
@@ -219,7 +219,7 @@ function resolveNoteFilePath(workspacePath: string, projectName: string, title: 
 interface NoteFileData {
   id: string; projectId: string; workspaceId: string; title: string; content: string;
   tagIds: string[]; linkedNoteIds: string[]; linkedCardIds: string[];
-  isPinned: boolean; createdAt: string; updatedAt: string; archivedAt?: string;
+  isPinned: boolean; folder?: string; createdAt: string; updatedAt: string; archivedAt?: string;
   projectName: string;
 }
 

--- a/electron/notes-files.ts
+++ b/electron/notes-files.ts
@@ -132,7 +132,7 @@ export interface NoteData {
   linkedNoteIds: string[];
   linkedCardIds: string[];
   isPinned: boolean;
-  folder: string;
+  folder?: string;
   createdAt: string;
   updatedAt: string;
   archivedAt?: string;

--- a/src/components/graph/ForceGraphCanvas.tsx
+++ b/src/components/graph/ForceGraphCanvas.tsx
@@ -39,6 +39,7 @@ function edgeColor(edgeType: string): { color: string; opacity: number; dash: bo
     case "co-mention":     return { color: resolveCssVar("--border"),  opacity: 0.5, dash: true  };
     case "keyword":        return { color: resolveCssVar("--border"),  opacity: 0.4, dash: true  };
     case "assignee":       return { color: resolveCssVar("--border"),  opacity: 0.4, dash: true  };
+    case "wikilink":       return { color: resolveCssVar("--accent"),  opacity: 0.75, dash: false };
     default:               return { color: resolveCssVar("--border"),  opacity: 0.4, dash: false };
   }
 }
@@ -134,14 +135,18 @@ export function ForceGraphCanvas({ graph, selectedNodeId, onNodeClick, onBackgro
           const { color, opacity } = edgeColor(link.edgeType ?? "");
           return toAlpha(color, opacity);
         }}
-        linkWidth={(link: { edgeType?: string }) =>
-          link.edgeType === "flow-edge" ? 2 : 1
-        }
+        linkWidth={(link: { edgeType?: string; weight?: number }) => {
+          if (link.edgeType === "flow-edge") return 2;
+          if (link.edgeType === "wikilink") return 2;
+          // Weight-based thickness for auto-discovered edges (0–1 range)
+          if (link.weight != null && link.weight < 1) return 0.5 + link.weight * 1.0;
+          return 1;
+        }}
         linkLineDash={(link: { edgeType?: string }) =>
           edgeColor(link.edgeType ?? "").dash ? [3, 3] : null
         }
         linkDirectionalArrowLength={(link: { edgeType?: string }) =>
-          link.edgeType === "flow-edge" ? 4 : 0
+          link.edgeType === "flow-edge" || link.edgeType === "wikilink" ? 4 : 0
         }
         linkDirectionalArrowRelPos={1}
         onNodeClick={handleNodeClick}

--- a/src/components/graph/GraphAIPanel.tsx
+++ b/src/components/graph/GraphAIPanel.tsx
@@ -1,0 +1,555 @@
+"use client";
+
+/**
+ * GraphAIPanel — AI assistant embedded in KnowledgeGraphView.
+ *
+ * The AI writes prose markdown freely, then calls the `suggest_connections`
+ * tool to emit structured actions. We intercept that tool call via onToolCall,
+ * capture the args, and render each action as an interactive Apply card.
+ * Prose and actions are fully separate — no parsing or stripping required.
+ */
+
+import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { X, Send, Square, Sparkles, Loader2, CheckCircle, Link2, FileText, Kanban, Tag, Check, ChevronDown, ChevronUp } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useCairnStore } from "@/store";
+import { useShallow } from "zustand/react/shallow";
+import type { KnowledgeGraph, GraphNode } from "@/types";
+import { MarkdownContent } from "@/components/chat/chat-panel/MarkdownContent";
+
+// ── Action types (mirror suggest_connections schema) ──────────────────────────
+
+type SuggestedAction =
+  | { type: "add_wikilink";   sourceNoteId: string; sourceTitle: string; targetTitle: string; reason: string }
+  | { type: "link_note_note"; sourceNoteId: string; sourceTitle: string; targetNoteId: string; targetTitle: string; reason: string }
+  | { type: "link_note_card"; noteId: string; noteTitle: string; cardId: string; cardTitle: string; reason: string }
+  | { type: "add_tag";        nodeId: string; nodeTitle: string; nodeType: "note" | "card"; tagName: string; reason: string };
+
+interface Message {
+  role: "user" | "assistant";
+  content: string;
+  actions?: SuggestedAction[];
+}
+
+interface GraphAIPanelProps {
+  graph: KnowledgeGraph;
+  selectedNode: GraphNode | null;
+  onClose: () => void;
+}
+
+// ── Graph context builder ─────────────────────────────────────────────────────
+
+function buildGraphContext(graph: KnowledgeGraph, selectedNode: GraphNode | null): string {
+  const nodeLines = graph.nodes
+    .slice(0, 80)
+    .map((n) => {
+      const snippet = n.meta?.snippet ? ` — "${n.meta.snippet.slice(0, 80).replace(/\n/g, " ")}"` : "";
+      return `- [${n.type}] id=${n.id} "${n.title}"${snippet}`;
+    })
+    .join("\n");
+
+  const edgeLines = graph.edges
+    .slice(0, 100)
+    .map((e) => {
+      const src = graph.nodes.find((n) => n.id === e.source);
+      const tgt = graph.nodes.find((n) => n.id === e.target);
+      if (!src || !tgt) return null;
+      return `- "${src.title}" → "${tgt.title}" (${e.type}${e.weight != null ? `, w=${e.weight.toFixed(2)}` : ""})`;
+    })
+    .filter(Boolean)
+    .join("\n");
+
+  const sel = selectedNode
+    ? `\n\nSelected: [${selectedNode.type}] id=${selectedNode.id} "${selectedNode.title}"${selectedNode.meta?.snippet ? `\nPreview: "${selectedNode.meta.snippet}"` : ""}`
+    : "";
+
+  return `NODES (${graph.nodes.length} total, first 80):\n${nodeLines || "(none)"}\n\nEDGES (${graph.edges.length} total, first 100):\n${edgeLines || "(none)"}${sel}`;
+}
+
+// ── System prompt ─────────────────────────────────────────────────────────────
+
+const SYSTEM_PROMPT = `You are a Knowledge Graph assistant embedded in Cairn, a note-taking and project management app.
+
+You help users build meaningful connections between their notes, tasks, and projects. You have access to a snapshot of their current knowledge graph — each node includes its ID and title.
+
+Your capabilities:
+1. **Suggest missing connections** — identify notes/cards that are related but not yet linked
+2. **Recommend wikilinks** — suggest [[Note Title]] wikilinks to add to specific notes
+3. **Suggest tags** — recommend tags to apply to notes or cards
+4. **Explain connections** — describe why two nodes are related
+5. **Graph analysis** — identify clusters, orphan nodes, and structural patterns
+
+## Workflow
+
+Write your analysis as clear, concise markdown prose.
+
+When you have specific actionable suggestions, call the \`suggest_connections\` tool with those actions. The user will see Apply buttons for each one. Use node IDs exactly as they appear in the graph snapshot. Limit to 8 actions maximum.
+
+Do not put the actions in your prose — call the tool instead.`;
+
+// ── Action card ───────────────────────────────────────────────────────────────
+
+function actionIcon(type: SuggestedAction["type"]) {
+  switch (type) {
+    case "add_wikilink":   return <Link2 size={11} className="text-[var(--accent)] shrink-0" />;
+    case "link_note_note": return <FileText size={11} className="text-[var(--info)] shrink-0" />;
+    case "link_note_card": return <Kanban size={11} className="text-[var(--success)] shrink-0" />;
+    case "add_tag":        return <Tag size={11} className="text-[var(--warning)] shrink-0" />;
+  }
+}
+
+function actionLabel(action: SuggestedAction): string {
+  switch (action.type) {
+    case "add_wikilink":   return `Add [[${action.targetTitle}]] → "${action.sourceTitle}"`;
+    case "link_note_note": return `Link "${action.sourceTitle}" ↔ "${action.targetTitle}"`;
+    case "link_note_card": return `Link "${action.noteTitle}" → "${action.cardTitle}"`;
+    case "add_tag":        return `Tag "${action.nodeTitle}" #${action.tagName}`;
+  }
+}
+
+interface ActionCardProps {
+  action: SuggestedAction;
+  onApply: () => Promise<void>;
+  onDismiss: () => void;
+}
+
+function ActionCard({ action, onApply, onDismiss }: ActionCardProps) {
+  const [state, setState] = useState<"idle" | "applying" | "done">("idle");
+  const [expanded, setExpanded] = useState(false);
+
+  async function handleApply() {
+    setState("applying");
+    try { await onApply(); setState("done"); }
+    catch { setState("idle"); }
+  }
+
+  return (
+    <div className={cn(
+      "rounded-lg border text-[0.714rem] overflow-hidden transition-colors",
+      state === "done"
+        ? "border-[var(--success)]/30 bg-[color-mix(in_srgb,var(--success)_6%,transparent)]"
+        : "border-[var(--border)] bg-[var(--surface)]"
+    )}>
+      <div className="flex items-center gap-2 px-2.5 py-2">
+        {actionIcon(action.type)}
+        <span className={cn(
+          "flex-1 min-w-0 leading-snug",
+          state === "done" ? "text-[var(--text-tertiary)] line-through truncate" : "text-[var(--text-secondary)]"
+        )}>
+          {actionLabel(action)}
+        </span>
+
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="shrink-0 p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
+          title="Why?"
+        >
+          {expanded ? <ChevronUp size={10} /> : <ChevronDown size={10} />}
+        </button>
+
+        {state === "done" ? (
+          <Check size={11} className="text-[var(--success)] shrink-0" />
+        ) : (
+          <button
+            onClick={handleApply}
+            disabled={state === "applying"}
+            className="shrink-0 px-2 py-0.5 rounded bg-[var(--accent-dim)] text-[var(--accent)] hover:bg-[color-mix(in_srgb,var(--accent)_20%,transparent)] transition-colors disabled:opacity-50 text-[0.643rem] font-medium"
+          >
+            {state === "applying" ? <Loader2 size={9} className="animate-spin" /> : "Apply"}
+          </button>
+        )}
+
+        {state !== "done" && (
+          <button
+            onClick={onDismiss}
+            className="shrink-0 p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
+            title="Dismiss"
+          >
+            <X size={10} />
+          </button>
+        )}
+      </div>
+
+      {expanded && (
+        <div className="px-2.5 pb-2 pt-1.5 text-[0.643rem] text-[var(--text-tertiary)] leading-relaxed border-t border-[var(--border)]">
+          {action.reason}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Actions list ──────────────────────────────────────────────────────────────
+
+interface ActionsListProps {
+  actions: SuggestedAction[];
+  notes: { id: string; title: string; content?: string | null; linkedNoteIds: string[]; linkedCardIds: string[]; tagIds: string[] }[];
+  cards: { id: string; linkedNoteIds: string[]; tagIds: string[] }[];
+  tags: { id: string; name: string; workspaceId: string }[];
+  activeWorkspaceId: string | null;
+  updateNote: (id: string, patch: object) => void;
+  updateCard: (id: string, patch: object) => void;
+  linkNoteToCard: (noteId: string, cardId: string) => void;
+  createTag: (workspaceId: string, name: string) => { id: string };
+  recomputeGraphRelationships: (workspaceId: string) => Promise<void>;
+}
+
+function ActionsList(props: ActionsListProps) {
+  const { actions, notes, cards, tags, activeWorkspaceId, updateNote, updateCard, linkNoteToCard, createTag, recomputeGraphRelationships } = props;
+  const [dismissed, setDismissed] = useState<Set<number>>(new Set());
+  const [applyAllState, setApplyAllState] = useState<"idle" | "applying" | "done">("idle");
+
+  async function applyAction(action: SuggestedAction) {
+    switch (action.type) {
+      case "add_wikilink": {
+        const note = notes.find((n) => n.id === action.sourceNoteId);
+        if (!note) throw new Error("Note not found");
+        updateNote(action.sourceNoteId, { content: (note.content ?? "") + `\n\n[[${action.targetTitle}]]` });
+        break;
+      }
+      case "link_note_note": {
+        const src = notes.find((n) => n.id === action.sourceNoteId);
+        const tgt = notes.find((n) => n.id === action.targetNoteId);
+        if (!src || !tgt) throw new Error("Note not found");
+        updateNote(action.sourceNoteId, { linkedNoteIds: Array.from(new Set([...src.linkedNoteIds, action.targetNoteId])) });
+        updateNote(action.targetNoteId, { linkedNoteIds: Array.from(new Set([...tgt.linkedNoteIds, action.sourceNoteId])) });
+        break;
+      }
+      case "link_note_card": {
+        linkNoteToCard(action.noteId, action.cardId);
+        break;
+      }
+      case "add_tag": {
+        if (!activeWorkspaceId) throw new Error("No workspace");
+        const existingTag = tags.find((t) => t.name.toLowerCase() === action.tagName.toLowerCase());
+        const tag = existingTag ?? createTag(activeWorkspaceId, action.tagName);
+        if (action.nodeType === "note") {
+          const note = notes.find((n) => n.id === action.nodeId);
+          if (note) updateNote(action.nodeId, { tagIds: Array.from(new Set([...note.tagIds, tag.id])) });
+        } else {
+          const card = cards.find((c) => c.id === action.nodeId);
+          if (card) updateCard(action.nodeId, { tagIds: Array.from(new Set([...card.tagIds, tag.id])) });
+        }
+        break;
+      }
+    }
+    if (activeWorkspaceId) recomputeGraphRelationships(activeWorkspaceId).catch(() => {});
+  }
+
+  async function handleApplyAll() {
+    setApplyAllState("applying");
+    for (let i = 0; i < actions.length; i++) {
+      if (dismissed.has(i)) continue;
+      try { await applyAction(actions[i]); } catch { /* skip */ }
+    }
+    setApplyAllState("done");
+  }
+
+  const visible = actions.filter((_, i) => !dismissed.has(i));
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="mt-2 space-y-1.5">
+      <div className="flex items-center justify-between px-0.5">
+        <span className="text-[0.643rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">
+          {visible.length} suggested action{visible.length !== 1 ? "s" : ""}
+        </span>
+        {visible.length > 1 && applyAllState === "idle" && (
+          <button onClick={handleApplyAll} className="text-[0.643rem] text-[var(--accent)] hover:underline">
+            Apply all
+          </button>
+        )}
+        {applyAllState === "done" && (
+          <span className="text-[0.643rem] text-[var(--success)] flex items-center gap-1">
+            <Check size={9} /> All applied
+          </span>
+        )}
+      </div>
+      {actions.map((action, i) =>
+        dismissed.has(i) ? null : (
+          <ActionCard
+            key={i}
+            action={action}
+            onApply={() => applyAction(action)}
+            onDismiss={() => setDismissed((prev) => new Set([...prev, i]))}
+          />
+        )
+      )}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export function GraphAIPanel({ graph, selectedNode, onClose }: GraphAIPanelProps) {
+  const {
+    aiConfig, notes, cards, tags, activeWorkspaceId,
+    updateNote, updateCard, linkNoteToCard, createTag, recomputeGraphRelationships,
+  } = useCairnStore(useShallow((s) => ({
+    aiConfig:                    s.aiConfig,
+    notes:                       s.notes,
+    cards:                       s.cards,
+    tags:                        s.tags,
+    activeWorkspaceId:           s.activeWorkspaceId,
+    updateNote:                  s.updateNote,
+    updateCard:                  s.updateCard,
+    linkNoteToCard:              s.linkNoteToCard,
+    createTag:                   s.createTag,
+    recomputeGraphRelationships: s.recomputeGraphRelationships,
+  })));
+
+  const [messages, setMessages]          = useState<Message[]>([]);
+  const [input, setInput]                = useState("");
+  const [isLoading, setIsLoading]        = useState(false);
+  const [streamingContent, setStreaming] = useState("");
+  const [toolCalls, setToolCalls]        = useState<{ tool: string; label: string }[]>([]);
+  // Actions captured from the suggest_connections tool call mid-stream
+  const pendingActionsRef = useRef<SuggestedAction[]>([]);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef       = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, streamingContent, toolCalls]);
+
+  useEffect(() => { inputRef.current?.focus(); }, []);
+
+  const graphContext = useMemo(
+    () => buildGraphContext(graph, selectedNode),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      graph.nodes.map((n) => n.id).join(","),
+      graph.edges.map((e) => `${e.source}>${e.target}`).join(","),
+      selectedNode?.id,
+    ]
+  );
+
+  const sendMessage = useCallback(async () => {
+    const text = input.trim();
+    if (!text || isLoading) return;
+    const electron = window.electron;
+    if (!electron) return;
+
+    const userMsg: Message = { role: "user", content: text };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
+    setIsLoading(true);
+    setStreaming("");
+    setToolCalls([]);
+    pendingActionsRef.current = [];
+
+    const history = [...messages, userMsg].map((m) => ({ role: m.role, content: m.content }));
+    const systemPromptWithContext = `${SYSTEM_PROMPT}\n\n--- CURRENT GRAPH SNAPSHOT ---\n${graphContext}`;
+
+    const unsubTool = electron.chat.onToolCall((e: { tool: string; label: string; args: Record<string, unknown> }) => {
+      if (e.tool === "suggest_connections") {
+        // Capture actions — will be attached to the message on done
+        const incoming = (e.args.actions ?? []) as SuggestedAction[];
+        pendingActionsRef.current = incoming;
+      } else {
+        // Show all other tool calls as progress chips
+        setToolCalls((prev) => [...prev, { tool: e.tool, label: e.label }]);
+      }
+    });
+
+    const unsubToken = electron.chat.onToken((e: { delta: string }) => {
+      setStreaming((prev) => prev + e.delta);
+    });
+
+    const unsubDone = electron.chat.onDone((e: { content: string }) => {
+      unsubTool();
+      unsubToken();
+      unsubDone();
+      // Capture actions synchronously before clearing the ref — the setMessages
+      // updater function runs asynchronously, so pendingActionsRef.current would
+      // already be [] by the time React calls the updater if we don't snapshot it.
+      const capturedActions = pendingActionsRef.current;
+      pendingActionsRef.current = [];
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: e.content, actions: capturedActions },
+      ]);
+      setStreaming("");
+      setToolCalls([]);
+      setIsLoading(false);
+    });
+
+    electron.chat.stream({
+      message: text,
+      threadId: "graph-ai-panel",
+      config: { baseUrl: aiConfig.baseUrl, model: aiConfig.model, apiKey: aiConfig.apiKey },
+      ...(history.length > 1 ? { history: history.slice(0, -1) } : {}),
+      systemPrompt: systemPromptWithContext,
+    });
+  }, [input, isLoading, messages, graphContext, aiConfig]);
+
+  const stopStream = useCallback(() => {
+    window.electron?.chat.abort();
+    setIsLoading(false);
+    setToolCalls([]);
+    if (streamingContent) {
+      const capturedActions = pendingActionsRef.current;
+      pendingActionsRef.current = [];
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: streamingContent, actions: capturedActions },
+      ]);
+      setStreaming("");
+    }
+  }, [streamingContent]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+  }, [sendMessage]);
+
+  const suggestedPrompts = useMemo(() => {
+    const base = [
+      "What connections am I missing in this graph?",
+      "Which notes are related but not linked?",
+      "Suggest wikilinks I should add",
+    ];
+    if (selectedNode) return [
+      `What should I link to "${selectedNode.title}"?`,
+      `Explain the connections around "${selectedNode.title}"`,
+      ...base.slice(0, 1),
+    ];
+    return base;
+  }, [selectedNode]);
+
+  return (
+    <div className="flex flex-col w-80 border-l border-[var(--border)] bg-[var(--surface)] flex-shrink-0 overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-[var(--border)] flex-shrink-0">
+        <Sparkles size={13} className="text-[var(--accent)]" />
+        <span className="flex-1 text-xs font-medium text-[var(--text-primary)]">Graph Assistant</span>
+        {selectedNode && (
+          <span className="text-[0.714rem] text-[var(--text-tertiary)] truncate max-w-24" title={selectedNode.title}>
+            {selectedNode.title}
+          </span>
+        )}
+        <button onClick={onClose} className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors">
+          <X size={13} />
+        </button>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto min-h-0 p-3 space-y-3">
+
+        {/* Empty state */}
+        {messages.length === 0 && !isLoading && (
+          <div className="space-y-2">
+            <p className="text-[0.714rem] text-[var(--text-tertiary)] leading-relaxed">
+              Ask me to analyse your graph, suggest connections, or recommend wikilinks.
+            </p>
+            <div className="space-y-1.5">
+              {suggestedPrompts.map((prompt) => (
+                <button
+                  key={prompt}
+                  onClick={() => { setInput(prompt); inputRef.current?.focus(); }}
+                  className="w-full text-left text-[0.714rem] px-2.5 py-2 rounded-md border border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--accent)] hover:border-[var(--accent)] hover:bg-[var(--accent-dim)] transition-colors leading-snug"
+                >
+                  {prompt}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Message history */}
+        {messages.map((msg, i) => (
+          <div key={i} className={cn("flex", msg.role === "user" ? "justify-end" : "justify-start")}>
+            {msg.role === "user" ? (
+              <div className="max-w-[95%] rounded-lg px-3 py-2 text-xs leading-relaxed bg-[var(--accent)] text-white">
+                {msg.content}
+              </div>
+            ) : (
+              <div className="w-full min-w-0">
+                <div className="rounded-lg px-3 py-2 text-xs leading-relaxed bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-secondary)]">
+                  <MarkdownContent content={msg.content} />
+                </div>
+                {msg.actions && msg.actions.length > 0 && (
+                  <ActionsList
+                    actions={msg.actions}
+                    notes={notes}
+                    cards={cards}
+                    tags={tags}
+                    activeWorkspaceId={activeWorkspaceId}
+                    updateNote={updateNote}
+                    updateCard={updateCard}
+                    linkNoteToCard={linkNoteToCard}
+                    createTag={createTag}
+                    recomputeGraphRelationships={recomputeGraphRelationships}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+
+        {/* In-flight: tool call chips + streaming bubble */}
+        {isLoading && (
+          <div className="flex flex-col gap-1">
+            {toolCalls.map((tc, i) => (
+              <div key={i} className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] w-fit text-[0.714rem] text-[var(--text-secondary)]">
+                <CheckCircle size={10} className="text-[var(--accent)] shrink-0" />
+                {tc.label}
+              </div>
+            ))}
+            {streamingContent ? (
+              <div className="rounded-lg px-3 py-2 text-xs bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-secondary)] leading-relaxed">
+                <MarkdownContent content={streamingContent} />
+                <span className="inline-block w-0.5 h-3 bg-[var(--accent)] animate-pulse ml-0.5 align-middle" />
+              </div>
+            ) : (
+              <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] w-fit text-[0.714rem] text-[var(--text-tertiary)]">
+                <Loader2 size={10} className="animate-spin text-[var(--accent)] shrink-0" />
+                {toolCalls.length === 0 ? "Thinking…" : "Working…"}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input */}
+      <div className="flex-shrink-0 border-t border-[var(--border)] p-2">
+        <div className="flex items-end gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-3 py-2 focus-within:border-[var(--accent)] transition-colors">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about connections…"
+            rows={1}
+            className="flex-1 bg-transparent text-xs text-[var(--text-primary)] placeholder-[var(--text-tertiary)] outline-none resize-none leading-relaxed"
+            style={{ minHeight: "1.4rem", maxHeight: "5rem" }}
+            onInput={(e) => {
+              const el = e.currentTarget;
+              el.style.height = "auto";
+              el.style.height = `${Math.min(el.scrollHeight, 80)}px`;
+            }}
+          />
+          <button
+            onClick={isLoading ? stopStream : sendMessage}
+            disabled={!isLoading && !input.trim()}
+            className={cn(
+              "shrink-0 p-1 rounded transition-colors",
+              isLoading
+                ? "text-[var(--danger)] hover:bg-[color-mix(in_srgb,var(--danger)_10%,transparent)]"
+                : input.trim()
+                  ? "text-[var(--accent)] hover:bg-[var(--accent-dim)]"
+                  : "text-[var(--text-tertiary)] opacity-40 cursor-not-allowed"
+            )}
+          >
+            {isLoading ? <Square size={13} /> : <Send size={13} />}
+          </button>
+        </div>
+        <p className="text-[0.643rem] text-[var(--text-tertiary)] mt-1 px-1">
+          {graph.nodes.length} nodes · {graph.edges.length} edges in context
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/graph/GraphAIPanel.tsx
+++ b/src/components/graph/GraphAIPanel.tsx
@@ -109,18 +109,16 @@ function actionLabel(action: SuggestedAction): string {
 
 interface ActionCardProps {
   action: SuggestedAction;
+  state: "idle" | "applying" | "done";
   onApply: () => Promise<void>;
   onDismiss: () => void;
 }
 
-function ActionCard({ action, onApply, onDismiss }: ActionCardProps) {
-  const [state, setState] = useState<"idle" | "applying" | "done">("idle");
+function ActionCard({ action, state, onApply, onDismiss }: ActionCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   async function handleApply() {
-    setState("applying");
-    try { await onApply(); setState("done"); }
-    catch { setState("idle"); }
+    await onApply();
   }
 
   return (
@@ -197,7 +195,12 @@ interface ActionsListProps {
 function ActionsList(props: ActionsListProps) {
   const { actions, notes, cards, tags, activeWorkspaceId, updateNote, updateCard, linkNoteToCard, createTag, recomputeGraphRelationships } = props;
   const [dismissed, setDismissed] = useState<Set<number>>(new Set());
+  const [cardStates, setCardStates] = useState<Map<number, "idle" | "applying" | "done">>(() => new Map());
   const [applyAllState, setApplyAllState] = useState<"idle" | "applying" | "done">("idle");
+
+  function setCardState(i: number, state: "idle" | "applying" | "done") {
+    setCardStates((prev) => new Map(prev).set(i, state));
+  }
 
   async function applyAction(action: SuggestedAction) {
     switch (action.type) {
@@ -240,7 +243,13 @@ function ActionsList(props: ActionsListProps) {
     setApplyAllState("applying");
     for (let i = 0; i < actions.length; i++) {
       if (dismissed.has(i)) continue;
-      try { await applyAction(actions[i]); } catch { /* skip */ }
+      setCardState(i, "applying");
+      try {
+        await applyAction(actions[i]);
+        setCardState(i, "done");
+      } catch {
+        setCardState(i, "idle");
+      }
     }
     setApplyAllState("done");
   }
@@ -270,7 +279,16 @@ function ActionsList(props: ActionsListProps) {
           <ActionCard
             key={i}
             action={action}
-            onApply={() => applyAction(action)}
+            state={cardStates.get(i) ?? "idle"}
+            onApply={async () => {
+              setCardState(i, "applying");
+              try {
+                await applyAction(action);
+                setCardState(i, "done");
+              } catch {
+                setCardState(i, "idle");
+              }
+            }}
             onDismiss={() => setDismissed((prev) => new Set([...prev, i]))}
           />
         )

--- a/src/components/graph/KnowledgeGraphView.tsx
+++ b/src/components/graph/KnowledgeGraphView.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useCallback, useState, useMemo } from "react";
 import {
-  GitBranch, Circle, RefreshCw, ChevronDown, LayoutGrid, Search,
+  GitBranch, Circle, RefreshCw, ChevronDown, LayoutGrid, Search, Sparkles,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCairnStore } from "@/store";
@@ -11,6 +11,7 @@ import { useLoadGraph } from "@/hooks/useLoadGraph";
 import { filterGraphNodes, filterGraphEdges, nodeTypeColor } from "@/store/slices/graph";
 import type { GraphNode, GraphNodeType } from "@/types";
 import { GraphDetailPanel } from "./GraphDetailPanel";
+import { GraphAIPanel } from "./GraphAIPanel";
 import { ForceGraphCanvas } from "./ForceGraphCanvas";
 import { RadialTreeCanvas } from "./RadialTreeCanvas";
 import { Tooltip } from "@/components/ui/tooltip";
@@ -49,6 +50,7 @@ export function KnowledgeGraphView() {
   const [projectDropdownOpen, setProjectDropdownOpen] = useState(false);
   const [recomputing, setRecomputing] = useState(false);
   const [graphSearch, setGraphSearch] = useState("");
+  const [aiPanelOpen, setAiPanelOpen] = useState(false);
 
   // Load graph on mount + when workspace changes
   useLoadGraph(activeWorkspaceId);
@@ -294,7 +296,7 @@ export function KnowledgeGraphView() {
           </Tooltip>
         )}
 
-        {/* Stats + Recompute — pinned to right */}
+        {/* Stats + Recompute + AI — pinned to right */}
         <span className="ml-auto flex items-center gap-2 text-[0.786rem] text-[var(--text-tertiary)]">
           {`${filteredNodes.length} nodes · ${filteredEdges.length} edges`}
           <Tooltip content="Recompute auto-relationships">
@@ -304,6 +306,20 @@ export function KnowledgeGraphView() {
               className="flex items-center gap-1 px-1.5 py-1 rounded border border-[var(--border)] text-[var(--text-tertiary)] hover:bg-[var(--surface-2)] transition-colors disabled:opacity-50"
             >
               <RefreshCw size={11} className={recomputing ? "animate-spin" : ""} />
+            </button>
+          </Tooltip>
+          <Tooltip content="AI Graph Assistant">
+            <button
+              onClick={() => setAiPanelOpen((v) => !v)}
+              className={cn(
+                "flex items-center gap-1.5 px-2 py-1 rounded border text-xs transition-colors",
+                aiPanelOpen
+                  ? "border-transparent bg-[var(--accent-dim)] text-[var(--accent)]"
+                  : "border-[var(--border)] text-[var(--text-tertiary)] hover:bg-[var(--surface-2)]"
+              )}
+            >
+              <Sparkles size={11} />
+              AI
             </button>
           </Tooltip>
         </span>
@@ -365,10 +381,19 @@ export function KnowledgeGraphView() {
         </div>
 
         {/* Detail panel */}
-        {selectedNode && (
+        {selectedNode && !aiPanelOpen && (
           <GraphDetailPanel
             node={selectedNode}
             onClose={() => setSelectedGraphNode(null)}
+          />
+        )}
+
+        {/* AI Graph Assistant panel */}
+        {aiPanelOpen && (
+          <GraphAIPanel
+            graph={searchedGraph}
+            selectedNode={selectedNode}
+            onClose={() => setAiPanelOpen(false)}
           />
         )}
       </div>

--- a/src/components/notes/TableOfContents.tsx
+++ b/src/components/notes/TableOfContents.tsx
@@ -13,6 +13,7 @@
 
 import { useMemo, useEffect, useState, useRef } from "react";
 import { cn } from "@/lib/utils";
+import { parseWikilinks } from "@/lib/wikilink-parser";
 
 // ── Slug ─────────────────────────────────────────────────────────────────────
 
@@ -55,18 +56,45 @@ export function extractHeadings(markdown: string): Heading[] {
   return headings;
 }
 
+// ── Wikilink extraction ───────────────────────────────────────────────────────
+
+export interface WikiLink {
+  title: string;
+  noteId: string | null;
+}
+
+/** Extract unique wikilinks from raw markdown, deduplicated by title. */
+export function extractWikiLinks(
+  markdown: string,
+  notes: { id: string; title: string }[]
+): WikiLink[] {
+  const titleIndex = new Map(notes.map((n) => [n.title.toLowerCase().trim(), n.id]));
+  const seen = new Set<string>();
+  const links: WikiLink[] = [];
+  for (const { title } of parseWikilinks(markdown)) {
+    const key = title.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    links.push({ title, noteId: titleIndex.get(key) ?? null });
+  }
+  return links;
+}
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
 interface Props {
   markdown: string;
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  /** Pass workspace notes to render a Links section in the TOC */
+  notes?: { id: string; title: string }[];
 }
 
 // Minimum gap (px) to maintain between the content column right edge and the TOC left edge
 const MIN_GAP = 24;
 
-export function TableOfContents({ markdown, scrollContainerRef }: Props) {
-  const headings = useMemo(() => extractHeadings(markdown), [markdown]);
+export function TableOfContents({ markdown, scrollContainerRef, notes = [] }: Props) {
+  const headings  = useMemo(() => extractHeadings(markdown), [markdown]);
+  const wikiLinks = useMemo(() => extractWikiLinks(markdown, notes), [markdown, notes]);
   const [visible, setVisible] = useState(false);
   const tocRef = useRef<HTMLDivElement>(null);
 
@@ -100,7 +128,7 @@ export function TableOfContents({ markdown, scrollContainerRef }: Props) {
     };
   }, [scrollContainerRef]);
 
-  if (headings.length < 2) return null;
+  if (headings.length < 2 && wikiLinks.length === 0) return null;
 
   function handleClick(e: React.MouseEvent<HTMLAnchorElement>, id: string) {
     e.preventDefault();
@@ -121,29 +149,67 @@ export function TableOfContents({ markdown, scrollContainerRef }: Props) {
       className="absolute top-5 right-4 w-52 flex-shrink-0 transition-opacity duration-150"
       style={{ opacity: visible ? 1 : 0, pointerEvents: visible ? "auto" : "none" }}
     >
-      <div className="sticky top-5">
-        <p className="text-[0.714rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] mb-2 px-1">
-          On this page
-        </p>
-        <nav className="flex flex-col gap-0.5">
-          {headings.map((h, i) => (
-            <a
-              key={`${h.id}-${i}`}
-              href={`#${h.id}`}
-              onClick={(e) => handleClick(e, h.id)}
-              className={cn(
-                "text-[0.786rem] leading-snug truncate rounded px-1 py-0.5 transition-colors",
-                "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]",
-                h.level === 1 && "font-medium",
-                h.level === 2 && "pl-3",
-                h.level === 3 && "pl-5 text-[0.714rem]",
-              )}
-              title={h.text}
-            >
-              {h.text}
-            </a>
-          ))}
-        </nav>
+      <div className="sticky top-5 space-y-4">
+        {headings.length >= 2 && (
+          <div>
+            <p className="text-[0.714rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] mb-2 px-1">
+              On this page
+            </p>
+            <nav className="flex flex-col gap-0.5">
+              {headings.map((h, i) => (
+                <a
+                  key={`${h.id}-${i}`}
+                  href={`#${h.id}`}
+                  onClick={(e) => handleClick(e, h.id)}
+                  className={cn(
+                    "text-[0.786rem] leading-snug truncate rounded px-1 py-0.5 transition-colors",
+                    "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]",
+                    h.level === 1 && "font-medium",
+                    h.level === 2 && "pl-3",
+                    h.level === 3 && "pl-5 text-[0.714rem]",
+                  )}
+                  title={h.text}
+                >
+                  {h.text}
+                </a>
+              ))}
+            </nav>
+          </div>
+        )}
+
+        {wikiLinks.length > 0 && (
+          <div>
+            <p className="text-[0.714rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] mb-2 px-1">
+              Links
+            </p>
+            <nav className="flex flex-col gap-0.5">
+              {wikiLinks.map((wl, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => {
+                    if (wl.noteId) {
+                      window.dispatchEvent(new CustomEvent("cairn:select-note", { detail: { noteId: wl.noteId } }));
+                    }
+                  }}
+                  title={wl.noteId ? `Open: ${wl.title}` : `Note not found: ${wl.title}`}
+                  className={cn(
+                    "flex items-center gap-1.5 w-full text-left text-[0.786rem] leading-snug truncate rounded px-1 py-0.5 transition-colors",
+                    wl.noteId
+                      ? "text-[var(--accent)] hover:bg-[color-mix(in_srgb,var(--accent)_10%,transparent)] cursor-pointer"
+                      : "text-[var(--text-tertiary)] opacity-50 cursor-default"
+                  )}
+                >
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="shrink-0" aria-hidden="true">
+                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+                  </svg>
+                  <span className="truncate">{wl.title}</span>
+                </button>
+              ))}
+            </nav>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/notes/TableOfContents.tsx
+++ b/src/components/notes/TableOfContents.tsx
@@ -13,72 +13,15 @@
 
 import { useMemo, useEffect, useState, useRef } from "react";
 import { cn } from "@/lib/utils";
-import { parseWikilinks } from "@/lib/wikilink-parser";
+import {
+  headingSlug,
+  extractHeadings,
+  extractWikiLinks,
+} from "./toc-utils";
 
-// ── Slug ─────────────────────────────────────────────────────────────────────
-
-/**
- * GitHub-style heading slug: lowercase, spaces → hyphens, strip everything
- * except alphanumerics and hyphens.
- */
-export function headingSlug(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/\s+/g, "-")
-    .replace(/[^\w-]/g, "")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
-}
-
-// ── Heading extraction ────────────────────────────────────────────────────────
-
-export interface Heading {
-  level: 1 | 2 | 3;
-  text: string;
-  id: string;
-}
-
-/** Parse h1/h2/h3 headings from raw markdown source. */
-export function extractHeadings(markdown: string): Heading[] {
-  const headings: Heading[] = [];
-  // Match ATX-style headings (# / ## / ###) — ignore headings inside code fences
-  let inFence = false;
-  for (const line of markdown.split("\n")) {
-    if (line.startsWith("```")) { inFence = !inFence; continue; }
-    if (inFence) continue;
-    const m = line.match(/^(#{1,3})\s+(.+)/);
-    if (m) {
-      const level = m[1].length as 1 | 2 | 3;
-      const text = m[2].trim();
-      headings.push({ level, text, id: headingSlug(text) });
-    }
-  }
-  return headings;
-}
-
-// ── Wikilink extraction ───────────────────────────────────────────────────────
-
-export interface WikiLink {
-  title: string;
-  noteId: string | null;
-}
-
-/** Extract unique wikilinks from raw markdown, deduplicated by title. */
-export function extractWikiLinks(
-  markdown: string,
-  notes: { id: string; title: string }[]
-): WikiLink[] {
-  const titleIndex = new Map(notes.map((n) => [n.title.toLowerCase().trim(), n.id]));
-  const seen = new Set<string>();
-  const links: WikiLink[] = [];
-  for (const { title } of parseWikilinks(markdown)) {
-    const key = title.toLowerCase();
-    if (seen.has(key)) continue;
-    seen.add(key);
-    links.push({ title, noteId: titleIndex.get(key) ?? null });
-  }
-  return links;
-}
+// Re-export so existing import sites (note-editor, tests) don't break
+export { headingSlug, extractHeadings, extractWikiLinks };
+export type { Heading, WikiLink } from "./toc-utils";
 
 // ── Component ─────────────────────────────────────────────────────────────────
 

--- a/src/components/notes/WikilinkPicker.tsx
+++ b/src/components/notes/WikilinkPicker.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+/**
+ * WikilinkPicker — floating autocomplete for `[[Note Title]]` insertion.
+ *
+ * Rendered by NoteEditor when the user types `[[` or clicks the
+ * "Insert link" toolbar button. Positioned relative to the editor container.
+ */
+
+import React, { useEffect, useRef, useState, useCallback } from "react";
+import { FileText } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Note } from "@/types";
+
+export interface WikilinkPickerProps {
+  /** All notes available for linking (excluding the currently-open note) */
+  notes: Note[];
+  /** Projects list for showing project name alongside note title */
+  projects: { id: string; name: string }[];
+  /** Current search query (text typed after `[[`) */
+  query: string;
+  /** Called when the user selects a note — receives the note title */
+  onSelect: (title: string) => void;
+  /** Called when the picker should close without inserting */
+  onClose: () => void;
+  /** CSS top offset (px) for the floating panel, relative to editor container */
+  top?: number;
+  /** CSS left offset (px) */
+  left?: number;
+}
+
+export function WikilinkPicker({
+  notes,
+  projects,
+  query,
+  onSelect,
+  onClose,
+  top,
+  left,
+}: WikilinkPickerProps) {
+  const [activeIdx, setActiveIdx] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const projectMap = new Map(projects.map((p) => [p.id, p.name]));
+
+  const filtered = query.trim() === ""
+    ? notes.slice(0, 12)
+    : notes
+        .filter((n) => n.title.toLowerCase().includes(query.toLowerCase()))
+        .slice(0, 12);
+
+  // Reset active index when filtered list changes
+  useEffect(() => {
+    setActiveIdx(0);
+  }, [query]);
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIdx((i) => Math.min(i + 1, filtered.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIdx((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        e.stopPropagation();
+        if (filtered[activeIdx]) onSelect(filtered[activeIdx].title);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    },
+    [filtered, activeIdx, onSelect, onClose]
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [handleKeyDown]);
+
+  // Scroll active item into view
+  useEffect(() => {
+    const el = listRef.current?.children[activeIdx] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+  }, [activeIdx]);
+
+  if (filtered.length === 0) {
+    return (
+      <div
+        data-wikilink-picker
+        className="absolute z-50 w-72 rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-lg py-2 px-3"
+        style={{ top, left }}
+      >
+        <p className="text-xs text-[var(--text-tertiary)]">No matching notes</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-wikilink-picker
+      className="absolute z-50 w-72 rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-lg py-1 max-h-60 overflow-y-auto"
+      style={{ top, left }}
+    >
+      <div ref={listRef}>
+        {filtered.map((note, idx) => {
+          const projectName = note.projectId ? projectMap.get(note.projectId) : undefined;
+          return (
+            <button
+              key={note.id}
+              onMouseDown={(e) => {
+                // mousedown instead of click so editor doesn't lose focus
+                e.preventDefault();
+                onSelect(note.title);
+              }}
+              onMouseEnter={() => setActiveIdx(idx)}
+              className={cn(
+                "w-full flex items-center gap-2 px-3 py-2 text-left transition-colors",
+                idx === activeIdx
+                  ? "bg-[var(--accent-dim)] text-[var(--accent)]"
+                  : "text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+              )}
+            >
+              <FileText size={12} className="flex-shrink-0 text-[var(--text-tertiary)]" />
+              <span className="flex-1 min-w-0">
+                <span className="block text-xs font-medium truncate">{note.title}</span>
+                {projectName && (
+                  <span className="block text-[0.714rem] text-[var(--text-tertiary)] truncate">
+                    {projectName}
+                  </span>
+                )}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/notes/note-editor.tsx
+++ b/src/components/notes/note-editor.tsx
@@ -8,6 +8,8 @@ import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 import { Pin, PinOff, Calendar, Eye, Pencil, Wand2, Loader2, CheckCircle2, Tag, Plus, X, Link2, Kanban, ChevronDown, FileText } from "lucide-react";
+import { WikilinkPicker } from "./WikilinkPicker";
+import { getActiveWikilink } from "@/lib/wikilink-parser";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { cn, formatRelative } from "@/lib/utils";
@@ -30,6 +32,7 @@ import type { Plugin as RemarkPlugin } from "unified";
 import type { Root as MdastRoot, Blockquote, Paragraph, Text as MdastText } from "mdast";
 import type { InlineMath } from "mdast-util-math";
 import { visit as mdastVisit } from "unist-util-visit";
+import { WIKILINK_RE } from "@/lib/wikilink-parser";
 
 const CALLOUT_RE = /^\[!([^\]]+)\]([\+\-]?)([\s\S]*)/;
 
@@ -68,6 +71,38 @@ const remarkCallout: RemarkPlugin<[], MdastRoot> = () => (tree) => {
         "data-default-open": defaultOpen ? "true" : "false",
       },
     };
+  });
+};
+
+// ── Remark plugin: wikilinks [[Title]] → <wikilink data-title="Title"> ────────
+// Scans Text nodes for [[...]] patterns, splits them into plain text + wikilink
+// HAST nodes so ReactMarkdown can render them via the `wikilink` component.
+const remarkWikilinks: RemarkPlugin<[], MdastRoot> = () => (tree) => {
+  const re = new RegExp(WIKILINK_RE.source, "g");
+  mdastVisit(tree, "text", (node: MdastText, index, parent) => {
+    if (index == null || !parent) return;
+    const text = node.value;
+    const newNodes: MdastRoot["children"][number][] = [];
+    let lastIndex = 0;
+    let m: RegExpExecArray | null;
+    re.lastIndex = 0;
+    while ((m = re.exec(text)) !== null) {
+      const title = m[1].trim();
+      if (lastIndex < m.index) {
+        newNodes.push({ type: "text", value: text.slice(lastIndex, m.index) });
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      newNodes.push({ type: "text", value: "", data: { hName: "wikilink", hProperties: { "data-title": title } } } as any);
+      lastIndex = m.index + m[0].length;
+    }
+    if (newNodes.length === 0) return;
+    if (lastIndex < text.length) {
+      newNodes.push({ type: "text", value: text.slice(lastIndex) });
+    }
+    // Replace the current node with the split nodes
+    parent.children.splice(index, 1, ...(newNodes as MdastRoot["children"]));
+    // Return the index delta so visitor skips re-visiting replaced nodes
+    return index + newNodes.length;
   });
 };
 
@@ -317,7 +352,7 @@ interface NoteEditorProps {
 type EditorMode = "write" | "read";
 
 export function NoteEditor({ note }: NoteEditorProps) {
-  const { updateNote, aiConfig, activeProjectId, getProjectColumns, tags, createTag, getTagById, activeWorkspaceId, setView } = useCairnStore(useShallow((s) => ({
+  const { updateNote, aiConfig, activeProjectId, getProjectColumns, tags, createTag, getTagById, activeWorkspaceId, setView, notes, projects } = useCairnStore(useShallow((s) => ({
     updateNote:        s.updateNote,
     aiConfig:          s.aiConfig,
     activeProjectId:   s.activeProjectId,
@@ -327,6 +362,8 @@ export function NoteEditor({ note }: NoteEditorProps) {
     getTagById:        s.getTagById,
     activeWorkspaceId: s.activeWorkspaceId,
     setView:           s.setView,
+    notes:             s.notes,
+    projects:          s.projects,
   })));
   const aiEnabled = aiConfig.aiEnabled ?? true;
   const editorRef = useRef<MarkdownEditorHandle>(null);
@@ -353,6 +390,14 @@ export function NoteEditor({ note }: NoteEditorProps) {
 
   // MD preview panel state — selected text to render in the bottom panel
   const [previewText, setPreviewText] = useState<string | null>(null);
+
+  // ── Wikilink picker state ──────────────────────────────────────────────────
+  const [wikilinkPicker, setWikilinkPicker] = useState<{
+    query: string;
+    triggerFrom: number;
+    top: number;
+    left: number;
+  } | null>(null);
 
   // Scroll container ref — used by TableOfContents to scroll to headings
   const previewScrollRef = useRef<HTMLDivElement>(null);
@@ -391,6 +436,31 @@ export function NoteEditor({ note }: NoteEditorProps) {
   const handleContentChange = useCallback(
     (markdown: string) => {
       setWordCount(countWords(markdown));
+
+      // Detect [[ wikilink trigger
+      const view = editorRef.current?.getView();
+      if (view) {
+        const cursorPos = view.state.selection.main.head;
+        const active = getActiveWikilink(markdown, cursorPos);
+        if (active) {
+          // Position the picker near the cursor
+          const coords = view.coordsAtPos(cursorPos);
+          const containerRect = containerRef.current?.getBoundingClientRect();
+          if (coords && containerRect) {
+            setWikilinkPicker({
+              query: active.query,
+              triggerFrom: active.triggerFrom,
+              top: coords.bottom - containerRect.top + 4,
+              left: Math.min(coords.left - containerRect.left, containerRect.width - 290),
+            });
+          } else {
+            setWikilinkPicker((prev) => prev ? { ...prev, query: active.query, triggerFrom: active.triggerFrom } : null);
+          }
+        } else {
+          setWikilinkPicker(null);
+        }
+      }
+
       pendingContent.current = { noteId: note.id, markdown };
       if (saveTimer.current) clearTimeout(saveTimer.current);
       saveTimer.current = setTimeout(() => {
@@ -496,6 +566,40 @@ export function NoteEditor({ note }: NoteEditorProps) {
     },
     [aiConfig.baseUrl, aiConfig.model, aiConfig.apiKey]
   );
+
+  // Insert [[Title]] replacing the typed `[[query` trigger text
+  const handleWikilinkSelect = useCallback((title: string) => {
+    const view = editorRef.current?.getView();
+    if (!view || !wikilinkPicker) {
+      setWikilinkPicker(null);
+      return;
+    }
+    // Replace from the `[[` trigger start to the current cursor
+    const from = wikilinkPicker.triggerFrom;
+    const to = view.state.selection.main.head;
+    const insert = `[[${title}]]`;
+    view.dispatch({
+      changes: { from, to, insert },
+      selection: { anchor: from + insert.length },
+    });
+    view.focus();
+    setWikilinkPicker(null);
+  }, [wikilinkPicker]);
+
+  // Toolbar button: open picker at cursor position without a `[[` trigger
+  const openWikilinkPicker = useCallback(() => {
+    const view = editorRef.current?.getView();
+    if (!view) return;
+    const cursorPos = view.state.selection.main.head;
+    const coords = view.coordsAtPos(cursorPos);
+    const containerRect = containerRef.current?.getBoundingClientRect();
+    setWikilinkPicker({
+      query: "",
+      triggerFrom: cursorPos,
+      top: coords && containerRect ? coords.bottom - containerRect.top + 4 : 80,
+      left: coords && containerRect ? Math.min(coords.left - containerRect.left, containerRect.width - 290) : 80,
+    });
+  }, []);
 
   const handleFormat = useCallback((action: FormatAction) => {
     const view = editorRef.current?.getView();
@@ -720,8 +824,33 @@ export function NoteEditor({ note }: NoteEditorProps) {
       }
       return <section {...props}>{children}</section>;
     },
+    wikilink({ ...props }: React.HTMLAttributes<HTMLElement> & ExtraProps) {
+      const title = (props as Record<string, string>)["data-title"] ?? "";
+      const target = notes.find((n) => n.title.toLowerCase() === title.toLowerCase());
+      const resolved = target != null;
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            if (target) {
+              window.dispatchEvent(new CustomEvent("cairn:select-note", { detail: { noteId: target.id } }));
+            }
+          }}
+          title={resolved ? `Open: ${title}` : `Note not found: ${title}`}
+          className={cn(
+            "inline-flex items-center gap-0.5 px-1 py-0.5 rounded text-[0.82em] font-medium transition-colors",
+            resolved
+              ? "text-[var(--accent)] bg-[color-mix(in_srgb,var(--accent)_12%,transparent)] hover:bg-[color-mix(in_srgb,var(--accent)_20%,transparent)] cursor-pointer"
+              : "text-[var(--text-tertiary)] bg-[var(--surface-2)] cursor-default line-through"
+          )}
+        >
+          [[{title}]]
+        </button>
+      );
+    },
   // previewScrollRef is a stable React ref — no need to list it as a dep
-  }), [note.id, note.content, updateNote]) as import("react-markdown").Components;
+  // notes is needed for wikilink resolution
+  }), [note.id, note.content, updateNote, notes]) as import("react-markdown").Components;
 
   const handleToggleTag = useCallback((tagId: string) => {
     const has = note.tagIds.includes(tagId);
@@ -743,6 +872,10 @@ export function NoteEditor({ note }: NoteEditorProps) {
         const target = e.target as HTMLElement;
         if (!target.closest(".cm-editor") && !target.closest("[data-ai-toolbar]") && !target.closest("[data-md-preview-portal]")) {
           setPreviewText(null);
+        }
+        // Dismiss wikilink picker when clicking outside it
+        if (!target.closest("[data-wikilink-picker]")) {
+          setWikilinkPicker(null);
         }
       }}
     >
@@ -806,6 +939,17 @@ export function NoteEditor({ note }: NoteEditorProps) {
               </button>
             </Tooltip>
           ))}
+          {mode === "write" && (
+            <Tooltip content="Insert wikilink [[Note Title]]">
+              <button
+                onClick={openWikilinkPicker}
+                className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors"
+              >
+                <Link2 size={12} />
+                Link
+              </button>
+            </Tooltip>
+          )}
           <Tooltip content={note.isPinned ? "Unpin note" : "Pin note"}>
             <button
               onClick={() => updateNote(note.id, { isPinned: !note.isPinned })}
@@ -878,6 +1022,19 @@ export function NoteEditor({ note }: NoteEditorProps) {
           />
         </div>
 
+        {/* Wikilink autocomplete picker */}
+        {wikilinkPicker && mode === "write" && (
+          <WikilinkPicker
+            notes={notes.filter((n) => n.id !== note.id)}
+            projects={projects}
+            query={wikilinkPicker.query}
+            onSelect={handleWikilinkSelect}
+            onClose={() => setWikilinkPicker(null)}
+            top={wikilinkPicker.top}
+            left={wikilinkPicker.left}
+          />
+        )}
+
         {/* Read / preview pane */}
         {mode === "read" && (
           <div ref={previewScrollRef} className="absolute inset-0 overflow-y-auto overflow-x-hidden">
@@ -891,8 +1048,8 @@ export function NoteEditor({ note }: NoteEditorProps) {
             <div className="px-6 py-5 max-w-4xl mx-auto">
               {note.content ? (
                 <div className="prose-cairn">
-                  <ReactMarkdown
-                     remarkPlugins={[remarkGfm, remarkBreaks, remarkMath, remarkPromoteDisplayMath, remarkCallout]}
+                   <ReactMarkdown
+                     remarkPlugins={[remarkGfm, remarkBreaks, remarkMath, remarkPromoteDisplayMath, remarkCallout, remarkWikilinks]}
                      rehypePlugins={[rehypeCaptureLatex, rehypeKatex, rehypeMergedPass]}
                      urlTransform={(url) => url.startsWith("asset://") ? url : defaultUrlTransform(url)}
                      components={mdComponents}
@@ -951,7 +1108,25 @@ function BacklinksPanel({ note, onOpenCard }: BacklinksPanelProps) {
     [note.linkedCardIds, cards],
   );
 
-  const total = linkedNotes.length + linkedCards.length;
+  // Notes that wikilink to this note via [[Current Note Title]]
+  const wikilinkBacklinks = useMemo(() => {
+    const titleLower = note.title.toLowerCase();
+    const re = /\[\[([^\][\n]+?)\]\]/g;
+    return notes.filter((n) => {
+      if (n.id === note.id) return false;
+      // Already shown in linkedNotes
+      if ((note.linkedNoteIds ?? []).includes(n.id)) return false;
+      const content = n.content ?? "";
+      let m: RegExpExecArray | null;
+      re.lastIndex = 0;
+      while ((m = re.exec(content)) !== null) {
+        if (m[1].trim().toLowerCase() === titleLower) return true;
+      }
+      return false;
+    });
+  }, [note.id, note.title, note.linkedNoteIds, notes]);
+
+  const total = linkedNotes.length + linkedCards.length + wikilinkBacklinks.length;
   if (total === 0) return null;
 
   return (
@@ -991,6 +1166,24 @@ function BacklinksPanel({ note, onOpenCard }: BacklinksPanelProps) {
               </button>
             );
           })}
+          {wikilinkBacklinks.length > 0 && (
+            <>
+              {(linkedNotes.length > 0 || linkedCards.length > 0) && (
+                <div className="h-px bg-[var(--border)] my-1" />
+              )}
+              {wikilinkBacklinks.map((n) => (
+                <button
+                  key={n.id}
+                  onClick={() => window.dispatchEvent(new CustomEvent("cairn:select-note", { detail: { noteId: n.id } }))}
+                  className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-[var(--surface-2)] text-xs text-[var(--text-secondary)] transition-colors text-left"
+                >
+                  <Link2 size={11} className="text-[var(--accent)] flex-shrink-0" />
+                  <span className="truncate flex-1">{n.title}</span>
+                  <span className="text-[0.714rem] text-[var(--accent)] opacity-70">wikilink</span>
+                </button>
+              ))}
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/components/notes/note-editor.tsx
+++ b/src/components/notes/note-editor.tsx
@@ -838,13 +838,17 @@ export function NoteEditor({ note }: NoteEditorProps) {
           }}
           title={resolved ? `Open: ${title}` : `Note not found: ${title}`}
           className={cn(
-            "inline-flex items-center gap-0.5 px-1 py-0.5 rounded text-[0.82em] font-medium transition-colors",
+            "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[0.82em] font-medium transition-colors align-baseline",
             resolved
-              ? "text-[var(--accent)] bg-[color-mix(in_srgb,var(--accent)_12%,transparent)] hover:bg-[color-mix(in_srgb,var(--accent)_20%,transparent)] cursor-pointer"
-              : "text-[var(--text-tertiary)] bg-[var(--surface-2)] cursor-default line-through"
+              ? "text-[var(--accent)] bg-[color-mix(in_srgb,var(--accent)_10%,transparent)] hover:bg-[color-mix(in_srgb,var(--accent)_18%,transparent)] cursor-pointer"
+              : "text-[var(--text-tertiary)] bg-[var(--surface-2)] cursor-default opacity-60"
           )}
         >
-          [[{title}]]
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="shrink-0" aria-hidden="true">
+            <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+            <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+          </svg>
+          {resolved ? title : `${title} ↗`}
         </button>
       );
     },
@@ -1043,6 +1047,7 @@ export function NoteEditor({ note }: NoteEditorProps) {
               <TableOfContents
                 markdown={note.content}
                 scrollContainerRef={previewScrollRef}
+                notes={notes}
               />
             )}
             <div className="px-6 py-5 max-w-4xl mx-auto">

--- a/src/components/notes/toc-utils.ts
+++ b/src/components/notes/toc-utils.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure utility functions for TableOfContents — extracted so they can be
+ * unit-tested in a Node/vitest environment without pulling in React or
+ * CSS-in-JS imports.
+ */
+
+import { parseWikilinks } from "../../lib/wikilink-parser";
+
+// ── Slug ──────────────────────────────────────────────────────────────────────
+
+/**
+ * GitHub-style heading slug: lowercase, spaces → hyphens, strip everything
+ * except alphanumerics and hyphens.
+ */
+export function headingSlug(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^\w-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// ── Heading extraction ────────────────────────────────────────────────────────
+
+export interface Heading {
+  level: 1 | 2 | 3;
+  text: string;
+  id: string;
+}
+
+/** Parse h1/h2/h3 headings from raw markdown source. */
+export function extractHeadings(markdown: string): Heading[] {
+  const headings: Heading[] = [];
+  let inFence = false;
+  for (const line of markdown.split("\n")) {
+    if (line.startsWith("```")) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    const m = line.match(/^(#{1,3})\s+(.+)/);
+    if (m) {
+      const level = m[1].length as 1 | 2 | 3;
+      const text = m[2].trim();
+      headings.push({ level, text, id: headingSlug(text) });
+    }
+  }
+  return headings;
+}
+
+// ── Wikilink extraction ───────────────────────────────────────────────────────
+
+export interface WikiLink {
+  title: string;
+  noteId: string | null;
+}
+
+/** Extract unique wikilinks from raw markdown, deduplicated by title. */
+export function extractWikiLinks(
+  markdown: string,
+  notes: { id: string; title: string }[]
+): WikiLink[] {
+  const titleIndex = new Map(notes.map((n) => [n.title.toLowerCase().trim(), n.id]));
+  const seen = new Set<string>();
+  const links: WikiLink[] = [];
+  for (const { title } of parseWikilinks(markdown)) {
+    const key = title.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    links.push({ title, noteId: titleIndex.get(key) ?? null });
+  }
+  return links;
+}

--- a/src/lib/wikilink-parser.test.ts
+++ b/src/lib/wikilink-parser.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Unit tests for src/lib/wikilink-parser.ts and
+ * src/components/notes/TableOfContents.tsx (extractWikiLinks helper)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseWikilinks,
+  resolveWikilinks,
+  segmentContent,
+  getActiveWikilink,
+} from "./wikilink-parser";
+import {
+  extractWikiLinks,
+  extractHeadings,
+  headingSlug,
+} from "../components/notes/toc-utils.js";
+
+// ── parseWikilinks ─────────────────────────────────────────────────────────────
+
+describe("parseWikilinks", () => {
+  it("returns empty array for content with no wikilinks", () => {
+    expect(parseWikilinks("No links here.")).toEqual([]);
+  });
+
+  it("parses a single wikilink", () => {
+    const result = parseWikilinks("See [[My Note]] for details.");
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("My Note");
+    expect(result[0].raw).toBe("[[My Note]]");
+    expect(result[0].index).toBe(4);
+    expect(result[0].end).toBe(15);
+  });
+
+  it("parses multiple wikilinks in order", () => {
+    const result = parseWikilinks("[[Alpha]] and [[Beta]] and [[Gamma]]");
+    expect(result.map((r) => r.title)).toEqual(["Alpha", "Beta", "Gamma"]);
+  });
+
+  it("trims whitespace inside brackets", () => {
+    const result = parseWikilinks("[[  Spaced Title  ]]");
+    expect(result[0].title).toBe("Spaced Title");
+  });
+
+  it("skips empty wikilinks [[]]", () => {
+    expect(parseWikilinks("[[]]")).toEqual([]);
+  });
+
+  it("skips wikilinks with only whitespace", () => {
+    expect(parseWikilinks("[[   ]]")).toEqual([]);
+  });
+
+  it("does not match across newlines", () => {
+    expect(parseWikilinks("[[\nfoo\n]]")).toEqual([]);
+  });
+
+  it("handles wikilinks at start and end of string", () => {
+    const result = parseWikilinks("[[Start]] middle [[End]]");
+    expect(result[0].title).toBe("Start");
+    expect(result[1].title).toBe("End");
+  });
+
+  it("correctly records index and end positions", () => {
+    const content = "abc[[Note]]xyz";
+    const [m] = parseWikilinks(content);
+    expect(content.slice(m.index, m.end)).toBe("[[Note]]");
+  });
+});
+
+// ── resolveWikilinks ───────────────────────────────────────────────────────────
+
+describe("resolveWikilinks", () => {
+  const notes = [
+    { id: "n1", title: "Alpha" },
+    { id: "n2", title: "Beta Note" },
+    { id: "n3", title: "Gamma" },
+  ];
+
+  it("resolves an exact-match wikilink", () => {
+    const result = resolveWikilinks("See [[Alpha]].", notes);
+    expect(result[0].noteId).toBe("n1");
+  });
+
+  it("resolves case-insensitively", () => {
+    const result = resolveWikilinks("[[ALPHA]] and [[beta note]]", notes);
+    expect(result[0].noteId).toBe("n1");
+    expect(result[1].noteId).toBe("n2");
+  });
+
+  it("returns null noteId for unresolved links", () => {
+    const result = resolveWikilinks("[[Unknown Note]]", notes);
+    expect(result[0].noteId).toBeNull();
+  });
+
+  it("first note wins when titles collide", () => {
+    const dupes = [
+      { id: "first", title: "Dupe" },
+      { id: "second", title: "dupe" },
+    ];
+    const result = resolveWikilinks("[[Dupe]]", dupes);
+    expect(result[0].noteId).toBe("first");
+  });
+
+  it("returns empty array for content with no wikilinks", () => {
+    expect(resolveWikilinks("plain text", notes)).toEqual([]);
+  });
+});
+
+// ── segmentContent ─────────────────────────────────────────────────────────────
+
+describe("segmentContent", () => {
+  const notes = [{ id: "n1", title: "World" }];
+
+  it("returns a single text segment when no wikilinks present", () => {
+    const segs = segmentContent("Hello plain text", notes);
+    expect(segs).toEqual([{ type: "text", text: "Hello plain text" }]);
+  });
+
+  it("segments text around a single wikilink", () => {
+    const segs = segmentContent("Hello [[World]] foo", notes);
+    expect(segs).toEqual([
+      { type: "text", text: "Hello " },
+      { type: "wikilink", text: "World", noteId: "n1" },
+      { type: "text", text: " foo" },
+    ]);
+  });
+
+  it("handles wikilink at the start", () => {
+    const segs = segmentContent("[[World]] bar", notes);
+    expect(segs[0]).toEqual({ type: "wikilink", text: "World", noteId: "n1" });
+    expect(segs[1]).toEqual({ type: "text", text: " bar" });
+  });
+
+  it("handles wikilink at the end", () => {
+    const segs = segmentContent("foo [[World]]", notes);
+    expect(segs[0]).toEqual({ type: "text", text: "foo " });
+    expect(segs[1]).toEqual({ type: "wikilink", text: "World", noteId: "n1" });
+  });
+
+  it("handles adjacent wikilinks", () => {
+    const segs = segmentContent("[[World]][[World]]", notes);
+    expect(segs).toHaveLength(2);
+    expect(segs[0].type).toBe("wikilink");
+    expect(segs[1].type).toBe("wikilink");
+  });
+
+  it("sets noteId to null for unresolved links", () => {
+    const segs = segmentContent("[[Unknown]]", notes);
+    expect(segs[0]).toEqual({ type: "wikilink", text: "Unknown", noteId: null });
+  });
+});
+
+// ── getActiveWikilink ──────────────────────────────────────────────────────────
+
+describe("getActiveWikilink", () => {
+  it("returns null when no [[ before cursor", () => {
+    expect(getActiveWikilink("hello world", 11)).toBeNull();
+  });
+
+  it("detects an open wikilink at cursor", () => {
+    const content = "Go [[My N";
+    const result = getActiveWikilink(content, content.length);
+    expect(result).not.toBeNull();
+    expect(result!.query).toBe("My N");
+    expect(result!.triggerFrom).toBe(3);
+  });
+
+  it("returns null when [[ is already closed before cursor", () => {
+    const content = "[[Done]] more text";
+    expect(getActiveWikilink(content, content.length)).toBeNull();
+  });
+
+  it("returns null when newline between [[ and cursor", () => {
+    const content = "[[foo\nbar";
+    expect(getActiveWikilink(content, content.length)).toBeNull();
+  });
+
+  it("returns empty query when cursor is immediately after [[", () => {
+    const content = "[[";
+    const result = getActiveWikilink(content, 2);
+    expect(result).not.toBeNull();
+    expect(result!.query).toBe("");
+    expect(result!.triggerFrom).toBe(0);
+  });
+
+  it("uses the latest [[ if multiple are present", () => {
+    const content = "[[done]] text [[partial";
+    const result = getActiveWikilink(content, content.length);
+    expect(result).not.toBeNull();
+    expect(result!.query).toBe("partial");
+    expect(result!.triggerFrom).toBe(14);
+  });
+});
+
+// ── TableOfContents helpers ────────────────────────────────────────────────────
+
+describe("headingSlug", () => {
+  it("lowercases and replaces spaces with hyphens", () => {
+    expect(headingSlug("Hello World")).toBe("hello-world");
+  });
+
+  it("strips non-alphanumeric characters", () => {
+    expect(headingSlug("C++ & Rust!")).toBe("c-rust");
+  });
+
+  it("collapses multiple hyphens", () => {
+    expect(headingSlug("foo -- bar")).toBe("foo-bar");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(headingSlug("!Hello!")).toBe("hello");
+  });
+});
+
+describe("extractHeadings", () => {
+  it("extracts h1 / h2 / h3 headings", () => {
+    const md = "# Title\n## Section\n### Subsection\nsome text";
+    const headings = extractHeadings(md);
+    expect(headings).toEqual([
+      { level: 1, text: "Title", id: "title" },
+      { level: 2, text: "Section", id: "section" },
+      { level: 3, text: "Subsection", id: "subsection" },
+    ]);
+  });
+
+  it("ignores headings inside code fences", () => {
+    const md = "```\n# not a heading\n```\n## Real";
+    const headings = extractHeadings(md);
+    expect(headings).toHaveLength(1);
+    expect(headings[0].text).toBe("Real");
+  });
+
+  it("returns empty array for content with no headings", () => {
+    expect(extractHeadings("just prose")).toEqual([]);
+  });
+
+  it("ignores h4+ headings", () => {
+    const md = "#### Deep\n## Shallow";
+    const headings = extractHeadings(md);
+    expect(headings).toHaveLength(1);
+    expect(headings[0].text).toBe("Shallow");
+  });
+});
+
+describe("extractWikiLinks", () => {
+  const notes = [
+    { id: "n1", title: "Alpha" },
+    { id: "n2", title: "Beta" },
+  ];
+
+  it("returns empty array for content with no wikilinks", () => {
+    expect(extractWikiLinks("no links", notes)).toEqual([]);
+  });
+
+  it("extracts and resolves wikilinks", () => {
+    const result = extractWikiLinks("See [[Alpha]] and [[Beta]].", notes);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ title: "Alpha", noteId: "n1" });
+    expect(result[1]).toEqual({ title: "Beta", noteId: "n2" });
+  });
+
+  it("deduplicates repeated wikilinks by title", () => {
+    const result = extractWikiLinks("[[Alpha]] [[Alpha]] [[alpha]]", notes);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Alpha");
+  });
+
+  it("sets noteId to null for unresolved links", () => {
+    const result = extractWikiLinks("[[Unknown]]", notes);
+    expect(result[0]).toEqual({ title: "Unknown", noteId: null });
+  });
+
+  it("works with an empty notes array", () => {
+    const result = extractWikiLinks("[[Alpha]]", []);
+    expect(result[0].noteId).toBeNull();
+  });
+});

--- a/src/lib/wikilink-parser.ts
+++ b/src/lib/wikilink-parser.ts
@@ -1,0 +1,143 @@
+/**
+ * Wikilink parser — `[[Note Title]]` syntax helpers
+ *
+ * Used by:
+ *  - The note editor autocomplete (detects `[[` trigger)
+ *  - The note renderer (renders wikilinks as clickable spans)
+ *  - The graph engine (electron/db/graph-queries.ts has its own inline copy
+ *    for the Node/Electron ABI boundary — keep in sync with WIKILINK_RE)
+ */
+
+/** Matches `[[Title]]` — capture group 1 is the title (trimmed) */
+export const WIKILINK_RE = /\[\[([^\][\n]+?)\]\]/g;
+
+export interface WikilinkMatch {
+  /** Full raw match including brackets, e.g. `[[My Note]]` */
+  raw: string;
+  /** Inner title text, trimmed */
+  title: string;
+  /** Start index (character offset in the source string) */
+  index: number;
+  /** End index (exclusive) */
+  end: number;
+}
+
+/**
+ * Extract all `[[Title]]` wikilinks from a markdown string.
+ * Returns matches in source order.
+ */
+export function parseWikilinks(content: string): WikilinkMatch[] {
+  const results: WikilinkMatch[] = [];
+  const re = new RegExp(WIKILINK_RE.source, "g");
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    const title = m[1].trim();
+    if (title.length === 0) continue;
+    results.push({
+      raw: m[0],
+      title,
+      index: m.index,
+      end: m.index + m[0].length,
+    });
+  }
+  return results;
+}
+
+export interface ResolvedWikilink extends WikilinkMatch {
+  /** Resolved note ID, or null if no note with this title exists */
+  noteId: string | null;
+}
+
+/**
+ * Resolve wikilink titles to note IDs.
+ *
+ * Matching is exact, case-insensitive. If multiple notes share the same
+ * title the first one wins (insertion order of the `notes` array).
+ */
+export function resolveWikilinks(
+  content: string,
+  notes: { id: string; title: string }[]
+): ResolvedWikilink[] {
+  // Build a lowercase-title → id lookup (first match wins)
+  const titleIndex = new Map<string, string>();
+  for (const n of notes) {
+    const key = n.title.toLowerCase().trim();
+    if (!titleIndex.has(key)) titleIndex.set(key, n.id);
+  }
+
+  return parseWikilinks(content).map((wl) => ({
+    ...wl,
+    noteId: titleIndex.get(wl.title.toLowerCase()) ?? null,
+  }));
+}
+
+/**
+ * Split `content` into an array of plain-text and wikilink segments,
+ * useful for rendering wikilinks inline without a full markdown parser.
+ *
+ * Example output for `"Hello [[World]] foo"`:
+ * ```
+ * [
+ *   { type: "text",     text: "Hello " },
+ *   { type: "wikilink", text: "World", noteId: "abc123" | null },
+ *   { type: "text",     text: " foo" },
+ * ]
+ * ```
+ */
+export type ContentSegment =
+  | { type: "text"; text: string }
+  | { type: "wikilink"; text: string; noteId: string | null };
+
+export function segmentContent(
+  content: string,
+  notes: { id: string; title: string }[]
+): ContentSegment[] {
+  const resolved = resolveWikilinks(content, notes);
+  if (resolved.length === 0) return [{ type: "text", text: content }];
+
+  const segments: ContentSegment[] = [];
+  let cursor = 0;
+
+  for (const wl of resolved) {
+    if (wl.index > cursor) {
+      segments.push({ type: "text", text: content.slice(cursor, wl.index) });
+    }
+    segments.push({ type: "wikilink", text: wl.title, noteId: wl.noteId });
+    cursor = wl.end;
+  }
+
+  if (cursor < content.length) {
+    segments.push({ type: "text", text: content.slice(cursor) });
+  }
+
+  return segments;
+}
+
+/**
+ * Returns the partial wikilink being typed at the cursor position, or null.
+ *
+ * Detects `[[` followed by any text up to the cursor without a closing `]]`.
+ * Used by the editor autocomplete to know when to show the picker.
+ */
+export interface ActiveWikilink {
+  /** The text typed so far after `[[`, e.g. `"My N"` */
+  query: string;
+  /** Character offset in the document where `[[` starts */
+  triggerFrom: number;
+}
+
+export function getActiveWikilink(
+  content: string,
+  cursorPos: number
+): ActiveWikilink | null {
+  // Look backwards from cursor for `[[` without an intervening `]]` or newline
+  const before = content.slice(0, cursorPos);
+  const lastOpen = before.lastIndexOf("[[");
+  if (lastOpen === -1) return null;
+
+  const between = before.slice(lastOpen + 2);
+  // If there's a closing `]]` or a newline between `[[` and cursor → not active
+  if (between.includes("]]") || between.includes("\n")) return null;
+
+  return { query: between, triggerFrom: lastOpen };
+}

--- a/src/store/slices/graph.ts
+++ b/src/store/slices/graph.ts
@@ -41,7 +41,7 @@ export const DEFAULT_GRAPH_FILTERS: GraphFilters = {
   nodeTypes: ["project", "note", "card", "tag"],
   edgeTypes: [
     "note-note", "note-card", "tag-member", "project-member",
-    "flow-ref", "flow-edge", "co-mention", "keyword", "assignee",
+    "flow-ref", "flow-edge", "co-mention", "keyword", "assignee", "wikilink",
   ],
   includeAuto: true,
 };
@@ -151,5 +151,6 @@ export function edgeTypeLabel(type: GraphEdgeType): string {
     case "co-mention":     return "Co-mention";
     case "keyword":        return "Keyword";
     case "assignee":       return "Assignee";
+    case "wikilink":       return "Wikilink";
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -242,7 +242,8 @@ export type GraphNodeType = "project" | "note" | "card" | "tag";
 
 export type GraphEdgeType =
   | "note-note" | "note-card" | "tag-member" | "project-member"
-  | "flow-ref" | "flow-edge" | "co-mention" | "keyword" | "assignee";
+  | "flow-ref" | "flow-edge" | "co-mention" | "keyword" | "assignee"
+  | "wikilink";
 
 export interface GraphNode {
   id: ID;


### PR DESCRIPTION
## What does this PR do?

Adds Obsidian-style `[[Note Title]]` wikilinks throughout the note editor, surfaces wikilink edges in the Knowledge Graph, and introduces an AI Graph Assistant that analyses the graph and suggests missing connections with one-click apply actions.

## Type of change

- [x] New feature

## Screenshots / recording

<img width="873" height="424" alt="image" src="https://github.com/user-attachments/assets/025754e7-90a0-43b6-a874-bb600529d3ec" />

<img width="217" height="579" alt="image" src="https://github.com/user-attachments/assets/42f43b2e-a230-48e9-893c-5e8df8e7d3d6" />

<img width="1065" height="357" alt="image" src="https://github.com/user-attachments/assets/092bea78-64d2-4440-9b27-670dd886bb6d" />

## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes (425 tests across 9 files)
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] No new DB migrations (schema unchanged)
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

- `suggest_connections` is a `CHAT_ONLY_TOOLS` entry — it must never appear in the MCP tool list. The no-op handler in `chat-executor.ts` is intentional; the renderer intercepts it via `onToolCall` before the executor sees it.
- `mcp-server.ts` has a locally inlined `NoteFileData` interface (ABI isolation). The `folder?: string` change was mirrored manually — keep in sync with `electron/notes-files.ts`.
- `cairn:select-note` custom event (fired by TOC links and wikilink chips) is expected to be handled by a listener in `note-editor.tsx` / the notes view — confirm this wiring is present before merging.
- The `toc-utils.ts` extraction is a pure refactor of logic that was already in `TableOfContents.tsx`; `TableOfContents` re-exports everything so no import sites outside the component tree are affected.