### PR TITLE
v1.1.1 Fixes - Wikilinks, Note Discovery

### DIFF
--- a/changelogs/v1.1.1.md
+++ b/changelogs/v1.1.1.md
@@ -1,0 +1,68 @@
+# v1.1.1
+
+## Bug fixes
+
+### Fixed: "Reveal in Finder" label incorrect on Windows and Linux
+
+The context menu item in the Notes sidebar always said "Reveal in Finder" regardless of platform. It now reads "Reveal in Explorer" on Windows and "Reveal in Files" on Linux. The underlying `shell.showItemInFolder()` call was already cross-platform correct — only the label was wrong.
+
+### Fixed: Plain `.md` files dropped into a project folder not appearing in Notes
+
+The file watcher (`file-watcher.ts`) silently ignored any `.md` file that lacked Cairn YAML frontmatter (`id` and `projectId` fields). This meant files added externally — from a file manager, `git pull`, or another editor — would never show up in the Notes view.
+
+The watcher now calls a new `adoptExternalNoteFile()` helper when `parseNoteFile` returns `null`. The helper resolves the target project by matching the first path segment under `notes/` against the slugged names of all projects in the database, generates a new note ID, derives the title from the filename, and writes Cairn frontmatter back to the file before upserting it into SQLite. Both `add` and `change` events trigger adoption so files that have their frontmatter stripped by an external editor are also recovered.
+
+Files outside any known project folder are silently ignored — there is no project to assign them to.
+
+### Fixed: Wikilink `[[` picker spawning off-screen
+
+The autocomplete picker that appears when typing `[[` or clicking the Wikilink toolbar button was positioned using container-relative coordinates subtracted from `coordsAtPos`. Because the editor pane is scrollable, the cursor's visual position did not match the computed CSS `top`, causing the picker to appear far below or off the bottom of the screen.
+
+The picker is now rendered into a **portal on `document.body`** with `position: fixed` and viewport-relative coordinates sourced directly from CodeMirror's `coordsAtPos`. Flip logic opens the picker above the cursor when there is insufficient space below (`spaceBelow < 240px && spaceAbove > spaceBelow`). The horizontal position is clamped to `[8px, viewport width − picker width − 8px]` so it never overflows either edge.
+
+---
+
+## New feature: Export note as PDF
+
+Notes can now be exported as PDF from the read-mode toolbar.
+
+- A **PDF** button appears in the note header when in read mode (next to Write/Read toggle). Shows a spinner while exporting and a checkmark on completion.
+- Captures the fully-rendered `prose-cairn` HTML — wikilink chips, callouts, tables, code blocks, and math are all included exactly as they appear in read mode.
+- Main process opens a hidden `BrowserWindow`, loads the HTML as a `data:` URL with inlined light-theme CSS, calls `webContents.printToPDF()`, and saves via a native Save dialog.
+- Code blocks are rewritten to a light palette before export (the `CodeBlock` component computes dark/light colours at render time from the active app theme; these are post-processed in the renderer before the HTML is sent to the main process).
+- `@page { size: A4; margin: 2cm 2.2cm }` ensures correct margins. Long lines in code blocks use `white-space: pre-wrap; word-break: break-all` so content wraps rather than clips. Tables use `table-layout: fixed`. Page-break hints prevent headings and code blocks from splitting awkwardly across pages.
+- Only shown when running in Electron (`window.electron?.exportNotePdf` guard).
+
+---
+
+## Changes
+
+### Wikilink button moved to formatting toolbar
+
+The **Link** button previously in the main note header toolbar has been removed. The wikilink action now lives in the **Insert** group of the `AITextToolbar` formatting bar (alongside Code block and Divider), labelled "Wikilink `[[Note]]`". This keeps the header toolbar uncluttered and puts the action next to other insertion tools.
+
+---
+
+## New files
+
+| File | Purpose |
+|------|---------|
+| `src/components/graph/graph-ai-utils.ts` | Pure helpers extracted from `GraphAIPanel` for testability: `wikilinkAlreadyExists`, `buildGraphContext` |
+| `src/components/graph/GraphAIPanel.test.ts` | 16 unit tests for `wikilinkAlreadyExists` and `buildGraphContext` |
+| `src/components/notes/toc-utils.ts` | Pure TOC helpers extracted from `TableOfContents.tsx`: `headingSlug`, `extractHeadings`, `extractWikiLinks` |
+| `src/lib/wikilink-parser.test.ts` | 39 unit tests for `parseWikilinks`, `resolveWikilinks`, `segmentContent`, `getActiveWikilink`, `extractHeadings`, `headingSlug`, `extractWikiLinks` |
+
+## Changed files
+
+| File | Change |
+|------|--------|
+| `src/components/notes/notes-view.tsx` | Platform-aware "Reveal in …" label |
+| `electron/notes-files.ts` | New `adoptExternalNoteFile()` helper |
+| `electron/file-watcher.ts` | `handleFileAdd` / `handleFileChange` fall through to `adoptExternalNoteFile` on parse failure |
+| `electron/ipc/handlers.ts` | New `app:exportNotePdf` IPC handler |
+| `electron/preload.ts` | Exposed `exportNotePdf` on `window.electron` |
+| `src/components/notes/note-editor.tsx` | PDF export button and handler; wikilink picker state uses viewport-relative `anchorRect`; `Link` toolbar button removed |
+| `src/components/notes/WikilinkPicker.tsx` | Portal + fixed positioning; flip above/below logic; horizontal clamping |
+| `src/components/notes/ai-text-toolbar.tsx` | Added `"wikilink"` to `FormatAction` and Insert group |
+| `src/components/graph/GraphAIPanel.tsx` | Imports pure helpers from `graph-ai-utils.ts` |
+| `src/components/notes/TableOfContents.tsx` | Re-exports from `toc-utils.ts` |

--- a/electron/file-watcher.ts
+++ b/electron/file-watcher.ts
@@ -17,7 +17,7 @@
 
 import chokidar, { type FSWatcher } from "chokidar";
 import type Database from "better-sqlite3";
-import { notesDir, parseNoteFile, upsertNoteFromFile } from "./notes-files";
+import { notesDir, parseNoteFile, upsertNoteFromFile, adoptExternalNoteFile } from "./notes-files";
 import * as q from "./db/queries";
 
 let watcher: FSWatcher | null = null;
@@ -69,8 +69,8 @@ export function startFileWatcher(
   });
 
   watcher
-    .on("add",    (fp) => handleFileAdd(fp, db, onChanged))
-    .on("change", (fp) => handleFileChange(fp, db, onChanged))
+    .on("add",    (fp) => handleFileAdd(fp, workspacePath, db, onChanged))
+    .on("change", (fp) => handleFileChange(fp, workspacePath, db, onChanged))
     .on("unlink", (fp) => handleFileDelete(fp, db, onChanged));
 }
 
@@ -84,9 +84,11 @@ export function stopFileWatcher(): void {
 
 // ── Event handlers ────────────────────────────
 
-function handleFileAdd(filePath: string, db: Database.Database, onChanged: () => void): void {
+function handleFileAdd(filePath: string, workspacePath: string, db: Database.Database, onChanged: () => void): void {
   if (!filePath.endsWith(".md")) return;
-  const note = parseNoteFile(filePath);
+  let note = parseNoteFile(filePath);
+  // Plain .md file with no Cairn frontmatter — try to adopt it
+  if (!note) note = adoptExternalNoteFile(db, workspacePath, filePath);
   if (!note) return;
   pathToNoteId.set(filePath, note.id);
   if (suppressedNoteIds.has(note.id)) return;
@@ -94,9 +96,11 @@ function handleFileAdd(filePath: string, db: Database.Database, onChanged: () =>
   onChanged();
 }
 
-function handleFileChange(filePath: string, db: Database.Database, onChanged: () => void): void {
+function handleFileChange(filePath: string, workspacePath: string, db: Database.Database, onChanged: () => void): void {
   if (!filePath.endsWith(".md")) return;
-  const note = parseNoteFile(filePath);
+  let note = parseNoteFile(filePath);
+  // Plain .md file — try to adopt (e.g. frontmatter was stripped by external editor)
+  if (!note) note = adoptExternalNoteFile(db, workspacePath, filePath);
   if (!note) return;
   pathToNoteId.set(filePath, note.id);
   if (suppressedNoteIds.has(note.id)) return;

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -629,6 +629,107 @@ export function registerAppHandlers(
     updateTrayBadge(0);
   }));
 
+  // ── Export note as PDF ─────────────────────────────
+  ipcMain.handle("app:exportNotePdf", (_e, { title, html }: { title: string; html: string }) =>
+    handle(async () => {
+      if (!win || win.isDestroyed()) throw new Error("No window");
+
+      const { canceled, filePath: savePath } = await dialog.showSaveDialog(win, {
+        title: "Export Note as PDF",
+        defaultPath: `${title}.pdf`,
+        filters: [{ name: "PDF Document", extensions: ["pdf"] }],
+      });
+      if (canceled || !savePath) return null;
+
+      // Wrap the rendered HTML in a self-contained document with light-theme
+      // prose-cairn styles inlined so the PDF is readable regardless of app theme.
+      const fullHtml = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>${title.replace(/</g, "&lt;")}</title>
+<style>
+*, *::before, *::after { box-sizing: border-box; }
+:root {
+  --text-primary: #1a1917;
+  --text-secondary: #4a4744;
+  --surface-2: #f0eeeb;
+  --border: #dddad6;
+  --accent: #6457e8;
+}
+@page {
+  size: A4;
+  margin: 2cm 2.2cm;
+}
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #ffffff;
+  color: #1a1917;
+  /* Ensure nothing overflows the page width */
+  max-width: 100%;
+  overflow-x: hidden;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+.prose-cairn { color: var(--text-primary); font-size: 0.875rem; line-height: 1.7; }
+.prose-cairn h1 { font-size: 1.5rem; font-weight: 700; margin: 1.25rem 0 0.5rem; color: var(--text-primary); }
+.prose-cairn h2 { font-size: 1.2rem; font-weight: 600; margin: 1rem 0 0.4rem; color: var(--text-primary); }
+.prose-cairn h3 { font-size: 1rem; font-weight: 600; margin: 0.75rem 0 0.3rem; color: var(--text-primary); }
+.prose-cairn p { margin: 0.5rem 0; word-wrap: break-word; overflow-wrap: break-word; }
+.prose-cairn strong { font-weight: 600; }
+.prose-cairn em { font-style: italic; }
+.prose-cairn code { font-family: ui-monospace, monospace; font-size: 0.8em; background: var(--surface-2); border: 1px solid var(--border); border-radius: 3px; padding: 0.1em 0.35em; word-break: break-all; }
+/* Code blocks: overflow wraps rather than clips */
+.prose-cairn pre { margin: 0.75rem 0; padding: 0.75rem 1rem; background: var(--surface-2) !important; color: #374151 !important; border: 1px solid var(--border); border-radius: 6px; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; word-break: break-all; max-width: 100%; }
+.prose-cairn pre code { background: none !important; border: none; padding: 0; font-size: 0.8rem; white-space: pre-wrap; word-break: break-all; }
+.prose-cairn ul { list-style: disc; padding-left: 1.5rem; margin: 0.5rem 0; }
+.prose-cairn ol { list-style: decimal; padding-left: 1.5rem; margin: 0.5rem 0; }
+.prose-cairn li { margin: 0.2rem 0; }
+.prose-cairn blockquote { border-left: 3px solid var(--accent); margin: 0.75rem 0; padding: 0.25rem 0 0.25rem 1rem; color: var(--text-secondary); }
+.prose-cairn hr { border: none; border-top: 1px solid var(--border); margin: 1rem 0; }
+.prose-cairn a { color: var(--accent); text-decoration: underline; word-break: break-all; }
+.prose-cairn table { width: 100%; border-collapse: collapse; font-size: 0.8rem; margin: 0.75rem 0; table-layout: fixed; word-wrap: break-word; }
+.prose-cairn th { background: var(--surface-2); font-weight: 600; text-align: left; padding: 0.4rem 0.6rem; border: 1px solid var(--border); word-wrap: break-word; }
+.prose-cairn td { padding: 0.35rem 0.6rem; border: 1px solid var(--border); word-wrap: break-word; }
+.prose-cairn tr:nth-child(even) td { background: var(--surface-2); }
+/* Wikilink chips */
+.wikilink-chip { display: inline-flex; align-items: center; gap: 3px; color: var(--accent); font-size: 0.85em; }
+/* Callout blocks */
+.callout { border-left: 3px solid var(--accent); background: var(--surface-2); padding: 0.5rem 0.75rem; margin: 0.75rem 0; border-radius: 0 4px 4px 0; }
+/* Page break hints */
+h1, h2, h3 { page-break-after: avoid; }
+pre, blockquote, table { page-break-inside: avoid; }
+</style>
+</head>
+<body>
+<div class="prose-cairn">${html}</div>
+</body>
+</html>`;
+
+      // Open a hidden window, load the HTML, print to PDF, then close
+      const printWin = new BrowserWindow({
+        show: false,
+        webPreferences: { nodeIntegration: false, contextIsolation: true },
+      });
+
+      await printWin.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(fullHtml)}`);
+
+      const pdfBuffer = await printWin.webContents.printToPDF({
+        printBackground: true,
+        pageSize: "A4",
+        // Margins are defined via @page in the HTML — use "default" so the
+        // CSS @page rule is respected rather than being overridden here.
+        margins: { marginType: "default" },
+      });
+
+      printWin.destroy();
+
+      fs.writeFileSync(savePath, pdfBuffer);
+      return { filePath: savePath };
+    })
+  );
+
   // ── URL metadata fetch (OG tags + <title>) ─────────
   // Runs in the main process so there are no CORS restrictions.
   ipcMain.handle("db:flow:url:fetch", (_e, { url }: { url: string }) =>

--- a/electron/notes-files.ts
+++ b/electron/notes-files.ts
@@ -29,6 +29,7 @@ import fs from "fs";
 import matter from "gray-matter";
 import type Database from "better-sqlite3";
 import * as q from "./db/queries";
+import { generateId } from "./db/queries";
 import { toSlug, stripMarkdown } from "./shared/text-utils";
 
 export { toSlug, stripMarkdown };
@@ -268,6 +269,78 @@ function syncDir(db: Database.Database, dir: string): void {
 // Uses INSERT OR IGNORE + UPDATE to avoid UNIQUE constraint errors when the
 // file watcher fires on a file that was just written by the app itself.
 // The SELECT+INSERT pattern had a race window; this is fully atomic.
+
+/**
+ * Attempt to adopt a plain .md file that was dropped into a project folder
+ * from outside the app (no Cairn frontmatter).
+ *
+ * Resolves the project by matching the first path segment under `notes/` to a
+ * project slug in the database. If a matching project is found, generates a new
+ * note ID, writes Cairn frontmatter back to the file, then upserts into SQLite.
+ *
+ * Returns the adopted NoteData on success, or null if the file can't be adopted
+ * (e.g. not inside a known project folder, or the file is unreadable).
+ */
+export function adoptExternalNoteFile(
+  db: Database.Database,
+  workspacePath: string,
+  filePath: string,
+): NoteData | null {
+  try {
+    const root = notesDir(workspacePath);
+    const rel  = path.relative(root, filePath); // e.g. "my-project/sub/Note Title.md"
+    const segments = rel.split(path.sep);
+    if (segments.length < 1) return null;
+
+    const projectSlug = segments[0];
+
+    // Find the project whose slug matches the folder name
+    const projects = db.prepare(
+      "SELECT id, name, workspace_id FROM projects WHERE archived_at IS NULL"
+    ).all() as { id: string; name: string; workspace_id: string }[];
+
+    const project = projects.find((p) => toSlug(p.name) === projectSlug);
+    if (!project) return null;
+
+    // Read file content
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const { content } = matter(raw);
+
+    // Derive title from filename (strip .md extension)
+    const filename = segments[segments.length - 1];
+    const title = path.basename(filename, ".md");
+
+    // Derive subfolder from intermediate path segments (un-slugged as-is)
+    const folderSegments = segments.slice(1, -1);
+    const folder = folderSegments.join("/");
+
+    const now  = new Date().toISOString();
+    const id   = generateId();
+
+    const note: NoteData = {
+      id,
+      projectId:     project.id,
+      workspaceId:   project.workspace_id,
+      title,
+      content,
+      tagIds:        [],
+      linkedNoteIds: [],
+      linkedCardIds: [],
+      isPinned:      false,
+      folder,
+      createdAt:     now,
+      updatedAt:     now,
+      projectName:   project.name,
+    };
+
+    // Write Cairn frontmatter back to the file so future reads recognise it
+    writeNoteFile(workspacePath, note);
+
+    return note;
+  } catch {
+    return null;
+  }
+}
 
 export function upsertNoteFromFile(db: Database.Database, note: NoteData): void {
   // Only upsert if the referenced project exists

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -145,6 +145,10 @@ const api = {
   // ── Reveal note in Finder / Explorer ─────────
   revealNote: (noteId: string, projectId: string) => invoke("app:revealNote", { noteId, projectId }),
 
+  // ── Export note as PDF ────────────────────────
+  exportNotePdf: (title: string, html: string) =>
+    invoke<{ filePath: string } | null>("app:exportNotePdf", { title, html }),
+
   // ── Open a URL in the system default browser ──
   openExternal: (url: string) => ipcRenderer.send("app:openExternal", url),
 

--- a/src/components/graph/GraphAIPanel.test.ts
+++ b/src/components/graph/GraphAIPanel.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for GraphAIPanel pure helpers:
+ *   - wikilinkAlreadyExists  — duplicate wikilink guard
+ *   - buildGraphContext      — graph snapshot serialiser fed to the AI
+ */
+
+import { describe, it, expect } from "vitest";
+import { wikilinkAlreadyExists, buildGraphContext } from "./graph-ai-utils";
+import type { KnowledgeGraph, GraphNode } from "../../types";
+
+// ── wikilinkAlreadyExists ─────────────────────────────────────────────────────
+
+describe("wikilinkAlreadyExists", () => {
+  it("returns false when the link is absent", () => {
+    expect(wikilinkAlreadyExists("Some note content", "Target Note")).toBe(false);
+  });
+
+  it("returns true for an exact match", () => {
+    expect(wikilinkAlreadyExists("See [[Target Note]] for details.", "Target Note")).toBe(true);
+  });
+
+  it("is case-insensitive on the title", () => {
+    expect(wikilinkAlreadyExists("[[target note]]", "Target Note")).toBe(true);
+    expect(wikilinkAlreadyExists("[[TARGET NOTE]]", "Target Note")).toBe(true);
+  });
+
+  it("ignores surrounding whitespace inside brackets", () => {
+    expect(wikilinkAlreadyExists("[[ Target Note ]]", "Target Note")).toBe(true);
+  });
+
+  it("does not match partial title overlap", () => {
+    expect(wikilinkAlreadyExists("[[Target Note Extended]]", "Target Note")).toBe(false);
+  });
+
+  it("handles regex special characters in the title", () => {
+    expect(wikilinkAlreadyExists("[[C++ Notes]]", "C++ Notes")).toBe(true);
+    expect(wikilinkAlreadyExists("plain text", "C++ Notes")).toBe(false);
+  });
+
+  it("returns true when the link appears anywhere in multi-line content", () => {
+    const content = "Intro paragraph.\n\nSome detail.\n\n[[Target Note]]\n\nMore text.";
+    expect(wikilinkAlreadyExists(content, "Target Note")).toBe(true);
+  });
+
+  it("returns false for empty content", () => {
+    expect(wikilinkAlreadyExists("", "Target Note")).toBe(false);
+  });
+});
+
+// ── buildGraphContext ─────────────────────────────────────────────────────────
+
+function makeNote(id: string, title: string, snippet = ""): GraphNode {
+  return { id, type: "note", title, workspaceId: "ws1", meta: { snippet } };
+}
+
+function makeEdge(source: string, target: string, type: string, weight?: number) {
+  return { id: `${type}:${source}:${target}`, source, target, type, weight } as KnowledgeGraph["edges"][number];
+}
+
+describe("buildGraphContext", () => {
+  it("includes all nodes in the NODES section", () => {
+    const graph: KnowledgeGraph = {
+      nodes: [makeNote("n1", "Alpha"), makeNote("n2", "Beta")],
+      edges: [],
+    };
+    const ctx = buildGraphContext(graph, null);
+    expect(ctx).toContain('"Alpha"');
+    expect(ctx).toContain('"Beta"');
+    expect(ctx).toContain("NODES (2 total");
+  });
+
+  it("puts wikilink edges in EXISTING WIKILINKS, not OTHER EDGES", () => {
+    const graph: KnowledgeGraph = {
+      nodes: [makeNote("n1", "Alpha"), makeNote("n2", "Beta")],
+      edges: [makeEdge("n1", "n2", "wikilink", 1.0)],
+    };
+    const ctx = buildGraphContext(graph, null);
+    expect(ctx).toContain("EXISTING WIKILINKS");
+    expect(ctx).toContain('"Alpha" ↔ "Beta"');
+    // The wikilink pair must NOT appear in the OTHER EDGES block
+    const otherEdgesSection = ctx.split("OTHER EDGES")[1] ?? "";
+    expect(otherEdgesSection).not.toContain('"Alpha"');
+  });
+
+  it("puts non-wikilink edges in OTHER EDGES", () => {
+    const graph: KnowledgeGraph = {
+      nodes: [makeNote("n1", "Alpha"), makeNote("n2", "Beta")],
+      edges: [makeEdge("n1", "n2", "co-mention", 0.9)],
+    };
+    const ctx = buildGraphContext(graph, null);
+    expect(ctx).toContain("OTHER EDGES");
+    expect(ctx).toContain('"Alpha" → "Beta" (co-mention');
+    // co-mention must NOT appear in EXISTING WIKILINKS
+    const wikilinkSection = ctx.split("EXISTING WIKILINKS")[1]?.split("OTHER EDGES")[0] ?? "";
+    expect(wikilinkSection).not.toContain("Alpha");
+  });
+
+  it("shows (none) in EXISTING WIKILINKS when there are no wikilink edges", () => {
+    const graph: KnowledgeGraph = {
+      nodes: [makeNote("n1", "Alpha")],
+      edges: [],
+    };
+    const ctx = buildGraphContext(graph, null);
+    // Should still have the section header, with (none)
+    expect(ctx).toContain("EXISTING WIKILINKS");
+    // The (none) placeholder should follow the wikilinks header
+    const afterHeader = ctx.split("EXISTING WIKILINKS")[1] ?? "";
+    expect(afterHeader.split("OTHER EDGES")[0]).toContain("(none)");
+  });
+
+  it("includes the do-not-suggest label in EXISTING WIKILINKS header", () => {
+    const graph: KnowledgeGraph = { nodes: [], edges: [] };
+    const ctx = buildGraphContext(graph, null);
+    expect(ctx).toContain("do NOT suggest adding these");
+  });
+
+  it("includes selected node info when provided", () => {
+    const graph: KnowledgeGraph = {
+      nodes: [makeNote("n1", "Alpha", "Some snippet")],
+      edges: [],
+    };
+    const ctx = buildGraphContext(graph, makeNote("n1", "Alpha", "Some snippet"));
+    expect(ctx).toContain("Selected:");
+    expect(ctx).toContain('"Alpha"');
+  });
+
+  it("omits selected node section when null", () => {
+    const graph: KnowledgeGraph = { nodes: [], edges: [] };
+    const ctx = buildGraphContext(graph, null);
+    expect(ctx).not.toContain("Selected:");
+  });
+
+  it("includes both wikilink and other edges when mixed", () => {
+    const graph: KnowledgeGraph = {
+      nodes: [makeNote("n1", "Alpha"), makeNote("n2", "Beta"), makeNote("n3", "Gamma")],
+      edges: [
+        makeEdge("n1", "n2", "wikilink", 1.0),
+        makeEdge("n2", "n3", "keyword", 0.4),
+      ],
+    };
+    const ctx = buildGraphContext(graph, null);
+    expect(ctx).toContain('"Alpha" ↔ "Beta"');
+    expect(ctx).toContain('"Beta" → "Gamma" (keyword');
+    // Cross-check: wikilink pair not in other edges block
+    const otherEdgesSection = ctx.split("OTHER EDGES")[1] ?? "";
+    expect(otherEdgesSection).not.toContain("Alpha");
+  });
+});

--- a/src/components/graph/GraphAIPanel.tsx
+++ b/src/components/graph/GraphAIPanel.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import type { KnowledgeGraph, GraphNode } from "@/types";
+import { wikilinkAlreadyExists, buildGraphContext } from "./graph-ai-utils";
 import { MarkdownContent } from "@/components/chat/chat-panel/MarkdownContent";
 
 // ── Action types (mirror suggest_connections schema) ──────────────────────────
@@ -37,34 +38,7 @@ interface GraphAIPanelProps {
   onClose: () => void;
 }
 
-// ── Graph context builder ─────────────────────────────────────────────────────
 
-function buildGraphContext(graph: KnowledgeGraph, selectedNode: GraphNode | null): string {
-  const nodeLines = graph.nodes
-    .slice(0, 80)
-    .map((n) => {
-      const snippet = n.meta?.snippet ? ` — "${n.meta.snippet.slice(0, 80).replace(/\n/g, " ")}"` : "";
-      return `- [${n.type}] id=${n.id} "${n.title}"${snippet}`;
-    })
-    .join("\n");
-
-  const edgeLines = graph.edges
-    .slice(0, 100)
-    .map((e) => {
-      const src = graph.nodes.find((n) => n.id === e.source);
-      const tgt = graph.nodes.find((n) => n.id === e.target);
-      if (!src || !tgt) return null;
-      return `- "${src.title}" → "${tgt.title}" (${e.type}${e.weight != null ? `, w=${e.weight.toFixed(2)}` : ""})`;
-    })
-    .filter(Boolean)
-    .join("\n");
-
-  const sel = selectedNode
-    ? `\n\nSelected: [${selectedNode.type}] id=${selectedNode.id} "${selectedNode.title}"${selectedNode.meta?.snippet ? `\nPreview: "${selectedNode.meta.snippet}"` : ""}`
-    : "";
-
-  return `NODES (${graph.nodes.length} total, first 80):\n${nodeLines || "(none)"}\n\nEDGES (${graph.edges.length} total, first 100):\n${edgeLines || "(none)"}${sel}`;
-}
 
 // ── System prompt ─────────────────────────────────────────────────────────────
 
@@ -84,6 +58,8 @@ Your capabilities:
 Write your analysis as clear, concise markdown prose.
 
 When you have specific actionable suggestions, call the \`suggest_connections\` tool with those actions. The user will see Apply buttons for each one. Use node IDs exactly as they appear in the graph snapshot. Limit to 8 actions maximum.
+
+**Important:** The graph snapshot includes an "EXISTING WIKILINKS" section. Never suggest \`add_wikilink\` actions for pairs that already appear there — those links already exist.
 
 Do not put the actions in your prose — call the tool instead.`;
 
@@ -207,7 +183,9 @@ function ActionsList(props: ActionsListProps) {
       case "add_wikilink": {
         const note = notes.find((n) => n.id === action.sourceNoteId);
         if (!note) throw new Error("Note not found");
-        updateNote(action.sourceNoteId, { content: (note.content ?? "") + `\n\n[[${action.targetTitle}]]` });
+        const existing = note.content ?? "";
+        if (wikilinkAlreadyExists(existing, action.targetTitle)) break;
+        updateNote(action.sourceNoteId, { content: existing + `\n\n[[${action.targetTitle}]]` });
         break;
       }
       case "link_note_note": {

--- a/src/components/graph/graph-ai-utils.ts
+++ b/src/components/graph/graph-ai-utils.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure utility functions extracted from GraphAIPanel for testability.
+ * No React, no store, no IPC — safe to import in Node/vitest.
+ */
+
+import type { KnowledgeGraph, GraphNode } from "../../types";
+
+// ── Wikilink duplicate guard ──────────────────────────────────────────────────
+
+/**
+ * Returns true if `[[targetTitle]]` already exists in `content`
+ * (exact title match, case-insensitive, surrounding whitespace ignored).
+ */
+export function wikilinkAlreadyExists(content: string, targetTitle: string): boolean {
+  const escaped = targetTitle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\[\\[\\s*${escaped}\\s*\\]\\]`, "i").test(content);
+}
+
+// ── Graph context builder ─────────────────────────────────────────────────────
+
+export function buildGraphContext(graph: KnowledgeGraph, selectedNode: GraphNode | null): string {
+  const nodeLines = graph.nodes
+    .slice(0, 80)
+    .map((n) => {
+      const snippet = n.meta?.snippet ? ` — "${n.meta.snippet.slice(0, 80).replace(/\n/g, " ")}"` : "";
+      return `- [${n.type}] id=${n.id} "${n.title}"${snippet}`;
+    })
+    .join("\n");
+
+  // Separate wikilink edges from other edges so the AI knows which [[links]] already exist
+  const wikilinkEdges = graph.edges.filter((e) => e.type === "wikilink");
+  const otherEdges    = graph.edges.filter((e) => e.type !== "wikilink");
+
+  const edgeLines = otherEdges
+    .slice(0, 100)
+    .map((e) => {
+      const src = graph.nodes.find((n) => n.id === e.source);
+      const tgt = graph.nodes.find((n) => n.id === e.target);
+      if (!src || !tgt) return null;
+      return `- "${src.title}" → "${tgt.title}" (${e.type}${e.weight != null ? `, w=${e.weight.toFixed(2)}` : ""})`;
+    })
+    .filter(Boolean)
+    .join("\n");
+
+  const wikilinkLines = wikilinkEdges
+    .slice(0, 60)
+    .map((e) => {
+      const src = graph.nodes.find((n) => n.id === e.source);
+      const tgt = graph.nodes.find((n) => n.id === e.target);
+      if (!src || !tgt) return null;
+      return `- "${src.title}" ↔ "${tgt.title}"`;
+    })
+    .filter(Boolean)
+    .join("\n");
+
+  const sel = selectedNode
+    ? `\n\nSelected: [${selectedNode.type}] id=${selectedNode.id} "${selectedNode.title}"${selectedNode.meta?.snippet ? `\nPreview: "${selectedNode.meta.snippet}"` : ""}`
+    : "";
+
+  return `NODES (${graph.nodes.length} total, first 80):\n${nodeLines || "(none)"}\n\nEXISTING WIKILINKS (${wikilinkEdges.length} total, first 60) — do NOT suggest adding these:\n${wikilinkLines || "(none)"}\n\nOTHER EDGES (${otherEdges.length} total, first 100):\n${edgeLines || "(none)"}${sel}`;
+}

--- a/src/components/notes/WikilinkPicker.tsx
+++ b/src/components/notes/WikilinkPicker.tsx
@@ -3,14 +3,22 @@
 /**
  * WikilinkPicker — floating autocomplete for `[[Note Title]]` insertion.
  *
- * Rendered by NoteEditor when the user types `[[` or clicks the
- * "Insert link" toolbar button. Positioned relative to the editor container.
+ * Rendered into a portal on document.body with `position: fixed` so scroll
+ * inside the editor container does not affect placement. The picker flips
+ * above the cursor when there is insufficient space below, and is always
+ * clamped to the viewport on all four sides.
  */
 
 import React, { useEffect, useRef, useState, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { FileText } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Note } from "@/types";
+
+const PICKER_WIDTH  = 288; // w-72
+const PICKER_HEIGHT = 240; // max-h-60
+const GAP = 6;
+const VIEWPORT_PAD = 8;
 
 export interface WikilinkPickerProps {
   /** All notes available for linking (excluding the currently-open note) */
@@ -23,10 +31,12 @@ export interface WikilinkPickerProps {
   onSelect: (title: string) => void;
   /** Called when the picker should close without inserting */
   onClose: () => void;
-  /** CSS top offset (px) for the floating panel, relative to editor container */
-  top?: number;
-  /** CSS left offset (px) */
-  left?: number;
+  /**
+   * Viewport-relative position of the cursor (from `coordsAtPos`).
+   * The picker positions itself near this point, flipping above/below
+   * as needed to stay on screen.
+   */
+  anchorRect: { top: number; bottom: number; left: number };
 }
 
 export function WikilinkPicker({
@@ -35,8 +45,7 @@ export function WikilinkPicker({
   query,
   onSelect,
   onClose,
-  top,
-  left,
+  anchorRect,
 }: WikilinkPickerProps) {
   const [activeIdx, setActiveIdx] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
@@ -50,9 +59,7 @@ export function WikilinkPicker({
         .slice(0, 12);
 
   // Reset active index when filtered list changes
-  useEffect(() => {
-    setActiveIdx(0);
-  }, [query]);
+  useEffect(() => { setActiveIdx(0); }, [query]);
 
   // Keyboard navigation
   const handleKeyDown = useCallback(
@@ -72,7 +79,7 @@ export function WikilinkPicker({
         onClose();
       }
     },
-    [filtered, activeIdx, onSelect, onClose]
+    [filtered, activeIdx, onSelect, onClose],
   );
 
   useEffect(() => {
@@ -86,56 +93,70 @@ export function WikilinkPicker({
     el?.scrollIntoView({ block: "nearest" });
   }, [activeIdx]);
 
-  if (filtered.length === 0) {
-    return (
-      <div
-        data-wikilink-picker
-        className="absolute z-50 w-72 rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-lg py-2 px-3"
-        style={{ top, left }}
-      >
-        <p className="text-xs text-[var(--text-tertiary)]">No matching notes</p>
-      </div>
-    );
-  }
+  // ── Position calculation ─────────────────────────────────────────────────
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
 
-  return (
+  // Flip above cursor when there isn't enough space below
+  const spaceBelow = vh - anchorRect.bottom - GAP - VIEWPORT_PAD;
+  const spaceAbove = anchorRect.top       - GAP - VIEWPORT_PAD;
+  const openUpward = spaceBelow < PICKER_HEIGHT && spaceAbove > spaceBelow;
+
+  const top = openUpward
+    ? anchorRect.top  - PICKER_HEIGHT - GAP
+    : anchorRect.bottom + GAP;
+
+  // Clamp left so picker never overflows viewport edges
+  const left = Math.min(
+    Math.max(anchorRect.left, VIEWPORT_PAD),
+    vw - PICKER_WIDTH - VIEWPORT_PAD,
+  );
+
+  // ── Render ───────────────────────────────────────────────────────────────
+  const content = (
     <div
       data-wikilink-picker
-      className="absolute z-50 w-72 rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-lg py-1 max-h-60 overflow-y-auto"
-      style={{ top, left }}
+      className="fixed z-[9999] w-72 rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-xl py-1 overflow-y-auto"
+      style={{ top, left, maxHeight: PICKER_HEIGHT }}
     >
-      <div ref={listRef}>
-        {filtered.map((note, idx) => {
-          const projectName = note.projectId ? projectMap.get(note.projectId) : undefined;
-          return (
-            <button
-              key={note.id}
-              onMouseDown={(e) => {
-                // mousedown instead of click so editor doesn't lose focus
-                e.preventDefault();
-                onSelect(note.title);
-              }}
-              onMouseEnter={() => setActiveIdx(idx)}
-              className={cn(
-                "w-full flex items-center gap-2 px-3 py-2 text-left transition-colors",
-                idx === activeIdx
-                  ? "bg-[var(--accent-dim)] text-[var(--accent)]"
-                  : "text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
-              )}
-            >
-              <FileText size={12} className="flex-shrink-0 text-[var(--text-tertiary)]" />
-              <span className="flex-1 min-w-0">
-                <span className="block text-xs font-medium truncate">{note.title}</span>
-                {projectName && (
-                  <span className="block text-[0.714rem] text-[var(--text-tertiary)] truncate">
-                    {projectName}
-                  </span>
+      {filtered.length === 0 ? (
+        <p className="text-xs text-[var(--text-tertiary)] px-3 py-2">No matching notes</p>
+      ) : (
+        <div ref={listRef}>
+          {filtered.map((note, idx) => {
+            const projectName = note.projectId ? projectMap.get(note.projectId) : undefined;
+            return (
+              <button
+                key={note.id}
+                onMouseDown={(e) => {
+                  // mousedown so editor doesn't lose focus before onSelect fires
+                  e.preventDefault();
+                  onSelect(note.title);
+                }}
+                onMouseEnter={() => setActiveIdx(idx)}
+                className={cn(
+                  "w-full flex items-center gap-2 px-3 py-2 text-left transition-colors",
+                  idx === activeIdx
+                    ? "bg-[var(--accent-dim)] text-[var(--accent)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--surface-2)]",
                 )}
-              </span>
-            </button>
-          );
-        })}
-      </div>
+              >
+                <FileText size={12} className="flex-shrink-0 text-[var(--text-tertiary)]" />
+                <span className="flex-1 min-w-0">
+                  <span className="block text-xs font-medium truncate">{note.title}</span>
+                  {projectName && (
+                    <span className="block text-[0.714rem] text-[var(--text-tertiary)] truncate">
+                      {projectName}
+                    </span>
+                  )}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
+
+  return createPortal(content, document.body);
 }

--- a/src/components/notes/ai-text-toolbar.tsx
+++ b/src/components/notes/ai-text-toolbar.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import {
   Loader2, Wand2, RefreshCw, AlignLeft, Expand, SpellCheck, MessageSquare, X,
-  Bold, Italic, Strikethrough, Code, Code2, Link, Quote, List, ListOrdered,
+  Bold, Italic, Strikethrough, Code, Code2, Link, Link2, Quote, List, ListOrdered,
   Heading1, Heading2, Heading3, Highlighter, CheckSquare, Minus,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -36,7 +36,8 @@ export type FormatAction =
   | "ordered"
   | "task"
   | "codeblock"
-  | "hr";
+  | "hr"
+  | "wikilink";
 
 interface AITextToolbarProps {
   onAction: (action: AITextAction, customPrompt?: string) => void;
@@ -85,8 +86,9 @@ const FORMAT_GROUPS: { id: FormatAction; label: string; icon: React.ReactNode }[
   ],
   // Insert
   [
-    { id: "codeblock", label: "Code block", icon: <Code2 size={12} /> },
-    { id: "hr",        label: "Divider ---", icon: <Minus size={12} /> },
+    { id: "codeblock", label: "Code block",           icon: <Code2 size={12} /> },
+    { id: "hr",        label: "Divider ---",           icon: <Minus size={12} /> },
+    { id: "wikilink",  label: "Wikilink [[Note]]",    icon: <Link2 size={12} /> },
   ],
 ];
 
@@ -458,6 +460,9 @@ export function applyFormat(view: EditorView, action: FormatAction): { from: num
     view.focus();
     return { from: replaceFrom, to: replaceFrom + insert.length };
   }
+
+  // wikilink is handled by the editor (opens the picker) — nothing to do here
+  if (action === "wikilink") return null;
 
   if (action === "hr") {
     const line   = state.doc.lineAt(from);

--- a/src/components/notes/note-editor.tsx
+++ b/src/components/notes/note-editor.tsx
@@ -7,7 +7,7 @@ import remarkBreaks from "remark-breaks";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
-import { Pin, PinOff, Calendar, Eye, Pencil, Wand2, Loader2, CheckCircle2, Tag, Plus, X, Link2, Kanban, ChevronDown, FileText } from "lucide-react";
+import { Pin, PinOff, Calendar, Eye, Pencil, Wand2, Loader2, CheckCircle2, Tag, Plus, X, Link2, Kanban, ChevronDown, FileText, FileDown } from "lucide-react";
 import { WikilinkPicker } from "./WikilinkPicker";
 import { getActiveWikilink } from "@/lib/wikilink-parser";
 import { useCairnStore } from "@/store";
@@ -395,12 +395,13 @@ export function NoteEditor({ note }: NoteEditorProps) {
   const [wikilinkPicker, setWikilinkPicker] = useState<{
     query: string;
     triggerFrom: number;
-    top: number;
-    left: number;
+    anchorRect: { top: number; bottom: number; left: number };
   } | null>(null);
 
   // Scroll container ref — used by TableOfContents to scroll to headings
   const previewScrollRef = useRef<HTMLDivElement>(null);
+  // Ref to the prose-cairn div — used by PDF export to capture rendered HTML
+  const proseRef = useRef<HTMLDivElement>(null);
 
   // ── Math plugins (stable per note) ────────────────────────────────────────
   // makeLatexPlugins() creates a shared mutable latexBlocks array coupled
@@ -445,13 +446,11 @@ export function NoteEditor({ note }: NoteEditorProps) {
         if (active) {
           // Position the picker near the cursor
           const coords = view.coordsAtPos(cursorPos);
-          const containerRect = containerRef.current?.getBoundingClientRect();
-          if (coords && containerRect) {
+          if (coords) {
             setWikilinkPicker({
               query: active.query,
               triggerFrom: active.triggerFrom,
-              top: coords.bottom - containerRect.top + 4,
-              left: Math.min(coords.left - containerRect.left, containerRect.width - 290),
+              anchorRect: { top: coords.top, bottom: coords.bottom, left: coords.left },
             });
           } else {
             setWikilinkPicker((prev) => prev ? { ...prev, query: active.query, triggerFrom: active.triggerFrom } : null);
@@ -590,18 +589,22 @@ export function NoteEditor({ note }: NoteEditorProps) {
   const openWikilinkPicker = useCallback(() => {
     const view = editorRef.current?.getView();
     if (!view) return;
+    // Restore focus so coordsAtPos returns a real position (the formatting
+    // toolbar uses onMouseDown+preventDefault which can shift focus away from CM).
+    view.focus();
     const cursorPos = view.state.selection.main.head;
     const coords = view.coordsAtPos(cursorPos);
-    const containerRect = containerRef.current?.getBoundingClientRect();
-    setWikilinkPicker({
-      query: "",
-      triggerFrom: cursorPos,
-      top: coords && containerRect ? coords.bottom - containerRect.top + 4 : 80,
-      left: coords && containerRect ? Math.min(coords.left - containerRect.left, containerRect.width - 290) : 80,
-    });
+    // coords are already viewport-relative — pass them straight through.
+    // If unavailable (cursor not visible), fall back to a mid-screen estimate.
+    const anchorRect = coords
+      ? { top: coords.top, bottom: coords.bottom, left: coords.left }
+      : { top: window.innerHeight / 2, bottom: window.innerHeight / 2 + 20, left: window.innerWidth / 2 };
+    setWikilinkPicker({ query: "", triggerFrom: cursorPos, anchorRect });
   }, []);
 
   const handleFormat = useCallback((action: FormatAction) => {
+    // wikilink opens the picker rather than inserting markdown directly
+    if (action === "wikilink") { openWikilinkPicker(); return; }
     const view = editorRef.current?.getView();
     if (!view) return;
     const range = applyFormat(view, action);
@@ -609,7 +612,7 @@ export function NoteEditor({ note }: NoteEditorProps) {
       const newText = view.state.sliceDoc(range.from, range.to).trim();
       if (newText.length >= 3) setPreviewText(newText);
     }
-  }, []);
+  }, [openWikilinkPicker]);
 
   useEffect(() => {
     if (!spawnLoading) return;
@@ -867,6 +870,55 @@ export function NoteEditor({ note }: NoteEditorProps) {
     updateNote(note.id, { tagIds: [...note.tagIds, tag.id] });
   }, [activeWorkspaceId, note.id, note.tagIds, createTag, updateNote]);
 
+  const [exportState, setExportState] = useState<"idle" | "exporting" | "done">("idle");
+  const handleExportPdf = useCallback(async () => {
+    if (!proseRef.current || !window.electron?.exportNotePdf) return;
+    setExportState("exporting");
+    try {
+      const raw = proseRef.current.innerHTML;
+      // Post-process HTML to make code blocks print-friendly:
+      // CodeBlock uses hardcoded inline styles derived from the active theme.
+      // We parse the captured HTML, rewrite those inline styles to light-palette
+      // values, and remove the Copy button (not useful in a PDF).
+      const doc = new DOMParser().parseFromString(`<div>${raw}</div>`, "text/html");
+      const root = doc.body.firstElementChild!;
+
+      // Each CodeBlock renders as: div.my-4.rounded-lg > div(header) + pre
+      for (const block of root.querySelectorAll<HTMLElement>("div.my-4")) {
+        const pre = block.querySelector<HTMLElement>("pre");
+        const header = block.querySelector<HTMLElement>("div");
+        if (!pre) continue;
+
+        // Force light-theme colours on pre and its border container
+        pre.style.background = "#f8f7f5";
+        pre.style.color      = "#374151";
+        block.style.border   = "1px solid #dddad6";
+
+        // Rewrite token span colours from DARK palette → LIGHT palette
+        const DARK_TO_LIGHT: Record<string, string> = {
+          "#c678dd": "#7c3aed", "#e5c07b": "#b45309", "#56b6c2": "#0891b2",
+          "#d19a66": "#c2410c", "#98c379": "#16a34a", "#e06c75": "#dc2626",
+          "#5c6370": "#9ca3af", "#61afef": "#1d4ed8", "#abb2bf": "#374151",
+        };
+        for (const span of pre.querySelectorAll<HTMLElement>("span[style]")) {
+          const c = span.style.color.toLowerCase();
+          // normalise hex shorthand if needed, try direct map
+          if (DARK_TO_LIGHT[c]) span.style.color = DARK_TO_LIGHT[c];
+        }
+
+        // Remove the Copy button header — not useful in print
+        if (header) header.remove();
+      }
+
+      const html = root.innerHTML;
+      await window.electron.exportNotePdf(note.title, html);
+      setExportState("done");
+      setTimeout(() => setExportState("idle"), 2000);
+    } catch {
+      setExportState("idle");
+    }
+  }, [note.title]);
+
   return (
     <div
       ref={containerRef}
@@ -943,14 +995,25 @@ export function NoteEditor({ note }: NoteEditorProps) {
               </button>
             </Tooltip>
           ))}
-          {mode === "write" && (
-            <Tooltip content="Insert wikilink [[Note Title]]">
+
+          {mode === "read" && window.electron?.exportNotePdf && (
+            <Tooltip content="Export as PDF">
               <button
-                onClick={openWikilinkPicker}
-                className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors"
+                onClick={handleExportPdf}
+                disabled={exportState === "exporting"}
+                className={cn(
+                  "flex items-center gap-1.5 px-2 py-1 rounded-md text-xs transition-colors",
+                  exportState === "done"
+                    ? "text-[var(--success)]"
+                    : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] disabled:opacity-50"
+                )}
               >
-                <Link2 size={12} />
-                Link
+                {exportState === "exporting"
+                  ? <Loader2 size={12} className="animate-spin" />
+                  : exportState === "done"
+                    ? <CheckCircle2 size={12} />
+                    : <FileDown size={12} />}
+                {exportState === "done" ? "Saved" : "PDF"}
               </button>
             </Tooltip>
           )}
@@ -1026,7 +1089,7 @@ export function NoteEditor({ note }: NoteEditorProps) {
           />
         </div>
 
-        {/* Wikilink autocomplete picker */}
+        {/* Wikilink autocomplete picker — rendered in a portal at fixed viewport coords */}
         {wikilinkPicker && mode === "write" && (
           <WikilinkPicker
             notes={notes.filter((n) => n.id !== note.id)}
@@ -1034,8 +1097,7 @@ export function NoteEditor({ note }: NoteEditorProps) {
             query={wikilinkPicker.query}
             onSelect={handleWikilinkSelect}
             onClose={() => setWikilinkPicker(null)}
-            top={wikilinkPicker.top}
-            left={wikilinkPicker.left}
+            anchorRect={wikilinkPicker.anchorRect}
           />
         )}
 
@@ -1052,7 +1114,7 @@ export function NoteEditor({ note }: NoteEditorProps) {
             )}
             <div className="px-6 py-5 max-w-4xl mx-auto">
               {note.content ? (
-                <div className="prose-cairn">
+                <div className="prose-cairn" ref={proseRef}>
                    <ReactMarkdown
                      remarkPlugins={[remarkGfm, remarkBreaks, remarkMath, remarkPromoteDisplayMath, remarkCallout, remarkWikilinks]}
                      rehypePlugins={[rehypeCaptureLatex, rehypeKatex, rehypeMergedPass]}

--- a/src/components/notes/notes-view.tsx
+++ b/src/components/notes/notes-view.tsx
@@ -719,7 +719,7 @@ const NoteListItem = React.memo(function NoteListItem({ note, isActive, indent =
               {note.isPinned ? "Unpin" : "Pin"}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onReveal(); }}>
-              <FileText size={12} />Reveal in Finder
+              <FileText size={12} />Reveal in {window.electron?.platform === "win32" ? "Explorer" : window.electron?.platform === "linux" ? "Files" : "Finder"}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onArchive(); }}>


### PR DESCRIPTION
## What does this PR do?

Fixes three bugs introduced or exposed by the v1.1.0 wikilink feature (platform label, external file adoption, picker positioning), adds PDF export for notes, and moves the wikilink toolbar button into the formatting bar where it belongs.

## Type of change

- [x] Bug fix
- [x] New feature


## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes (441 tests across 10 files)
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] No new DB migrations (schema unchanged)
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

- `adoptExternalNoteFile` matches projects by slugging their names — if two projects slug to the same string the first DB result wins. This is an edge case and consistent with how project folders are already created.
- PDF export captures `innerHTML` of the rendered `prose-cairn` div and post-processes code block inline styles to a light palette before sending to the main process. The hidden `BrowserWindow` always renders with light-theme CSS regardless of the app's active theme.
- `WikilinkPicker` now renders into a `document.body` portal with `position: fixed`. The `data-wikilink-picker` attribute used by the editor's `onMouseDown` dismiss logic still works correctly since it targets the DOM node, not its position in the React tree.
- The `"wikilink"` `FormatAction` returns `null` from `applyFormat` — it is intercepted in `handleFormat` in `note-editor.tsx` before reaching CodeMirror.