### PR TITLE
v1.1.2 - MD Fixes

### DIFF
--- a/changelogs/v1.1.2.md
+++ b/changelogs/v1.1.2.md
@@ -1,0 +1,57 @@
+# v1.1.2
+
+## Bug fixes
+
+### Fixed: Plain `.md` files present at startup not appearing in Notes
+
+`syncNotesFromDisk` (called once on startup and after workspace reinitialise) walked the notes directory and silently skipped any `.md` file that lacked Cairn YAML frontmatter — the `parseNoteFile` result was `null` and the file was `continue`d over. Files dropped into a project folder before opening the app were therefore never imported.
+
+`syncDir` now falls through to `adoptExternalNoteFile` when `parseNoteFile` returns `null`, matching the behaviour already in place for the live file watcher.
+
+### Fixed: Copy/paste of a `.md` file caused both notes to disappear
+
+When a file was copied inside a project folder (e.g. `My Note.md` → `My Note copy.md`), `adoptExternalNoteFile` called `writeNoteFile()` to write back the Cairn frontmatter. `writeNoteFile` derives a new file path from the note title slug (`my-note-copy.md`) and writes there — leaving the original file (`My Note copy.md`) untouched with no frontmatter.
+
+On the next file-watcher event the original was detected again, adopted a second time with a brand-new ID, and the slug file was overwritten — resulting in two broken notes with mismatched IDs, neither of which resolved correctly in the UI.
+
+`adoptExternalNoteFile` now writes the frontmatter **in-place** to the exact `filePath` it received, using `matter.stringify` + `fs.writeFileSync` directly. `writeNoteFile` is no longer called from adoption paths. Each file keeps its own filename and receives a unique stable ID.
+
+### Fixed: GitHub Actions Playwright cache never hitting
+
+The `smoke-e2e` job ran `npx playwright install chromium --with-deps` unconditionally on every run — the cache step had no `id`, so its `cache-hit` output was unavailable and the install step had no condition to skip on a hit. Combined with a cache key that lacked a `runner.os` discriminator, the cache entry was never matched on subsequent runs.
+
+- Added `id: playwright-cache` to the cache step so `steps.playwright-cache.outputs.cache-hit` is available.
+- Cache key changed from `playwright-chromium-<hash>` to `playwright-chromium-${{ runner.os }}-<hash>` — OS-scoped and stable.
+- Browser binary install (`npx playwright install chromium`) now runs only on `cache-hit != 'true'`.
+- OS-level system dependencies (`npx playwright install-deps chromium`) always run — they are not cacheable (apt packages in system paths) but complete in ~10 s with no browser download.
+
+---
+
+## Tests
+
+11 new unit tests added to `electron/notes-files.test.ts` covering the two file adoption fixes:
+
+**`adoptExternalNoteFile`**
+- Returns `null` for a file outside any project folder
+- Returns `null` when the folder slug matches no project
+- Adopts a plain `.md` file and writes frontmatter in-place to the original path
+- Does not create a second slug-derived file
+- Copy/paste scenario: two files with different names receive independent IDs, no extra files created
+- Derives subfolder from intermediate path segments
+- Idempotent: an already-adopted file is parseable by `parseNoteFile` and would not be re-adopted
+
+**`syncNotesFromDisk`**
+- Imports a Cairn note file present at startup
+- Adopts a plain `.md` file present at startup (no frontmatter)
+- Does not overwrite an existing SQLite row for an already-known note
+- Adopts plain `.md` files across multiple projects in a single sync pass
+
+---
+
+## Changed files
+
+| File | Change |
+|------|--------|
+| `electron/notes-files.ts` | `adoptExternalNoteFile` writes frontmatter in-place; `syncDir` falls through to adoption; `syncNotesFromDisk` passes `workspacePath` through |
+| `electron/notes-files.test.ts` | 11 new tests for `adoptExternalNoteFile` and `syncNotesFromDisk` |
+| `.github/workflows/release.yml` | Playwright cache key OS-scoped; install step conditioned on cache miss; system deps always installed separately |

--- a/electron/notes-files.test.ts
+++ b/electron/notes-files.test.ts
@@ -9,6 +9,10 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import BetterSqlite3 from "better-sqlite3";
+import type Database from "better-sqlite3";
+import { applySchema } from "./db/schema";
+import { createWorkspace, createProject } from "./db/queries";
 import {
   toSlug,
   writeNoteFile,
@@ -17,6 +21,9 @@ import {
   deleteNoteFile,
   stripMarkdown,
   projectNotesDir,
+  notesDir,
+  adoptExternalNoteFile,
+  syncNotesFromDisk,
 } from "./notes-files";
 import type { NoteData } from "./notes-files";
 
@@ -284,5 +291,222 @@ describe("stripMarkdown", () => {
 
   it("handles empty string without error", () => {
     expect(stripMarkdown("")).toBe("");
+  });
+});
+
+// ── adoptExternalNoteFile ─────────────────────────────────────────────────
+
+function makeDb(): Database.Database {
+  const db = new BetterSqlite3(":memory:");
+  applySchema(db);
+  return db;
+}
+
+function seedProjectInDb(db: Database.Database, name = "My Project", id = "proj1", wsId = "ws1") {
+  createWorkspace(db, { id: wsId, name: "Test Workspace" });
+  return createProject(db, { id, workspaceId: wsId, name });
+}
+
+describe("adoptExternalNoteFile", () => {
+  let db: Database.Database;
+
+  beforeEach(() => { db = makeDb(); });
+
+  it("returns null for a file outside any project folder", () => {
+    seedProjectInDb(db);
+    // Write a .md file directly in notes/ root (no project subfolder)
+    const notesRoot = notesDir(tmpDir);
+    fs.mkdirSync(notesRoot, { recursive: true });
+    const fp = path.join(notesRoot, "orphan.md");
+    fs.writeFileSync(fp, "# Orphan\n\nNo project.\n", "utf-8");
+
+    const result = adoptExternalNoteFile(db, tmpDir, fp);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the project slug does not match any project", () => {
+    seedProjectInDb(db, "My Project");
+    const dir = path.join(notesDir(tmpDir), "unknown-project");
+    fs.mkdirSync(dir, { recursive: true });
+    const fp = path.join(dir, "some-note.md");
+    fs.writeFileSync(fp, "# Note\n\nContent.\n", "utf-8");
+
+    expect(adoptExternalNoteFile(db, tmpDir, fp)).toBeNull();
+  });
+
+  it("adopts a plain .md file and writes frontmatter in-place", () => {
+    seedProjectInDb(db, "My Project", "proj1", "ws1");
+    const dir = path.join(notesDir(tmpDir), toSlug("My Project"));
+    fs.mkdirSync(dir, { recursive: true });
+    const fp = path.join(dir, "My External Note.md");
+    fs.writeFileSync(fp, "# External\n\nSome content here.\n", "utf-8");
+
+    const note = adoptExternalNoteFile(db, tmpDir, fp);
+
+    expect(note).not.toBeNull();
+    expect(note!.title).toBe("My External Note");
+    expect(note!.projectId).toBe("proj1");
+    expect(note!.workspaceId).toBe("ws1");
+    expect(note!.content).toContain("Some content here");
+
+    // Frontmatter written IN-PLACE — original file path must now be parseable
+    const parsed = parseNoteFile(fp);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.id).toBe(note!.id);
+    expect(parsed!.title).toBe("My External Note");
+  });
+
+  it("does NOT create a second file — only the original path is modified", () => {
+    seedProjectInDb(db, "My Project", "proj1", "ws1");
+    const dir = path.join(notesDir(tmpDir), toSlug("My Project"));
+    fs.mkdirSync(dir, { recursive: true });
+    const fp = path.join(dir, "My Note.md");
+    fs.writeFileSync(fp, "# My Note\n\nBody.\n", "utf-8");
+
+    adoptExternalNoteFile(db, tmpDir, fp);
+
+    // Only the original file should exist — no slug-derived duplicate
+    const files = fs.readdirSync(dir).filter((f) => f.endsWith(".md"));
+    expect(files).toHaveLength(1);
+    expect(files[0]).toBe("My Note.md");
+  });
+
+  it("copy-paste scenario: two files with different names get independent IDs", () => {
+    seedProjectInDb(db, "My Project", "proj1", "ws1");
+    const dir = path.join(notesDir(tmpDir), toSlug("My Project"));
+    fs.mkdirSync(dir, { recursive: true });
+
+    const original = path.join(dir, "My Note.md");
+    const copy     = path.join(dir, "My Note copy.md");
+
+    fs.writeFileSync(original, "# My Note\n\nOriginal content.\n", "utf-8");
+    fs.writeFileSync(copy,     "# My Note copy\n\nOriginal content.\n", "utf-8");
+
+    const noteA = adoptExternalNoteFile(db, tmpDir, original);
+    const noteB = adoptExternalNoteFile(db, tmpDir, copy);
+
+    expect(noteA).not.toBeNull();
+    expect(noteB).not.toBeNull();
+
+    // IDs must be distinct
+    expect(noteA!.id).not.toBe(noteB!.id);
+
+    // Both original file paths must be parseable with their own IDs
+    const parsedA = parseNoteFile(original);
+    const parsedB = parseNoteFile(copy);
+    expect(parsedA!.id).toBe(noteA!.id);
+    expect(parsedB!.id).toBe(noteB!.id);
+
+    // Still exactly two files — no extra slug-derived duplicates
+    const files = fs.readdirSync(dir).filter((f) => f.endsWith(".md"));
+    expect(files).toHaveLength(2);
+  });
+
+  it("derives subfolder from intermediate path segments", () => {
+    seedProjectInDb(db, "My Project", "proj1", "ws1");
+    const dir = path.join(notesDir(tmpDir), toSlug("My Project"), "design", "typography");
+    fs.mkdirSync(dir, { recursive: true });
+    const fp = path.join(dir, "Font Scale.md");
+    fs.writeFileSync(fp, "# Font Scale\n\nContent.\n", "utf-8");
+
+    const note = adoptExternalNoteFile(db, tmpDir, fp);
+
+    expect(note).not.toBeNull();
+    expect(note!.folder).toBe("design/typography");
+  });
+
+  it("is idempotent — adopting an already-adopted file returns its existing data", () => {
+    seedProjectInDb(db, "My Project", "proj1", "ws1");
+    const dir = path.join(notesDir(tmpDir), toSlug("My Project"));
+    fs.mkdirSync(dir, { recursive: true });
+    const fp = path.join(dir, "Idempotent.md");
+    fs.writeFileSync(fp, "# Idempotent\n\nContent.\n", "utf-8");
+
+    const first  = adoptExternalNoteFile(db, tmpDir, fp);
+    // After first adoption the file has valid frontmatter — parseNoteFile succeeds,
+    // so adoptExternalNoteFile is never actually called a second time by the watcher.
+    // Verify the file is now parseable (and adoption would be skipped).
+    const parsed = parseNoteFile(fp);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.id).toBe(first!.id);
+  });
+});
+
+// ── syncNotesFromDisk ─────────────────────────────────────────────────────
+
+describe("syncNotesFromDisk", () => {
+  let db: Database.Database;
+
+  beforeEach(() => { db = makeDb(); });
+
+  it("imports a Cairn note file that exists at startup", () => {
+    seedProjectInDb(db, "My Project", "proj1", "ws1");
+    const note = makeNote({ projectName: "My Project" });
+    writeNoteFile(tmpDir, note);
+
+    syncNotesFromDisk(db, tmpDir);
+
+    const row = db.prepare("SELECT id FROM notes WHERE id = ?").get(note.id);
+    expect(row).not.toBeNull();
+  });
+
+  it("adopts a plain .md file present at startup (no frontmatter)", () => {
+    seedProjectInDb(db, "My Project", "proj1", "ws1");
+    const dir = path.join(notesDir(tmpDir), toSlug("My Project"));
+    fs.mkdirSync(dir, { recursive: true });
+    const fp = path.join(dir, "Startup Note.md");
+    fs.writeFileSync(fp, "# Startup Note\n\nAdded before app opened.\n", "utf-8");
+
+    syncNotesFromDisk(db, tmpDir);
+
+    // Note must now be in SQLite
+    const rows = db.prepare("SELECT id, title FROM notes WHERE project_id = ?").all("proj1") as { id: string; title: string }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe("Startup Note");
+
+    // File must have been updated with frontmatter in-place
+    const parsed = parseNoteFile(fp);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.id).toBe(rows[0].id);
+  });
+
+  it("does not overwrite an existing SQLite row for a Cairn note", () => {
+    seedProjectInDb(db, "My Project", "proj1", "ws1");
+    const note = makeNote({ projectName: "My Project", title: "Existing Note" });
+    writeNoteFile(tmpDir, note);
+    // Pre-insert the note into SQLite with modified title
+    db.prepare(`INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
+      tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, '[]', '[]', '[]', 0, 'note', '', ?, ?)`)
+      .run(note.id, note.projectId, note.workspaceId, "Modified Title", note.content, "",
+           note.createdAt, note.updatedAt);
+
+    syncNotesFromDisk(db, tmpDir);
+
+    // Should NOT overwrite — row was already present
+    const row = db.prepare("SELECT title FROM notes WHERE id = ?").get(note.id) as { title: string };
+    expect(row.title).toBe("Modified Title");
+  });
+
+  it("adopts multiple plain .md files across different projects at startup", () => {
+    createWorkspace(db, { id: "ws1", name: "WS" });
+    createProject(db, { id: "proj1", workspaceId: "ws1", name: "Alpha" });
+    createProject(db, { id: "proj2", workspaceId: "ws1", name: "Beta" });
+
+    const dirA = path.join(notesDir(tmpDir), toSlug("Alpha"));
+    const dirB = path.join(notesDir(tmpDir), toSlug("Beta"));
+    fs.mkdirSync(dirA, { recursive: true });
+    fs.mkdirSync(dirB, { recursive: true });
+    fs.writeFileSync(path.join(dirA, "Note A.md"), "# Note A\n\nContent A.\n", "utf-8");
+    fs.writeFileSync(path.join(dirB, "Note B.md"), "# Note B\n\nContent B.\n", "utf-8");
+
+    syncNotesFromDisk(db, tmpDir);
+
+    const all = db.prepare("SELECT id, project_id, title FROM notes ORDER BY title").all() as { id: string; project_id: string; title: string }[];
+    expect(all).toHaveLength(2);
+    expect(all[0].title).toBe("Note A");
+    expect(all[0].project_id).toBe("proj1");
+    expect(all[1].title).toBe("Note B");
+    expect(all[1].project_id).toBe("proj2");
   });
 });

--- a/electron/notes-files.ts
+++ b/electron/notes-files.ts
@@ -242,17 +242,19 @@ export function parseNoteFile(filePath: string): NoteData | null {
 export function syncNotesFromDisk(db: Database.Database, workspacePath: string): void {
   const root = notesDir(workspacePath);
   if (!fs.existsSync(root)) return;
-  syncDir(db, root);
+  syncDir(db, root, workspacePath);
 }
 
-function syncDir(db: Database.Database, dir: string): void {
+function syncDir(db: Database.Database, dir: string, workspacePath: string): void {
   for (const entry of fs.readdirSync(dir)) {
     const fp = path.join(dir, entry);
     const stat = fs.lstatSync(fp);
     if (stat.isDirectory()) {
-      syncDir(db, fp);
+      syncDir(db, fp, workspacePath);
     } else if (entry.endsWith(".md")) {
-      const note = parseNoteFile(fp);
+      let note = parseNoteFile(fp);
+      // Plain .md without Cairn frontmatter — adopt it in-place
+      if (!note) note = adoptExternalNoteFile(db, workspacePath, fp);
       if (!note) continue;
       // Only upsert if the note is missing from SQLite — avoids overwriting
       // in-memory state that is ahead of the file (e.g. unsaved edits).
@@ -263,7 +265,6 @@ function syncDir(db: Database.Database, dir: string): void {
     }
   }
 }
-
 // ── Upsert a parsed note into SQLite ──────────
 //
 // Uses INSERT OR IGNORE + UPDATE to avoid UNIQUE constraint errors when the
@@ -333,8 +334,24 @@ export function adoptExternalNoteFile(
       projectName:   project.name,
     };
 
-    // Write Cairn frontmatter back to the file so future reads recognise it
-    writeNoteFile(workspacePath, note);
+    // Write Cairn frontmatter back IN-PLACE to the original file path.
+    // We must NOT use writeNoteFile() here — that function resolves a new
+    // slug-based path from the title, which would create a second file and
+    // leave the original orphaned with no frontmatter.
+    const frontmatter: Record<string, unknown> = {
+      id,
+      projectId:     project.id,
+      workspaceId:   project.workspace_id,
+      title,
+      folder,
+      tagIds:        [],
+      linkedNoteIds: [],
+      linkedCardIds: [],
+      isPinned:      false,
+      createdAt:     now,
+      updatedAt:     now,
+    };
+    fs.writeFileSync(filePath, matter.stringify(content, frontmatter), "utf-8");
 
     return note;
   } catch {


### PR DESCRIPTION
## What does this PR do?

Fixes two regressions in external `.md` file adoption (files present at startup were ignored; copy/paste caused both files to lose their identity), and fixes the Playwright browser cache never hitting in CI.

## Type of change

- [x] Bug fix

## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes (452 tests across 10 files)
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only
- [x] No `text-[Npx]` pixel font classes
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] No new DB migrations (schema unchanged)
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

- `adoptExternalNoteFile` previously called `writeNoteFile()` which resolves a slug-based path from the title — this created a second file and left the original without frontmatter. It now writes directly to the `filePath` argument with `matter.stringify` + `fs.writeFileSync`.
- `syncDir` now has a `workspacePath` parameter threaded through from `syncNotesFromDisk`. Previously only the file watcher called `adoptExternalNoteFile`; startup sync did not.
- The Playwright fix separates browser binary caching (conditioned on cache miss) from OS system dep installation (always runs, fast). These cannot share a single `--with-deps` invocation if you want caching to be effective.