### PR TITLE
feat: ⌘F / ⌘⇧F search shortcuts across all views

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -364,7 +364,7 @@ Shared modules live in `src/components/graph/`: `analyticsUtils.ts`, `analyticsH
 | `src/components/agent/FileTree.tsx` | Lazy-expanding directory tree; direct `pickDirectory` → `updateProject` |
 | `src/components/agent/TerminalManager.ts` | Module-scope singleton — holds xterm Terminal + FitAddon per session |
 | `src/components/agent/SpawnAgentModal.tsx` | Spawn dialog — optional card, ad-hoc sessions, prompt editor |
-| `src/components/agent/editorTheme.ts` | Shared CM6 `buildTheme(fontScale)` + `buildHighlightStyle(isDark)` |
+| `src/components/agent/editorTheme.ts` | Shared CM6 `buildTheme(fontScale)` + `buildHighlightStyle(isDark)` + `buildSearchTheme()` — search panel CSS overrides used by both editors |
 | `src/components/agent/ImageViewer.tsx` | Image renderer via base64 IPC (avoids `file://` CSP restriction) |
 | `src/components/insights/InsightsView.tsx` | Insights view — hosts all analytics canvases with shared toolbar |
 | `src/components/graph/analyticsUtils.ts` | Shared constants + pure helpers for analytics canvases |
@@ -469,7 +469,8 @@ The Agent workspace has its own IPC namespace (`agent:*`) entirely separate from
 - **PTY sessions** — spawned in `electron/ipc/agent.ts` via `node-pty`. `node-pty` must be `--external` in esbuild and rebuilt for the Electron ABI via `npm run rebuild`. PTY output streams to the renderer via `ipcMain.emit('agent:data', ...)`.
 - **File I/O security** — every `readFile`, `readDir`, `writeFile`, and `readFileBase64` call goes through `assertWithinCodeDirectory(db, path)` before touching the filesystem. This validates the path against all registered `code_directory` values in the `projects` table. Never skip this check when adding new file IPC handlers.
 - **Renderer terminal** — `TerminalManager` (module-scope singleton) holds `xterm.js` Terminal + FitAddon instances. Sessions survive view navigation because the singleton is never garbage-collected. Font size updates must set `terminal.options.fontSize` and call `fitAddon.fit()` via `requestAnimationFrame` (one frame needed for cell remeasure).
-- **CM6 editor** — one `EditorView` instance per open file, CSS-hidden when inactive. `buildTheme(fontScale)` in `editorTheme.ts` accepts `fontScale` so the editor respects the user's font size setting. CM6 `HighlightStyle.define` requires static colour strings — CSS variables cannot be used there (documented in `editorTheme.ts`).
+- **CM6 editor** — one `EditorView` instance per open file, CSS-hidden when inactive. `buildTheme(fontScale)` in `editorTheme.ts` accepts `fontScale` so the editor respects the user's font size setting. CM6 `HighlightStyle.define` requires static colour strings — CSS variables cannot be used there (documented in `editorTheme.ts`). The editor includes a find/replace panel via `@codemirror/search` (`⌘F`); `buildSearchTheme()` must be appended **after** `buildTheme()` in the extensions array to override CM6's default `.cm-button`/`.cm-textfield` gradient styles with Cairn CSS variables.
+- **File search** — `agent:searchFiles` IPC (registered in `electron/ipc/agent.ts`) recursively walks the `code_directory` for filename matches, triggered by `⌘⇧F` in `FileTree.tsx` via a capture-phase listener that fires before the global `page.tsx` handler. Subject to the same `assertWithinCodeDirectory` security check as all file operations. Returns up to 50 results; skips `node_modules`, `.git`, `.next`, `dist*`, and similar build directories.
 - **`code_directory`** — stored on the `projects` table (migration v10). Set from the Project Overview inline row, not from AgentSettings. Written via the generic `db:project:update` IPC channel.
 
 ### Adding a new analytics canvas

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Cairn is a desktop app (Electron + Next.js) that combines markdown notes with a 
 - **Kanban board** — Drag-and-drop cards across columns with priority indicators
 - **Drag notes into folders** — Drag any note in the sidebar directly onto a folder row to move it; a "Move to root" drop zone appears while dragging
 - **Linked context** — Notes and cards reference each other bidirectionally
-- **Global search** — Instant full-text search across all notes and tasks (`⌘K`)
+- **Global search** — Instant full-text search across all notes and tasks (`⌘K` or `⌘⇧F`)
 - **AI chat** — Integrated assistant with live project context; reads and writes your data (`⌘/`); supports inline `ask_questions` forms for structured clarification
 - **Interactive PRD generation** — Describe what you want to build; the agent reads your project context, asks targeted clarifying questions via an inline form, then writes and saves a full PRD to your notes
 - **Idea Flow** — A freeform node canvas per project (`⌘4`): add idea, note reference, task reference, group, URL, and AI summary nodes; connect them with labelled edges; the AI and MCP can read and write the canvas as first-class authors
 - **Live dashboards** — Ask the AI to generate an interactive HTML dashboard for any project; choose from a template gallery or start blank; dashboards fetch live data on every load via a sandboxed `window.cairn.query()` bridge; runtime errors surface an inline "Fix with AI" button; HTML editable directly via a built-in CodeMirror overlay
 - **MCP server** — Exposes your workspace to external AI agents (OpenCode, Claude Desktop, etc.) via the Model Context Protocol
-- **Agent workspace** — Dedicated three-pane view (`⌘5`) for running AI coding agents (Claude Code, OpenCode, Aider, or any CLI binary) connected directly to project tasks. Spawn from a kanban card or ad-hoc. Includes a resizable file tree, multi-file CodeMirror 6 editor (syntax highlighting, ⌘S save, markdown preview, image viewer), xterm.js terminal with persistent sessions, and a git diff viewer (unified / split / changes-only modes with syntax highlighting)
+- **Agent workspace** — Dedicated three-pane view (`⌘5`) for running AI coding agents (Claude Code, OpenCode, Aider, or any CLI binary) connected directly to project tasks. Spawn from a kanban card or ad-hoc. Includes a resizable file tree with `⌘⇧F` filename search, multi-file CodeMirror 6 editor (syntax highlighting, `⌘S` save, `⌘F` find/replace, markdown preview, image viewer), xterm.js terminal with persistent sessions, and a git diff viewer (unified / split / changes-only modes with syntax highlighting)
 - **Knowledge Graph** — Workspace-wide graph of every note, card, project, and tag; Force-directed and Radial tree layouts; auto-discovered relationships (`⌘6`)
 - **Insights** — Analytics view: Ridgeline joy plot, Beeswarm, Bullet health bars, Sankey pipeline flow, Timeline, Matrix heatmap, Table (`⌘7`)
 - **Font scaling** — Five-step UI font size preference (XS–XL, default M) in Settings → General
@@ -196,17 +196,33 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 |------|----------|-------------|
 | `create_dashboard` | write | Create a live HTML dashboard in a project |
 | `update_dashboard` | write | Update an existing dashboard's title or HTML |
+| `get_dashboard_constants` | read | Returns the `window.cairn` query API reference for building dashboards |
 
 **Idea Flow**
 
 | Tool | Category | Description |
 |------|----------|-------------|
 | `get_idea_flow` | read | Full Idea Flow graph: nodes (with resolved note/task content) + edges |
+| `get_idea_flow_rules` | read | Returns node type conventions, data shapes, group rules, and positioning tips |
 | `create_idea_flow_node` | write | Add a node to the canvas (idea, note_ref, task_ref, group, url, ai_summary) |
 | `update_idea_flow_node` | write | Update a node's data and/or position (data fields are merged) |
+| `layout_idea_flow` | write | Auto-arrange all nodes with Dagre. Call after bulk-creating nodes |
 | `create_idea_flow_edge` | write | Connect two nodes with an optional label |
 | `delete_idea_flow_node` | delete | Remove a node and its connected edges |
 | `delete_idea_flow_edge` | delete | Remove a connection |
+
+**Knowledge Graph**
+
+| Tool | Category | Description |
+|------|----------|-------------|
+| `get_knowledge_graph` | read | Full workspace graph: projects, notes, cards, tags as nodes + edges |
+| `get_neighbors` | read | N-hop neighbourhood around a single node |
+
+**Tags**
+
+| Tool | Category | Description |
+|------|----------|-------------|
+| `create_tag` | write | Create a workspace tag with a name and hex colour |
 
 > **Agent tip:** call `get_cairn_context` at the start of a session for all workspace/project/column IDs. Use `list_ready_tasks` instead of `list_tasks` when you want to know what work can actually start — it filters out anything blocked by an unresolved dependency.
 
@@ -215,6 +231,9 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | Shortcut | Action |
 |----------|--------|
 | `⌘K` | Open global search |
+| `⌘⇧F` | Global search (any view) / File search in Agent view sidebar |
+| `⌘F` | In-context search — find/replace in Note or Agent editor; filter in Notes list, Board, or Knowledge Graph |
+| `⌘N` | New note (switches to Notes view) |
 | `⌘/` | Toggle AI chat |
 | `⌘\` | Toggle sidebar |
 | `⌘1` | Project overview |
@@ -227,11 +246,11 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 | `⌘S` | Save file (Agent editor) |
 | `⌘Z` | Undo |
 | `⌘⇧Z` / `⌘Y` | Redo |
-| `Esc` | Close modal / search |
+| `Esc` | Close modal / search / filter bar |
 
 ## Architecture
 
-Cairn is an Electron + Next.js desktop app with three independent processes sharing a single SQLite database (WAL mode):
+Cairn is an Electron + Next.js desktop app with two processes that share a single SQLite database (WAL mode), plus a separately-invokable MCP binary for external agent access:
 
 - **Renderer** (`src/`) — React/Next.js. Never touches the filesystem or database directly. All data flows through IPC via `window.electron.*`.
 - **Main process** (`electron/`) — Node.js. Owns SQLite, file I/O, the AI chat loop, and PTY sessions for coding agents.
@@ -319,6 +338,7 @@ The E2E suite runs against the Next.js dev server with a full `window.electron` 
 | Tool | Role |
 |------|------|
 | CodeMirror 6 | Note editor + Agent file editor (CM6, CSS-hidden-per-tab pattern) |
+| @codemirror/search | In-editor find/replace panel (`⌘F`) |
 | node-pty | PTY process spawning (Agent terminal) |
 | @xterm/xterm | Terminal emulator (Agent view) |
 | @xterm/addon-fit | Terminal auto-resize |

--- a/changelogs/v1.1.3.md
+++ b/changelogs/v1.1.3.md
@@ -1,0 +1,53 @@
+# v1.1.3
+
+## New feature: Search shortcuts
+
+Keyboard-driven search is now available across every major view.
+
+### `⌘F` / `Ctrl+F` — in-context search
+
+| View | Behaviour |
+|------|-----------|
+| Note editor | Opens the CodeMirror find/replace panel (find, replace, regex, case-sensitive, whole-word). `Esc` closes it. |
+| Agent file editor | Same CodeMirror find/replace panel. |
+| Notes list | Focuses the existing filter input in the sidebar. When the editor is focused, `⌘F` is passed through to CodeMirror rather than intercepted. |
+| Kanban board | Opens a filter bar above the columns. Cards are filtered live across all columns. A match count badge shows the total. `Esc` closes the bar and clears the filter. |
+| Knowledge Graph | Focuses the existing node search input (force and radial layouts only). |
+
+### `⌘⇧F` / `Ctrl+⇧F` — higher-level search
+
+| View | Behaviour |
+|------|-----------|
+| Any view except Agent | Opens the workspace-wide search overlay (previously only reachable via `⌘K`). `⌘K` still works. |
+| Agent view | Opens file search in the file tree sidebar (see below). |
+
+### Agent view: file search (`⌘⇧F`)
+
+A new file search mode in the Agent view file tree sidebar. Pressing `⌘⇧F` replaces the directory header with a search input. Typing runs a recursive filename search on the main process — skipping `node_modules`, `.git`, `dist`, `.next`, and other build directories — and returns up to 50 matching files as a flat list. Each result shows the filename and its relative directory path. Clicking a result opens it in the editor and closes search mode. `Esc` or the `✕` button returns to the tree.
+
+A search icon button in the normal file tree header also triggers file search mode.
+
+---
+
+## CodeMirror search panel theming
+
+The built-in CodeMirror search panel is now fully themed to match Cairn's design tokens. Previously it rendered with raw browser-default styles (gradient buttons, silver borders). It now uses `var(--surface-2)` backgrounds, `var(--border)` borders, `var(--accent)` focus rings, and `var(--accent)` highlight colours for search matches. The panel is consistent between the note editor and the agent file editor, and adapts automatically to light and dark themes.
+
+---
+
+## Changed files
+
+| File | Change |
+|------|--------|
+| `electron/ipc/agent.ts` | New `agent:searchFiles` IPC handler — recursive walk with configurable skip list, capped at 50 results, gated by `assertWithinCodeDirectory` |
+| `electron/preload.ts` | Exposed `agent.searchFiles` on `window.electron` |
+| `src/app/globals.css` | Global CM6 search panel styles — fallback layer ensuring correct theming before runtime theme injection and for editors that use only the global stylesheet |
+| `src/app/page.tsx` | `⌘⇧F` added as alias for global search; yields to Agent view's capture-phase handler |
+| `src/components/agent/editorTheme.ts` | `buildSearchTheme()` — scoped CM6 theme overriding base button/input gradients with Cairn tokens; `{ dark: false }` added to `buildTheme()` for consistent light/dark variant resolution |
+| `src/components/agent/FileEditorInner.tsx` | `@codemirror/search` extensions and `buildSearchTheme()` added |
+| `src/components/agent/FileTree.tsx` | File search mode: toggle, search input, IPC call, flat results list with filename + relative path; closes on file click; `⌘⇧F` handled in capture phase |
+| `src/components/graph/KnowledgeGraphView.tsx` | `⌘F` focuses existing node search input |
+| `src/components/kanban/board.tsx` | Filter bar with live card filtering and match count; `⌘F` opens it; `Esc` closes via functional state updater |
+| `src/components/notes/markdown-editor.tsx` | `@codemirror/search` extensions added; imports `buildSearchTheme()` from `editorTheme.ts` |
+| `src/components/notes/notes-view.tsx` | `⌘F` focuses filter input; guarded against firing when CM6 editor is focused |
+| `package.json` / `package-lock.json` | Added `@codemirror/search` |

--- a/electron/ipc/agent.ts
+++ b/electron/ipc/agent.ts
@@ -123,6 +123,39 @@ export function registerAgentHandlers(db: Database): void {
     })
   );
 
+  ipcMain.handle("agent:searchFiles", (_e, { dirPath, query }: { dirPath: string; query: string }) =>
+    handle(() => {
+      assertWithinCodeDirectory(db, dirPath);
+      const q = query.toLowerCase();
+      const results: { name: string; path: string; relativePath: string }[] = [];
+      const SKIP_DIRS = new Set(["node_modules", ".git", ".next", "dist", "dist-electron", "dist-mcp", "dist-app", "out", ".cache", "coverage", "__pycache__", ".venv", "venv"]);
+      const MAX_RESULTS = 50;
+
+      function walk(dir: string, relDir: string) {
+        if (results.length >= MAX_RESULTS) return;
+        let entries: fs.Dirent[];
+        try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+        catch { return; }
+        for (const e of entries) {
+          if (results.length >= MAX_RESULTS) return;
+          if (e.name.startsWith(".")) continue;
+          const fullPath = path.join(dir, e.name);
+          const relPath = relDir ? `${relDir}/${e.name}` : e.name;
+          if (e.isDirectory()) {
+            if (!SKIP_DIRS.has(e.name)) walk(fullPath, relPath);
+          } else {
+            if (e.name.toLowerCase().includes(q)) {
+              results.push({ name: e.name, path: fullPath, relativePath: relPath });
+            }
+          }
+        }
+      }
+
+      walk(dirPath, "");
+      return results;
+    })
+  );
+
   ipcMain.handle("agent:readFile", (_e, { filePath }: { filePath: string }) =>
     handle(() => {
       assertWithinCodeDirectory(db, filePath);

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -522,6 +522,8 @@ export function registerAppHandlers(
   updateTrayBadge: (count: number) => void,
   win?: BrowserWindow,
   onReinitialise?: (newWorkspacePath: string) => Promise<void>,
+  /** Called when the badge is cleared from the renderer — resets poller count too. */
+  onBadgeClear?: () => void,
 ): void {
   // ── Workspace folder selection / setup ────────────
   ipcMain.handle("app:selectWorkspaceFolder", async () => {
@@ -627,6 +629,7 @@ export function registerAppHandlers(
   ipcMain.handle("mcp:markNotificationsRead", () => handle(() => {
     markMcpNotificationsRead(db);
     updateTrayBadge(0);
+    onBadgeClear?.();
   }));
 
   // ── Export note as PDF ─────────────────────────────

--- a/electron/lib/mcp-poller.ts
+++ b/electron/lib/mcp-poller.ts
@@ -18,15 +18,21 @@ export interface McpPollerOptions {
   onDbChanged: () => void;
 }
 
+export interface McpPoller {
+  /** Reset the accumulated unread count to zero (call when the badge is cleared). */
+  resetCount: () => void;
+}
+
 export function startMcpNotificationPoller({
   db,
   dbPath,
   win: _win,
   updateBadge,
   onDbChanged,
-}: McpPollerOptions): void {
+}: McpPollerOptions): McpPoller {
   const walPath = dbPath + "-wal";
   let lastMtime = 0;
+  // Accumulated unread count — incremented on new notifications, reset via resetCount()
   let unreadCount = 0;
 
   try {
@@ -57,4 +63,8 @@ export function startMcpNotificationPoller({
   }
 
   setInterval(check, 1000);
+
+  return {
+    resetCount: () => { unreadCount = 0; },
+  };
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -234,30 +234,29 @@ app.whenReady().then(async () => {
   // ── System tray ───────────────────────────────────────────────────────
   const { updateBadge } = createTray(win);
 
-  // Clear badge when window gains focus
-  let unreadCount = 0;
-  win.on("focus", () => {
-    if (unreadCount > 0) {
-      markMcpNotificationsRead(ctx.db);
-      updateBadge(0);
-      unreadCount = 0;
-    }
-  });
-
-  // Register app:* and mcp:* IPC handlers (now that updateBadge is available)
-  registerAppHandlers(ctx.db, userDataPath, updateBadge, win, reinitialise);
-
   // ── MCP notification poller ───────────────────────────────────────────
-  startMcpNotificationPoller({
+  const poller = startMcpNotificationPoller({
     db: ctx.db,
     dbPath: initialDbPath,
     win,
-    updateBadge: (count) => {
-      unreadCount = count;
-      updateBadge(count);
-    },
+    updateBadge,
     onDbChanged: notifyDbChanged,
   });
+
+  // Shared reset — clears DB rows, badge, and the poller's accumulated count.
+  // Called from both the window focus event and the renderer IPC handler so
+  // the next batch of notifications always starts from 0.
+  function clearBadge() {
+    markMcpNotificationsRead(ctx.db);
+    updateBadge(0);
+    poller.resetCount();
+  }
+
+  // Clear badge when window gains focus
+  win.on("focus", clearBadge);
+
+  // Register app:* and mcp:* IPC handlers (now that updateBadge is available)
+  registerAppHandlers(ctx.db, userDataPath, updateBadge, win, reinitialise, clearBadge);
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -214,6 +214,7 @@ const api = {
     setDefaultAgent: (id: string) => invoke("agent:setDefaultAgent", { id }),
 
     readDir: (dirPath: string) => invoke("agent:readDir", { dirPath }),
+    searchFiles: (dirPath: string, query: string) => invoke<{ name: string; path: string; relativePath: string }[]>("agent:searchFiles", { dirPath, query }),
     readFile: (filePath: string) => invoke<string>("agent:readFile", { filePath }),
     readFileBase64: (filePath: string) => invoke<string>("agent:readFileBase64", { filePath }),
     writeFile: (filePath: string, content: string) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.2",
       "hasInstallScript": true,
       "dependencies": {
+        "@codemirror/search": "^6.7.0",
         "@dagrejs/dagre": "^3.0.0",
         "@radix-ui/react-context-menu": "^2.2.16",
         "@types/d3-hierarchy": "^3.1.7",
@@ -855,11 +856,21 @@
         "crelt": "^1.0.5"
       }
     },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
     "node_modules/@codemirror/state": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
       "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
@@ -869,7 +880,6 @@
       "version": "6.41.1",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
       "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.6.0",
@@ -3058,7 +3068,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@mermaid-js/parser": {
@@ -8648,7 +8657,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-dirname": {
@@ -17709,7 +17717,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/style-to-js": {
@@ -19099,7 +19106,6 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wait-on": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "postcss": "^8.5.10"
   },
   "dependencies": {
+    "@codemirror/search": "^6.7.0",
     "@dagrejs/dagre": "^3.0.0",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@types/d3-hierarchy": "^3.1.7",

--- a/scripts/generate-licenses.js
+++ b/scripts/generate-licenses.js
@@ -71,6 +71,9 @@ const ROLE_MAP = {
   // ── Editor ──────────────────────────────────────────────────────────────────
   "@codemirror/view":              ["CodeMirror 6",        "Note editor",                 "Editor"],
   "@codemirror/state":             ["CodeMirror state",    "Editor state model",          "Editor"],
+  "@codemirror/search":            ["CM search",           "In-editor find/replace panel","Editor"],
+  "@codemirror/commands":          ["CM commands",         "Keybindings & history",       "Editor"],
+  "@codemirror/language":          ["CM language",         "Syntax highlighting support", "Editor"],
   "@codemirror/lang-markdown":     ["CM Markdown",         "Markdown language support",   "Editor"],
   "@lezer/highlight":              ["Lezer",               "Syntax tree highlighter",     "Editor"],
   "react-markdown":                ["react-markdown",      "Markdown render",             "Editor"],

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -359,3 +359,78 @@ body {
 .prose-cairn td { padding: 0.35rem 0.6rem; border: 1px solid var(--border); }
 .prose-cairn tr:nth-child(even) td { background: var(--surface-2); }
 
+/* ── CodeMirror 6 search panel ───────────────────────────────────────────── */
+/* Global overrides — EditorView.theme() alone can lose to CM6's base sheet. */
+
+.cm-search {
+  background: var(--surface-1, var(--surface)) !important;
+  border-top: 1px solid var(--border) !important;
+  padding: 5px 10px !important;
+  display: flex !important;
+  align-items: center !important;
+  gap: 4px !important;
+  flex-wrap: wrap !important;
+}
+
+.cm-search label {
+  font-size: 0.75rem !important;
+  color: var(--text-secondary) !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 4px !important;
+  margin: 0 !important;
+}
+
+.cm-search input[type=checkbox] {
+  margin: 0 !important;
+  accent-color: var(--accent) !important;
+  width: 12px !important;
+  height: 12px !important;
+}
+
+.cm-search input.cm-textfield {
+  background: var(--surface-2) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 4px !important;
+  color: var(--text-primary) !important;
+  font-size: 0.8rem !important;
+  padding: 3px 7px !important;
+  outline: none !important;
+  box-shadow: none !important;
+  font-family: inherit !important;
+}
+
+.cm-search input.cm-textfield:focus {
+  border-color: var(--accent) !important;
+}
+
+.cm-search button.cm-button {
+  background: var(--surface-2) !important;
+  background-image: none !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 4px !important;
+  color: var(--text-primary) !important;
+  font-size: 0.75rem !important;
+  padding: 3px 8px !important;
+  cursor: pointer !important;
+  box-shadow: none !important;
+  font-family: inherit !important;
+  vertical-align: middle !important;
+}
+
+.cm-search button.cm-button:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent) !important;
+  border-color: var(--accent) !important;
+  color: var(--accent) !important;
+}
+
+.cm-searchMatch {
+  background: color-mix(in srgb, var(--accent) 25%, transparent) !important;
+  border-radius: 2px !important;
+  outline: none !important;
+}
+
+.cm-searchMatch.cm-searchMatch-selected {
+  background: color-mix(in srgb, var(--accent) 50%, transparent) !important;
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -169,6 +169,7 @@ export default function Home() {
       const inInput = tag === "INPUT" || tag === "TEXTAREA" || (e.target as HTMLElement)?.isContentEditable;
 
       if (mod && key === "k") { e.preventDefault(); toggleSearch(); }
+      else if (mod && e.shiftKey && key.toLowerCase() === "f") { if (activeView !== "agent") { e.preventDefault(); toggleSearch(); } }
       else if (mod && key === "/") { e.preventDefault(); if (aiEnabled) toggleChat(); }
       else if (mod && key === "\\") { e.preventDefault(); toggleSidebar(); }
       else if (mod && key === "1") { e.preventDefault(); setView("overview"); }

--- a/src/components/agent/FileEditorInner.tsx
+++ b/src/components/agent/FileEditorInner.tsx
@@ -9,9 +9,10 @@ import { useEffect, useRef, useState } from "react";
 import { EditorView, keymap } from "@codemirror/view";
 import { EditorState } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { search, searchKeymap } from "@codemirror/search";
 import { LanguageDescription } from "@codemirror/language";
 import { languages } from "@codemirror/language-data";
-import { buildTheme, buildHighlightStyle, lineNumbers } from "./editorTheme";
+import { buildTheme, buildHighlightStyle, buildSearchTheme, lineNumbers } from "./editorTheme";
 
 export interface FileEditorInnerProps {
   filePath: string;
@@ -50,12 +51,14 @@ export function FileEditorInner({ filePath, isActive, isDark, onDirtyChange, onS
           doc: content,
           extensions: [
             buildTheme(fontScale),
+            buildSearchTheme(),
             buildHighlightStyle(isDark),
             lineNumbers(),
             history(),
             keymap.of([
               ...defaultKeymap,
               ...historyKeymap,
+              ...searchKeymap,
               {
                 key: "Mod-s",
                 run: (view) => {
@@ -64,6 +67,7 @@ export function FileEditorInner({ filePath, isActive, isDark, onDirtyChange, onS
                 },
               },
             ]),
+            search({ top: false }),
             EditorView.lineWrapping,
             EditorView.updateListener.of((update) => {
               if (update.docChanged) onDirtyChange(pathRef.current, true);

--- a/src/components/agent/FileTree.tsx
+++ b/src/components/agent/FileTree.tsx
@@ -7,10 +7,10 @@
  * Expand/collapse directories on click. File click sets activeEditorFile.
  */
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   ChevronRight, ChevronDown, FolderOpen, Folder,
-  FileText, FileCode, FileJson, Settings, AlertCircle,
+  FileText, FileCode, FileJson, Settings, AlertCircle, Search, X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCairnStore } from "@/store";
@@ -135,10 +135,23 @@ interface FileTreeProps {
   project: Project | null;
 }
 
+interface SearchResult {
+  name: string;
+  path: string;
+  relativePath: string;
+}
+
 export function FileTree({ project }: FileTreeProps) {
   const { activeEditorFile, openEditorFile, updateProject } = useCairnStore(useShallow((s) => ({ activeEditorFile: s.activeEditorFile, openEditorFile: s.openEditorFile, updateProject: s.updateProject })));
   const [rootEntries, setRootEntries] = useState<DirEntry[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // File search mode
+  const [searchActive, setSearchActive] = useState(false);
+  const [searchQuery, setSearchQuery]   = useState("");
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [searching, setSearching]       = useState(false);
+  const searchInputRef                  = useRef<HTMLInputElement>(null);
 
   const codeDirectory = project?.codeDirectory ?? null;
 
@@ -149,6 +162,48 @@ export function FileTree({ project }: FileTreeProps) {
       ?.then((entries) => setRootEntries(entries))
       .catch((e: unknown) => setError(String(e)));
   }, [codeDirectory]);
+
+  // ⌘⇧F / Ctrl+⇧F — toggle file search
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const mod = e.metaKey || e.ctrlKey;
+      // e.key is "F" (uppercase) when Shift is held on most platforms,
+      // but normalise to lowercase to be safe across keyboard layouts.
+      const key = e.key.toLowerCase();
+      if (mod && e.shiftKey && key === "f") {
+        e.preventDefault();  // always prevent — even if no codeDirectory, avoid native find-in-page
+        e.stopPropagation();
+        if (!codeDirectory) return;
+        setSearchActive((v) => {
+          const next = !v;
+          if (!next) { setSearchQuery(""); setSearchResults([]); }
+          return next;
+        });
+        setTimeout(() => searchInputRef.current?.focus(), 0);
+      } else if (e.key === "Escape") {
+        setSearchActive((v) => {
+          if (v) { setSearchQuery(""); setSearchResults([]); }
+          return false;
+        });
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown, true); // capture phase — fires before page.tsx
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [codeDirectory]);
+
+  // Run search whenever query changes
+  useEffect(() => {
+    if (!searchActive || !codeDirectory || !searchQuery.trim()) {
+      setSearchResults([]);
+      return;
+    }
+    const q = searchQuery.trim();
+    setSearching(true);
+    (window.electron?.agent.searchFiles(codeDirectory, q) as Promise<SearchResult[]> | undefined)
+      ?.then((results) => setSearchResults(results ?? []))
+      .catch(() => setSearchResults([]))
+      .finally(() => setSearching(false));
+  }, [searchQuery, searchActive, codeDirectory]);
 
   async function handlePickCodeDir() {
     if (!project) return;
@@ -192,28 +247,91 @@ export function FileTree({ project }: FileTreeProps) {
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
       {/* Header */}
-      <div className="flex items-center gap-1.5 px-3 py-2 border-b border-[var(--border-subtle)] flex-shrink-0">
-        <FolderOpen size={12} className="text-[var(--text-tertiary)]" />
-        <span className="text-[0.714rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] truncate">
-          {codeDirectory.split("/").pop() ?? "Files"}
-        </span>
-      </div>
-
-      {/* Tree */}
-      <div className="flex-1 overflow-y-auto py-1">
-        {rootEntries.map((entry) => (
-          <TreeNode
-            key={entry.path}
-            entry={entry}
-            depth={0}
-            activePath={activeEditorFile}
-            onFileClick={openEditorFile}
+      {searchActive ? (
+        <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-[var(--border-subtle)] flex-shrink-0">
+          <Search size={11} className="text-[var(--text-tertiary)] flex-shrink-0" />
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search files…"
+            className="flex-1 min-w-0 bg-transparent text-[0.786rem] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] outline-none"
           />
-        ))}
-        {rootEntries.length === 0 && (
-          <p className="text-xs text-[var(--text-tertiary)] px-3 py-4 text-center">
-            Directory is empty
-          </p>
+          <button
+            onClick={() => { setSearchActive(false); setSearchQuery(""); setSearchResults([]); }}
+            className="flex-shrink-0 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
+          >
+            <X size={11} />
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-1.5 px-3 py-2 border-b border-[var(--border-subtle)] flex-shrink-0">
+          <FolderOpen size={12} className="text-[var(--text-tertiary)]" />
+          <span className="text-[0.714rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] truncate flex-1">
+            {codeDirectory.split("/").pop() ?? "Files"}
+          </span>
+          <button
+            onClick={() => { setSearchActive(true); setTimeout(() => searchInputRef.current?.focus(), 0); }}
+            className="text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
+            title="Search files (⌘⇧F)"
+          >
+            <Search size={11} />
+          </button>
+        </div>
+      )}
+
+      {/* Body — search results or file tree */}
+      <div className="flex-1 overflow-y-auto py-1">
+        {searchActive ? (
+          <>
+            {searching && (
+              <p className="text-[0.714rem] text-[var(--text-tertiary)] px-3 py-2">Searching…</p>
+            )}
+            {!searching && searchQuery.trim() && searchResults.length === 0 && (
+              <p className="text-[0.714rem] text-[var(--text-tertiary)] px-3 py-4 text-center">No files found</p>
+            )}
+            {!searching && !searchQuery.trim() && (
+              <p className="text-[0.714rem] text-[var(--text-tertiary)] px-3 py-4 text-center">Type to search files</p>
+            )}
+            {searchResults.map((result) => (
+              <button
+                key={result.path}
+                onClick={() => { openEditorFile(result.path); setSearchActive(false); setSearchQuery(""); setSearchResults([]); }}
+                className={cn(
+                  "flex flex-col w-full px-3 py-1 text-left transition-colors rounded-sm",
+                  activeEditorFile === result.path
+                    ? "text-[var(--accent)] bg-[var(--accent-dim)]"
+                    : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]"
+                )}
+              >
+                <span className="text-[0.786rem] truncate flex items-center gap-1.5">
+                  <FileIcon name={result.name} size={11} />
+                  {result.name}
+                </span>
+                <span className="text-[0.714rem] text-[var(--text-tertiary)] truncate pl-4">
+                  {result.relativePath.split("/").slice(0, -1).join("/") || "."}
+                </span>
+              </button>
+            ))}
+          </>
+        ) : (
+          <>
+            {rootEntries.map((entry) => (
+              <TreeNode
+                key={entry.path}
+                entry={entry}
+                depth={0}
+                activePath={activeEditorFile}
+                onFileClick={openEditorFile}
+              />
+            ))}
+            {rootEntries.length === 0 && (
+              <p className="text-xs text-[var(--text-tertiary)] px-3 py-4 text-center">
+                Directory is empty
+              </p>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/components/agent/editorTheme.ts
+++ b/src/components/agent/editorTheme.ts
@@ -82,6 +82,77 @@ export function buildTheme(fontScale = 1) {
     ".cm-lineNumbers .cm-gutterElement": { padding: "0 8px" },
     ".cm-activeLine": { background: "color-mix(in srgb, var(--accent) 5%, transparent)" },
     ".cm-activeLineGutter": { background: "color-mix(in srgb, var(--accent) 8%, transparent)" },
+  }, { dark: false });
+}
+
+// ── Search panel theme ─────────────────────────────────────────────────────
+// Must be appended after buildTheme() in the extensions array to win the
+// source-order race against CM6's own .cm-button / .cm-textfield base styles.
+export function buildSearchTheme() {
+  return EditorView.theme({
+    ".cm-search": {
+      background: "var(--surface-1, var(--surface)) !important",
+      borderTop: "1px solid var(--border) !important",
+      padding: "5px 10px !important",
+      display: "flex !important",
+      alignItems: "center !important",
+      gap: "4px !important",
+      flexWrap: "wrap !important",
+    },
+    ".cm-search label": {
+      fontSize: "0.75rem !important",
+      color: "var(--text-secondary) !important",
+      display: "inline-flex !important",
+      alignItems: "center !important",
+      gap: "4px !important",
+      margin: "0 !important",
+    },
+    ".cm-search input[type=checkbox]": {
+      margin: "0 !important",
+      accentColor: "var(--accent) !important",
+      width: "12px !important",
+      height: "12px !important",
+    },
+    ".cm-textfield": {
+      background: "var(--surface-2) !important",
+      border: "1px solid var(--border) !important",
+      borderRadius: "4px !important",
+      color: "var(--text-primary) !important",
+      fontSize: "0.8rem !important",
+      padding: "3px 7px !important",
+      outline: "none !important",
+      boxShadow: "none !important",
+      fontFamily: "inherit !important",
+    },
+    ".cm-textfield:focus": {
+      borderColor: "var(--accent) !important",
+    },
+    ".cm-button": {
+      background: "var(--surface-2) !important",
+      backgroundImage: "none !important",
+      border: "1px solid var(--border) !important",
+      borderRadius: "4px !important",
+      color: "var(--text-primary) !important",
+      fontSize: "0.75rem !important",
+      padding: "3px 8px !important",
+      cursor: "pointer !important",
+      fontFamily: "inherit !important",
+      verticalAlign: "middle !important",
+    },
+    ".cm-button:hover": {
+      background: "color-mix(in srgb, var(--accent) 12%, transparent) !important",
+      backgroundImage: "none !important",
+      borderColor: "var(--accent) !important",
+      color: "var(--accent) !important",
+    },
+    ".cm-searchMatch": {
+      background: "color-mix(in srgb, var(--accent) 25%, transparent) !important",
+      borderRadius: "2px !important",
+      outline: "none !important",
+    },
+    ".cm-searchMatch.cm-searchMatch-selected": {
+      background: "color-mix(in srgb, var(--accent) 50%, transparent) !important",
+    },
   });
 }
 

--- a/src/components/graph/KnowledgeGraphView.tsx
+++ b/src/components/graph/KnowledgeGraphView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useCallback, useState, useMemo } from "react";
+import React, { useEffect, useCallback, useState, useMemo, useRef } from "react";
 import {
   GitBranch, Circle, RefreshCw, ChevronDown, LayoutGrid, Search, Sparkles,
 } from "lucide-react";
@@ -51,6 +51,21 @@ export function KnowledgeGraphView() {
   const [recomputing, setRecomputing] = useState(false);
   const [graphSearch, setGraphSearch] = useState("");
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
+
+  // ⌘F / Ctrl+F — focus the graph search input
+  const graphSearchRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === "f") {
+        if (graphLayout !== "force" && graphLayout !== "radial") return;
+        e.preventDefault();
+        graphSearchRef.current?.focus();
+        graphSearchRef.current?.select();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [graphLayout]);
 
   // Load graph on mount + when workspace changes
   useLoadGraph(activeWorkspaceId);
@@ -237,6 +252,7 @@ export function KnowledgeGraphView() {
             <div className="relative flex items-center">
               <Search size={11} className="absolute left-2.5 text-[var(--text-tertiary)] pointer-events-none" />
               <input
+                ref={graphSearchRef}
                 type="text"
                 value={graphSearch}
                 onChange={(e) => setGraphSearch(e.target.value)}

--- a/src/components/kanban/board.tsx
+++ b/src/components/kanban/board.tsx
@@ -19,7 +19,7 @@ import {
   horizontalListSortingStrategy,
   arrayMove,
 } from "@dnd-kit/sortable";
-import { Plus, Kanban, Archive, Trash2 } from "lucide-react";
+import { Plus, Kanban, Archive, Trash2, Search, X } from "lucide-react";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { Button } from "@/components/ui/button";
@@ -85,6 +85,29 @@ export function KanbanBoard() {
   const [overId, setOverId]                 = useState<string | null>(null);
   const [deleteFlashing, setDeleteFlashing] = useState(false);
   const [hoverZone, setHoverZone]           = useState<"archive" | "delete" | null>(null);
+
+  // Board filter — ⌘F / Ctrl+F toggles and focuses
+  const [boardFilter, setBoardFilter]       = useState("");
+  const [filterVisible, setFilterVisible]   = useState(false);
+  const filterInputRef                      = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === "f") {
+        e.preventDefault();
+        setFilterVisible(true);
+        setTimeout(() => { filterInputRef.current?.focus(); filterInputRef.current?.select(); }, 0);
+      }
+      if (e.key === "Escape") {
+        setFilterVisible((visible) => {
+          if (visible) setBoardFilter("");
+          return false;
+        });
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   // Portal zone rects — computed from the board container when drag starts
   const boardRef    = useRef<HTMLDivElement>(null);
@@ -309,30 +332,73 @@ export function KanbanBoard() {
         onDragEnd={handleDragEnd}
       >
         <div ref={boardRef} className="flex-1 flex flex-col min-h-0 w-full overflow-hidden">
+          {/* Filter bar — shown when ⌘F is pressed */}
+          {filterVisible && (
+            <div className="flex items-center gap-2 px-4 py-2 border-b border-[var(--border)] bg-[var(--surface-1)] flex-shrink-0">
+              <div className="relative flex items-center flex-1 max-w-xs">
+                <Search size={12} className="absolute left-2.5 text-[var(--text-tertiary)] pointer-events-none" />
+                <input
+                  ref={filterInputRef}
+                  type="text"
+                  value={boardFilter}
+                  onChange={(e) => setBoardFilter(e.target.value)}
+                  placeholder="Filter cards…"
+                  className="w-full pl-7 pr-2 py-1.5 text-xs rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent-dim)]"
+                />
+              </div>
+              {boardFilter && (() => {
+                const q = boardFilter.toLowerCase();
+                const matchCount = columns.reduce((n, col) =>
+                  n + getColumnCards(col.id).filter((c) =>
+                    c.title.toLowerCase().includes(q) || (c.description ?? "").toLowerCase().includes(q)
+                  ).length, 0);
+                return (
+                  <span className="text-xs text-[var(--text-tertiary)]">
+                    {matchCount} match{matchCount === 1 ? "" : "es"}
+                  </span>
+                );
+              })()}
+              <button
+                onClick={() => { setBoardFilter(""); setFilterVisible(false); }}
+                className="p-1 rounded hover:bg-[var(--surface-2)] text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
+              >
+                <X size={13} />
+              </button>
+            </div>
+          )}
           <SortableContext items={columns.map((c) => c.id)} strategy={horizontalListSortingStrategy}>
             <div
               ref={boardScrollRef}
               className="flex-1 flex gap-3 overflow-x-auto p-5 min-h-0 transition-all duration-200"
               style={{ paddingTop: activeCard ? ZONE_H + 20 : 20 }}
             >
-              {columns.map((column) => (
-                <div key={column.id} ref={(el) => { columnRefs.current[column.id] = el; }} className="flex-shrink-0">
-                  <KanbanColumn
-                    column={column}
-                    cards={getColumnCards(column.id)}
-                    archivedCards={getArchivedColumnCards(column.id)}
-                    onCardClick={(cardId) => setDetailCardId(cardId)}
-                    onAddCard={(data) => createCard(column.id, activeProjectId, data.title, { dueDate: data.dueDate, assignee: data.assignee })}
-                    onRename={(name) => updateColumn(column.id, { name })}
-                    onSetLimit={(limit) => updateColumn(column.id, { cardLimit: limit ?? undefined })}
-                    onDelete={() => deleteColumn(column.id)}
-                    onRestoreCard={(cardId) => restoreCard(cardId)}
-                    isDragOver={overId === column.id}
-                    isColumnDragging={activeColumn?.id === column.id}
-                    isHighlighted={highlightedColumnId === column.id}
-                  />
-                </div>
-              ))}
+              {columns.map((column) => {
+                const allCards = getColumnCards(column.id);
+                const filteredCards = boardFilter
+                  ? allCards.filter((c) => {
+                      const q = boardFilter.toLowerCase();
+                      return c.title.toLowerCase().includes(q) || (c.description ?? "").toLowerCase().includes(q);
+                    })
+                  : allCards;
+                return (
+                  <div key={column.id} ref={(el) => { columnRefs.current[column.id] = el; }} className="flex-shrink-0">
+                    <KanbanColumn
+                      column={column}
+                      cards={filteredCards}
+                      archivedCards={getArchivedColumnCards(column.id)}
+                      onCardClick={(cardId) => setDetailCardId(cardId)}
+                      onAddCard={(data) => createCard(column.id, activeProjectId, data.title, { dueDate: data.dueDate, assignee: data.assignee })}
+                      onRename={(name) => updateColumn(column.id, { name })}
+                      onSetLimit={(limit) => updateColumn(column.id, { cardLimit: limit ?? undefined })}
+                      onDelete={() => deleteColumn(column.id)}
+                      onRestoreCard={(cardId) => restoreCard(cardId)}
+                      isDragOver={overId === column.id}
+                      isColumnDragging={activeColumn?.id === column.id}
+                      isHighlighted={highlightedColumnId === column.id}
+                    />
+                  </div>
+                );
+              })}
 
               <div className="flex-shrink-0 w-56">
                 <Button

--- a/src/components/notes/markdown-editor.tsx
+++ b/src/components/notes/markdown-editor.tsx
@@ -13,6 +13,8 @@ import { EditorState } from "@codemirror/state";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { languages } from "@codemirror/language-data";
 import { defaultKeymap, indentWithTab, history, historyKeymap } from "@codemirror/commands";
+import { search, searchKeymap } from "@codemirror/search";
+import { buildSearchTheme } from "@/components/agent/editorTheme";
 
 // ── Public handle so parent can read selection for AI toolbar ──────────────
 export interface MarkdownEditorHandle {
@@ -110,6 +112,7 @@ function buildTheme() {
 
     // Active line — very subtle highlight
     ".cm-activeLine": { background: "transparent" },
+
   }, { dark: false });
 }
 
@@ -225,12 +228,14 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(
         doc: initialValue,
         extensions: [
           history(),
-          keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
+          keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab, ...searchKeymap]),
           markdown({
             base: markdownLanguage,
             codeLanguages: languages,
           }),
+          search({ top: false }),
           buildTheme(),
+          buildSearchTheme(),
           cmPlaceholder(placeholder),
           updateListener,
           pasteHandler,

--- a/src/components/notes/notes-view.tsx
+++ b/src/components/notes/notes-view.tsx
@@ -120,6 +120,24 @@ export function NotesView() {
 
   // folder → collapsed state; true = collapsed, undefined/false = open
   const [collapsedFolders, setCollapsedFolders]  = useState<Record<string, boolean>>({});
+
+  // ⌘F / Ctrl+F — focus the filter input, but only when the CM6 editor
+  // is NOT focused (CM6's own searchKeymap handles it when the editor is active).
+  const filterInputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === "f") {
+        const inEditor = document.activeElement?.closest(".cm-editor") !== null;
+        if (inEditor) return; // let CM6 searchKeymap handle it
+        e.preventDefault();
+        filterInputRef.current?.focus();
+        filterInputRef.current?.select();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   // "Move to folder" for a specific note
   const [folderMoveNoteId, setFolderMoveNoteId]  = useState<string | null>(null);
   const [, setFolderMoveDest]       = useState("");
@@ -311,7 +329,7 @@ export function NotesView() {
         <div className="px-2 py-2 border-b border-[var(--border-subtle)]">
           <div className="relative">
             <Search size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-            <input type="text" value={filter} onChange={(e) => setFilter(e.target.value)}
+            <input ref={filterInputRef} type="text" value={filter} onChange={(e) => setFilter(e.target.value)}
               placeholder="Filter notes..."
               className="w-full pl-7 pr-2 py-1.5 text-xs rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent-dim)]" />
           </div>


### PR DESCRIPTION
## What does this PR do?

**Search panel (⌘F):**
- Notes editor: CM6 `@codemirror/search` find/replace panel via `searchKeymap`
- Agent file editor: same CM6 panel via `buildSearchTheme()` in `editorTheme.ts`
- Notes list: ⌘F focuses filter input (guarded: skips when `.cm-editor` is focused)
- Kanban board: ⌘F toggles filter bar with live card filtering + match count
- Knowledge Graph: ⌘F focuses existing node search input in toolbar

**File tree search (⌘⇧F):**
- Agent view: capture-phase handler toggles filename search in FileTree sidebar
- `agent:searchFiles` IPC handler: recursive walk, skips build dirs, capped at 50
- Preload: `agent.searchFiles(dirPath, query)` exposed on `window.electron`

**CM6 search panel theming:**
- `buildSearchTheme()` in `editorTheme.ts` — single source of truth, imported by both editors
- `globals.css` overrides aligned: padding, gap, button gradient reset, checkbox styling

**Docs + changelog:**
- `changelogs/v1.1.3.md`
- `README.md`: shortcuts table, MCP tools, features, architecture, tech stack
- `CONTRIBUTING.md`: `editorTheme.ts` key file description + Agent workspace section
- `scripts/generate-licenses.js`: added `@codemirror/search`, `@codemirror/commands`, `@codemirror/language`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [x] Docs / changelog
- [ ] Tests

## Screenshots / recording

<!-- For any UI change, include a screenshot or short screen recording. Delete this section if not applicable. -->

## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes (452/452)
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts` — N/A, no schema changes
- [x] `mcp-server.ts` changes use inlined SQL only — N/A, no MCP server changes

## Notes for reviewer

- `⌘⇧F` in the Agent view is registered in **capture phase** (`addEventListener(..., true)`) with `stopPropagation()` so it fires before and suppresses the `page.tsx` bubble-phase `⌘⇧F` global search handler.
- `buildSearchTheme()` must be listed **after** `buildTheme()` in the CodeMirror extensions array — `EditorView.theme()` specificity is order-dependent and the search theme's `!important` overrides on `.cm-button` need to win over CM6's own `baseTheme`.
- The hardcoded hex colours in `editorTheme.ts` are pre-existing One Dark/One Light syntax highlight palette entries — not touched by this PR. The "no hardcoded colours" rule applies to UI chrome; syntax tokens are intentionally fixed palette values.
- `e2e` tests not run locally — no new pages or routes introduced, all changes are within existing view components.