### PR TITLE
v1.1.4 - DB sync hardening across the note and task write path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,19 +266,34 @@ Available query tools inside a dashboard: `get_cairn_context`, `get_project_summ
 ```
 Note write (UI / chat / MCP)
   │
-  ├── writeNoteFile()  → <workspace>/notes/<Project>/<Title>.md
-  └── SQLite upsert   → notes table (type='note', content_text re-derived from markdown)
+  ├── writeNoteFile()  → <workspace>/notes/<Project>/<Title>.tmp → rename → .md  (atomic)
+  └── SQLite upsert   → notes table (type='note', content_text re-derived from markdown,
+                         version = version + 1)
 
 Dashboard write (chat / MCP — create_dashboard / update_dashboard)
   │
   └── SQLite upsert   → notes table (type='dashboard', content = raw HTML)
                         (no .md file written — HTML is not markdown)
 
-External .md edit
+External .md edit (live)
   │
   └── chokidar watcher → parseNoteFile() → upsertNoteFromFile() → SQLite
                                                                  → db:changed → renderer refresh
+
+External .md edit (startup — Cairn was closed)
+  │
+  └── syncNotesFromDisk() → compare frontmatter updatedAt / file mtime vs DB updated_at
+                           → if file is newer: upsertNoteFromFile() → SQLite
 ```
+
+**AI edit lock.** While the AI writes to a note the editor enters read-only mode:
+
+- **In-process (chat executor)** — `electron/lib/ai-write-lock.ts` holds a module-level `Set<string>`. The 5 note-writing cases in `chat-executor.ts` call `lockNote` / `unlockNote` in a try/finally. The lock fires `note:aiWriteStarted` / `note:aiWriteEnded` directly to the renderer via `webContents.send`.
+- **Cross-process (MCP server)** — `mcp_active_writes` SQLite table (migration v11). MCP tools INSERT on start, DELETE on finish. The WAL poller diffs the table each tick and fires the same IPC events.
+
+The renderer's `note-editor.tsx` subscribes to both events and flips the CM6 editor into `readOnly` mode via a `Compartment` — no editor recreation, undo history preserved.
+
+**Optimistic concurrency.** Both `notes` and `task_cards` carry a `version INTEGER` (migrations v12/v13) that increments on every write. MCP tools that mutate notes or tasks accept an optional `expectedVersion` argument and return a conflict error if the row version has advanced since the caller last read it. `get_note` and `get_task` both return the current `version`.
 
 ### Font scaling
 
@@ -310,10 +325,11 @@ Shared modules live in `src/components/graph/`: `analyticsUtils.ts`, `analyticsH
 | `electron/main.ts` | Startup orchestrator — BrowserWindow, IPC registration, file watcher |
 | `electron/lib/protocol.ts` | `app://` scheme registration + CSP headers |
 | `electron/lib/tray.ts` | System tray icon, menu, and badge update logic |
-| `electron/lib/mcp-poller.ts` | WAL mtime polling → `db:changed` IPC + MCP notification dispatch |
+| `electron/lib/ai-write-lock.ts` | Module-level `Set<string>` tracking active in-process AI note writes; fires `note:aiWriteStarted/Ended` IPC |
+| `electron/lib/mcp-poller.ts` | WAL mtime polling → `db:changed` IPC + MCP notification dispatch + `mcp_active_writes` diff for cross-process AI lock events |
 | `electron/lib/read-tools.ts` | `executeReadTool(db, snap, tool, args)` — shared read dispatch used by chat and dashboard bridge |
 | `electron/workspace-config.ts` | Read/write `workspace-config.json`; resolve `cairn.db` path |
-| `electron/notes-files.ts` | Note file I/O: `writeNoteFile`, `deleteNoteFile`, `parseNoteFile`, `upsertNoteFromFile` |
+| `electron/notes-files.ts` | Note file I/O: `writeNoteFile` (atomic `.tmp` → rename), `deleteNoteFile`, `parseNoteFile`, `upsertNoteFromFile`, `syncNotesFromDisk` (startup timestamp compare), `cleanStaleTmpFiles` |
 | `electron/file-watcher.ts` | chokidar watcher on `notes/`; syncs external `.md` edits to SQLite |
 | `electron/ipc/handlers.ts` | All `db:*` and `app:*` IPC channels; wrapped in `handle()` returning `IpcResult<T>` |
 | `electron/ipc/agent.ts` | All `agent:*` IPC channels — PTY spawn/kill, file I/O, git diff, `assertWithinCodeDirectory` |
@@ -336,7 +352,7 @@ Shared modules live in `src/components/graph/`: `analyticsUtils.ts`, `analyticsH
 |------|---------|
 | `src/store/index.ts` | Zustand store composition + hydration; delegates to domain slices |
 | `src/store/slices/` | Domain slices: `ui` (theme, fontScale, activeView), `workspace`, `board`, `notes`, `tags`, `chat`, `graph`, `selectors` |
-| `src/store/ipc.ts` | Shared `isElectron`, `ipc`, `ipcAwait` helpers used by all slices |
+| `src/store/ipc.ts` | Shared `isElectron`, `ipc`, `ipcAwait` helpers; `markOwnNoteWrite` / `isOwnNoteWrite` per-note write map (1.5 s window) used to gate WAL-poller re-hydration |
 | `src/hooks/useChatStream.ts` | AI stream lifecycle hook — subscriptions, loading state, `sendStream` |
 | `src/lib/constants.ts` | Shared constants: `COLUMN_COLORS`, `PRIORITY_OPTIONS`, `DEFAULT_AI_CONFIG`, etc. |
 | `src/lib/events.ts` | Typed `CairnEvents` helpers for internal custom event dispatch |
@@ -428,6 +444,7 @@ Use `React.memo` on list-item components (`KanbanCard`, `NoteListItem`, `Project
 - New IPC channels go in `electron/ipc/handlers.ts`, wrapped in the `handle()` helper.
 - `mcp-server.ts` uses **inlined SQL only** — do not import from `queries.ts` there.
 - Use `import * as z from "zod"` (not `import { z }`) in all Electron/MCP files — esbuild quirk.
+- When calling `ipc()` or `ipcAwait()` for a note mutation, also call `markOwnNoteWrite(noteId)` from `src/store/ipc.ts` immediately before — this tells the WAL poller re-hydration path to preserve the in-memory optimistic state for that note rather than overwriting it from the DB snapshot.
 
 ### Database migrations
 
@@ -511,10 +528,11 @@ npm run test:coverage     # coverage report
 | Test file | What it covers |
 |-----------|---------------|
 | `electron/db/queries.test.ts` | SQLite query helpers — CRUD, search, soft-delete |
-| `electron/notes-files.test.ts` | File I/O, slug generation, frontmatter round-trip |
+| `electron/notes-files.test.ts` | File I/O, slug generation, frontmatter round-trip, atomic writes, startup sync |
+| `electron/mcp-server.test.ts` | All MCP tools end-to-end via in-memory SQLite — happy path, edge cases, conflict detection |
 | `electron/ipc/chat-executor.test.ts` | Every tool case in `executeTool` |
 | `electron/ipc/handlers.test.ts` | IPC data layer, `executeReadTool`, `buildContextResponse` |
-| `electron/ipc/tool-parity.test.ts` | Ensures chat and MCP tool names stay in sync |
+| `electron/ipc/tool-parity.test.ts` | Ensures chat and MCP tool response shapes stay in sync (including `version` field parity) |
 
 **Please add or update tests when:**
 - Adding a new query helper to `queries.ts`

--- a/README.md
+++ b/README.md
@@ -153,15 +153,15 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 | Tool | Category | Description |
 |------|----------|-------------|
-| `get_note` | read | Full markdown content, linked IDs, and metadata of a note by ID |
+| `get_note` | read | Full markdown content, linked IDs, metadata, and `version` counter of a note by ID |
 | `list_notes` | read | List all notes in a project |
 | `search_notes` | read | Full-text search across notes |
 | `create_note` | write | Create a markdown note |
 | `import_note_from_file` | write | Import a local file as a note — server reads from disk, no need to inline content |
 | `ensure_note` | write | Idempotent create-or-update by title — prevents duplicate notes on re-run |
-| `append_to_note` | write | Append content to a note without re-sending the full body |
-| `patch_note` | write | Surgically replace a string inside a note — no need to re-send the full content |
-| `update_note` | write | Update a note's title, content, or pinned state |
+| `append_to_note` | write | Append content to a note without re-sending the full body. Accepts optional `expectedVersion` for conflict detection |
+| `patch_note` | write | Surgically replace a string inside a note — no need to re-send the full content. Accepts optional `expectedVersion` for conflict detection |
+| `update_note` | write | Update a note's title, content, or pinned state. Accepts optional `expectedVersion` for conflict detection |
 | `move_note` | write | Move a note to a different project |
 | `delete_note` | delete | Permanently delete a note |
 
@@ -169,13 +169,13 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 | Tool | Category | Description |
 |------|----------|-------------|
-| `get_task` | read | Full task detail by ID — includes `blockedByIds` |
+| `get_task` | read | Full task detail by ID — includes `blockedByIds` and `version` counter |
 | `list_tasks` | read | All tasks in a project grouped by column |
 | `list_ready_tasks` | read | Only unblocked, active tasks — use this to find work that can start now |
 | `search_tasks` | read | Full-text search across task cards |
 | `create_task` | write | Create a task card in a column |
-| `update_task` | write | Update a task's title, description, priority, due date, column, or assignee |
-| `update_task_status` | write | Move a single task to a different column |
+| `update_task` | write | Update a task's title, description, priority, due date, column, or assignee. Accepts optional `expectedVersion` for conflict detection |
+| `update_task_status` | write | Move a single task to a different column. Accepts optional `expectedVersion` for conflict detection |
 | `bulk_update_task_status` | write | Move multiple tasks to the same column in one call |
 | `link_note_to_task` | write | Bidirectionally link a note and a task |
 | `block_task` | write | Mark a task as blocked by another task in the same project |
@@ -256,7 +256,11 @@ Cairn is an Electron + Next.js desktop app with two processes that share a singl
 - **Main process** (`electron/`) — Node.js. Owns SQLite, file I/O, the AI chat loop, and PTY sessions for coding agents.
 - **MCP server** (`electron/mcp-server.ts`) — a self-contained binary connecting external AI agents (OpenCode, Claude Desktop, etc.) to the same database via WAL polling.
 
-Notes are plain `.md` files with YAML frontmatter; SQLite is the read/search cache. A chokidar file watcher syncs external edits back automatically. The **Agent workspace** (`⌘5`) runs coding agent CLIs via `node-pty` PTY sessions, with all file I/O path-validated against registered project `code_directory` values.
+Notes are plain `.md` files with YAML frontmatter; SQLite is the read/search cache. Every note write goes through `writeNoteFile()` which writes to a `.tmp` file and renames it into place (atomic). A chokidar file watcher syncs external edits back on startup and at runtime; on startup, `syncNotesFromDisk` compares file timestamps against the DB and overwrites SQLite if the file is newer. The **Agent workspace** (`⌘5`) runs coding agent CLIs via `node-pty` PTY sessions, with all file I/O path-validated against registered project `code_directory` values.
+
+When the AI (chat executor or MCP server) is writing to a note, the editor enters read-only mode with a pulsing banner. The in-process chat executor uses a module-level lock set (`ai-write-lock.ts`); the MCP server signals via a `mcp_active_writes` SQLite table that the WAL poller diffs every second.
+
+`notes` and `task_cards` each carry a `version` integer that increments on every write. MCP write tools accept an optional `expectedVersion` argument and return a conflict error if the row has been modified since the caller last read it.
 
 State in the renderer is managed by Zustand domain slices (`ui`, `workspace`, `board`, `notes`, `tags`, `chat`, `graph`, `selectors`), composed in `src/store/index.ts`. Analytics canvases in Insights follow a shared pattern: `useContainerDims` + `useScopedData` + `useFontScale` + D3/SVG rendering.
 
@@ -277,7 +281,7 @@ Tests live alongside the code they cover:
 | File | Tests | What's covered |
 |------|-------|---------------|
 | `electron/db/queries.test.ts` | 22 | SQLite query helpers — CRUD, search, soft-delete, snapshot |
-| `electron/notes-files.test.ts` | 29 | File I/O, slug generation, frontmatter round-trip (tmp dirs) |
+| `electron/notes-files.test.ts` | 40 | File I/O, slug generation, frontmatter round-trip, atomic writes, startup sync (tmp dirs) |
 | `electron/mcp-server.test.ts` | 134 | MCP `executeTool` end-to-end via in-memory SQLite — all tools, edge cases, blocker chains |
 | `electron/ipc/chat-executor.test.ts` | 98 | Every tool case in the AI chat executor — happy path, missing entities, error returns |
 | `electron/ipc/handlers.test.ts` | 14 | IPC data layer — `executeReadTool`, `buildContextResponse`, `getBy*` queries |

--- a/changelogs/v1.1.4.md
+++ b/changelogs/v1.1.4.md
@@ -1,0 +1,67 @@
+# v1.1.4
+
+## DB sync hardening
+
+A series of reliability improvements to the note and task write path, targeting race conditions between the user, the in-app AI chat, and the MCP server.
+
+### AI edit lock
+
+While the AI is writing to a note — either via the in-app chat executor or the MCP server — the note editor now enters read-only mode. A pulsing accent banner appears at the top of the editor: _"AI is editing this note…"_ The editor returns to normal the moment the write completes. The CM6 undo history is preserved across the lock (the editor is not recreated).
+
+Two separate lock mechanisms are used depending on the write source:
+
+- **In-app chat** — a module-level `Set` in the main process tracks active writes and fires `note:aiWriteStarted` / `note:aiWriteEnded` IPC events directly to the renderer.
+- **MCP server** — a new `mcp_active_writes` table (migration v11) is used as a cross-process signal. The WAL poller diffs the table every second and fires the same IPC events to the renderer.
+
+### Atomic file writes
+
+`writeNoteFile` now writes to a `.tmp` file and renames it into place (`fs.renameSync`), which is atomic at the filesystem level. A crash between a SQLite write and the file write previously left the `.md` file stale; the temp file is now the only recovery artefact and is cleaned up automatically on next startup.
+
+### Per-note own-write guard
+
+The `db:changed` handler previously used a global 3-second window to decide whether to skip re-hydration — any own write anywhere would suppress hydration for all notes for 3 seconds. It now tracks the last write timestamp per note ID (1.5 s window). When the WAL poller triggers a re-hydration, notes written by the user within the window are preserved from in-memory state; only notes written externally (by MCP or another process) are updated from SQLite.
+
+### SQLite transactions
+
+Multi-statement note writes are now wrapped in `db.transaction()` so a crash between two related SQL statements (e.g. `updateNote` + `restoreNote` during archive/restore, or a data UPDATE + `insertNotification` in the MCP server) leaves the database in a consistent state rather than partially written.
+
+### Startup external-edit recovery
+
+`syncNotesFromDisk` now compares the frontmatter `updatedAt` timestamp (and file `mtime` as a fallback with a 2-second buffer) against the DB `updated_at`. If the `.md` file is newer — indicating an external edit while Cairn was closed — the SQLite row is overwritten from disk. Previously, only notes missing from SQLite entirely were imported.
+
+### Optimistic concurrency — version columns
+
+A `version INTEGER` counter (starting at 0) has been added to both `notes` (migration v12) and `task_cards` (migration v13). The counter increments on every write. MCP tools that modify notes or tasks (`update_note`, `patch_note`, `append_to_note`, `update_task`, `update_task_status`) now accept an optional `expectedVersion` argument. If the note or card has been modified since the AI last read it, the tool returns a conflict error instead of silently overwriting. `get_note` and `get_task` both return the current `version` so callers can supply it on subsequent writes.
+
+---
+
+## Fixes
+
+- **MCP notifications suppressed while app is focused** — OS notifications and the unread badge no longer increment while the Cairn window is focused. Notifications are still marked as read immediately so they don't fire in a burst when the user switches away. Previously, notifications fired regardless of window focus state.
+
+---
+
+## Changed files
+
+| File | Change |
+|------|--------|
+| `electron/db/schema.ts` | Migrations v11 (`mcp_active_writes`), v12 (`notes.version`), v13 (`task_cards.version`) |
+| `electron/db/queries.ts` | `toNote` / `toCard` mappers include `version`; all note and card mutation functions increment `version`; `getActiveMcpWrites()` added |
+| `electron/ipc/handlers.ts` | `getWin` threaded through `DbContext`; archive-restore path wrapped in `db.transaction()`; `registerChatHandler` receives `getWin` |
+| `electron/ipc/chat.ts` | `getWin` getter threaded through `runToolLoop` → `executeTool` |
+| `electron/ipc/chat-executor.ts` | 5 note-writing cases wrapped with `aiWriteLock` lock/unlock; `get_note` and `get_task` responses include `version` |
+| `electron/ipc/agent.ts` | `agent:searchFiles` IPC handler (recursive walk, configurable skip list) |
+| `electron/lib/ai-write-lock.ts` | New — module-level `Set<string>` tracking active in-process AI writes; fires `note:aiWriteStarted/Ended` |
+| `electron/lib/mcp-poller.ts` | Diffs `mcp_active_writes` each tick; fires lock IPC events; suppresses OS notifications and badge when window is focused |
+| `electron/mcp-server.ts` | `mcp_active_writes` lock/unlock wrapping 5 note-writing tools; all note and task UPDATEs increment `version`; SQL+notification pairs wrapped in `db.transaction()`; `update_note`, `patch_note`, `append_to_note`, `update_task`, `update_task_status` accept `expectedVersion`; `get_note` and `get_task` return `version` |
+| `electron/notes-files.ts` | `writeNoteFile` uses `.tmp` + `renameSync`; `cleanStaleTmpFiles` on startup; `syncNotesFromDisk` overwrites SQLite from disk when file is newer |
+| `electron/main.ts` | Lazy `_win` getter assigned after `createWindow()`; poller startup wired |
+| `electron/preload.ts` | `onAiWriteStarted` / `onAiWriteEnded` exposed on `window.electron` |
+| `src/types/index.ts` | `Note` and `TaskCard` interfaces include `version: number` |
+| `src/store/ipc.ts` | `markOwnNoteWrite` / `isOwnNoteWrite` per-note write map (1.5 s window) |
+| `src/store/index.ts` | `hydrateFromElectron` refresh path preserves in-memory state for recently own-written notes |
+| `src/store/slices/notes.ts` | `markOwnNoteWrite` called before every note IPC; `version: 0` in optimistic note literal |
+| `src/store/slices/board.ts` | `version: 0` in optimistic card literal |
+| `src/components/notes/markdown-editor.tsx` | `readOnly` prop via CM6 `Compartment` (no editor recreation) |
+| `src/components/notes/note-editor.tsx` | IPC subscription for AI write lock; pulsing accent banner while AI writes |
+| `src/components/flow/flow-view.tsx` | `version: 0` in promoted-task literal |

--- a/electron/db/queries.ts
+++ b/electron/db/queries.ts
@@ -682,6 +682,20 @@ export function markMcpNotificationsRead(db: Database.Database): void {
   db.prepare("UPDATE mcp_notifications SET read = 1 WHERE read = 0").run();
 }
 
+/**
+ * Returns the set of note IDs currently being written by the MCP server process.
+ * Used by mcp-poller to diff against the previous poll and fire aiWriteStarted/Ended events.
+ * Returns an empty set if the table doesn't exist yet (e.g. pre-v11 DB).
+ */
+export function getActiveMcpWrites(db: Database.Database): Set<string> {
+  try {
+    const rows = db.prepare("SELECT note_id FROM mcp_active_writes").all() as { note_id: string }[];
+    return new Set(rows.map((r) => r.note_id));
+  } catch {
+    return new Set();
+  }
+}
+
 export function insertMcpNotification(db: Database.Database, n: { id: string; tool: string; title: string; body: string }): void {
   db.prepare("INSERT INTO mcp_notifications (id, tool, title, body, read, created_at) VALUES (?, ?, ?, ?, 0, ?)").run(n.id, n.tool, n.title, n.body, ts());
 }

--- a/electron/db/queries.ts
+++ b/electron/db/queries.ts
@@ -91,6 +91,7 @@ function toNote(row: any) {
     createdAt: row.created_at as string,
     updatedAt: row.updated_at as string,
     archivedAt: row.archived_at as string | undefined,
+    version: (row.version ?? 0) as number,
   };
 }
 
@@ -128,6 +129,7 @@ function toCard(row: any) {
     createdAt: row.created_at as string,
     updatedAt: row.updated_at as string,
     archivedAt: row.archived_at as string | undefined,
+    version: (row.version ?? 0) as number,
   };
 }
 
@@ -280,8 +282,8 @@ export function createNote(db: Database.Database, n: {
   const folder = n.folder ?? "";
   db.prepare(`
     INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
-      tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', ?, ?, ?, ?, ?)
+      tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at, version)
+    VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', ?, ?, ?, ?, ?, 0)
   `).run(n.id, n.projectId, n.workspaceId, n.title, content, contentText, tagIds, isPinned, type, folder, now, now);
   return toNote(db.prepare("SELECT * FROM notes WHERE id = ?").get(n.id));
 }
@@ -304,7 +306,8 @@ export function updateNote(db: Database.Database, id: string, patch: Partial<{
       archived_at     = COALESCE(?, archived_at),
       type            = COALESCE(?, type),
       folder          = COALESCE(?, folder),
-      updated_at      = ?
+      updated_at      = ?,
+      version         = version + 1
     WHERE id = ?
   `).run(
     patch.title ?? null,
@@ -338,7 +341,7 @@ export function getNoteById(db: Database.Database, id: string) {
  */
 export function moveNoteFolder(db: Database.Database, id: string, folder: string) {
   const now = ts();
-  db.prepare("UPDATE notes SET folder = ?, updated_at = ? WHERE id = ?").run(folder, now, id);
+  db.prepare("UPDATE notes SET folder = ?, updated_at = ?, version = version + 1 WHERE id = ?").run(folder, now, id);
   return toNote(db.prepare("SELECT * FROM notes WHERE id = ?").get(id));
 }
 
@@ -347,7 +350,7 @@ export function moveNoteFolder(db: Database.Database, id: string, folder: string
  */
 export function restoreNote(db: Database.Database, id: string) {
   const now = ts();
-  db.prepare("UPDATE notes SET archived_at = NULL, updated_at = ? WHERE id = ?").run(now, id);
+  db.prepare("UPDATE notes SET archived_at = NULL, updated_at = ?, version = version + 1 WHERE id = ?").run(now, id);
   return toNote(db.prepare("SELECT * FROM notes WHERE id = ?").get(id));
 }
 
@@ -441,7 +444,8 @@ export function updateCard(db: Database.Database, id: string, patch: Partial<{
       "order"         = COALESCE(?, "order"),
       assignee        = COALESCE(?, assignee),
       archived_at     = COALESCE(?, archived_at),
-      updated_at      = ?
+      updated_at      = ?,
+      version         = version + 1
     WHERE id = ?
   `).run(
     patch.columnId ?? null, patch.title ?? null, patch.description ?? null,
@@ -465,7 +469,7 @@ export function deleteCard(db: Database.Database, id: string) {
     const ids = p(row.blocked_by_ids) as string[];
     if (ids.includes(id)) {
       const updated = ids.filter((bid) => bid !== id);
-      db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ? WHERE id = ?")
+      db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ?, version = version + 1 WHERE id = ?")
         .run(j(updated), now, row.id);
     }
   }
@@ -482,7 +486,7 @@ export function getCardById(db: Database.Database, id: string) {
  */
 export function restoreCard(db: Database.Database, id: string) {
   const now = ts();
-  db.prepare("UPDATE task_cards SET archived_at = NULL, updated_at = ? WHERE id = ?").run(now, id);
+  db.prepare("UPDATE task_cards SET archived_at = NULL, updated_at = ?, version = version + 1 WHERE id = ?").run(now, id);
   return toCard(db.prepare("SELECT * FROM task_cards WHERE id = ?").get(id));
 }
 
@@ -491,7 +495,7 @@ export function restoreCard(db: Database.Database, id: string) {
  */
 export function clearCardDueDate(db: Database.Database, id: string) {
   const now = ts();
-  db.prepare("UPDATE task_cards SET due_date = NULL, updated_at = ? WHERE id = ?").run(now, id);
+  db.prepare("UPDATE task_cards SET due_date = NULL, updated_at = ?, version = version + 1 WHERE id = ?").run(now, id);
   return toCard(db.prepare("SELECT * FROM task_cards WHERE id = ?").get(id));
 }
 
@@ -505,7 +509,7 @@ export function addCardBlocker(db: Database.Database, cardId: string, blockerCar
   const ids = p(row.blocked_by_ids) as string[];
   if (!ids.includes(blockerCardId)) {
     ids.push(blockerCardId);
-    db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ? WHERE id = ?").run(j(ids), now, cardId);
+    db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ?, version = version + 1 WHERE id = ?").run(j(ids), now, cardId);
   }
   return toCard(db.prepare("SELECT * FROM task_cards WHERE id = ?").get(cardId));
 }
@@ -518,7 +522,7 @@ export function removeCardBlocker(db: Database.Database, cardId: string, blocker
   const row = db.prepare("SELECT blocked_by_ids FROM task_cards WHERE id = ?").get(cardId) as { blocked_by_ids: string } | undefined;
   if (!row) throw new Error(`Card ${cardId} not found`);
   const ids = (p(row.blocked_by_ids) as string[]).filter((id) => id !== blockerCardId);
-  db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ? WHERE id = ?").run(j(ids), now, cardId);
+  db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ?, version = version + 1 WHERE id = ?").run(j(ids), now, cardId);
   return toCard(db.prepare("SELECT * FROM task_cards WHERE id = ?").get(cardId));
 }
 
@@ -538,7 +542,7 @@ export function clearBlockersFromAll(db: Database.Database, doneCardIds: string[
     const ids = p(row.blocked_by_ids) as string[];
     const cleaned = ids.filter((bid) => !doneCardIds.includes(bid));
     if (cleaned.length !== ids.length) {
-      db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ? WHERE id = ?")
+      db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ?, version = version + 1 WHERE id = ?")
         .run(j(cleaned), now, row.id);
     }
   }

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -285,6 +285,19 @@ const MIGRATIONS: Migration[] = [
       db.exec("ALTER TABLE projects ADD COLUMN code_directory TEXT");
     }
   },
+
+  // v11: MCP active writes — tracks note IDs being written by the MCP server process
+  // so the Electron renderer can show a read-only indicator on the active note.
+  // The MCP process creates this table on startup via an inline CREATE TABLE IF NOT EXISTS
+  // (it cannot call applySchema due to the Node ABI boundary).
+  (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS mcp_active_writes (
+        note_id    TEXT NOT NULL PRIMARY KEY,
+        started_at TEXT NOT NULL
+      );
+    `);
+  },
 ];
 
 export function applySchema(db: Database.Database): void {

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -298,6 +298,25 @@ const MIGRATIONS: Migration[] = [
       );
     `);
   },
+
+  // v12: Optimistic concurrency — version counter on notes.
+  // Incremented on every write so MCP tools can detect mid-air collisions via
+  // an optional expectedVersion argument.
+  (db) => {
+    const cols = db.prepare("PRAGMA table_info(notes)").all() as { name: string }[];
+    if (!cols.some((c) => c.name === "version")) {
+      db.exec("ALTER TABLE notes ADD COLUMN version INTEGER NOT NULL DEFAULT 0");
+    }
+  },
+
+  // v13: Optimistic concurrency — version counter on task_cards.
+  // Same pattern as v12 notes — lets MCP detect stale update attempts.
+  (db) => {
+    const cols = db.prepare("PRAGMA table_info(task_cards)").all() as { name: string }[];
+    if (!cols.some((c) => c.name === "version")) {
+      db.exec("ALTER TABLE task_cards ADD COLUMN version INTEGER NOT NULL DEFAULT 0");
+    }
+  },
 ];
 
 export function applySchema(db: Database.Database): void {

--- a/electron/ipc/chat-executor.ts
+++ b/electron/ipc/chat-executor.ts
@@ -147,7 +147,7 @@ export async function executeTool(
         id: note.id, title: note.title, content: note.content,
         projectId: note.projectId, isPinned: note.isPinned,
         linkedNoteIds: note.linkedNoteIds, linkedCardIds: note.linkedCardIds,
-        updatedAt: note.updatedAt,
+        updatedAt: note.updatedAt, version: note.version ?? 0,
       };
     }
     case "create_dashboard": {
@@ -419,7 +419,7 @@ export async function executeTool(
         priority: card.priority, dueDate: card.dueDate,
         columnId: card.columnId, columnName: col?.name ?? "Unknown", columnType: col?.type ?? "custom",
         linkedNoteIds: card.linkedNoteIds, blockedByIds: card.blockedByIds ?? [],
-        projectId: card.projectId, createdAt: card.createdAt, updatedAt: card.updatedAt,
+        projectId: card.projectId, createdAt: card.createdAt, updatedAt: card.updatedAt, version: card.version ?? 0,
       };
     }
     case "delete_note": {

--- a/electron/ipc/chat-executor.ts
+++ b/electron/ipc/chat-executor.ts
@@ -6,6 +6,7 @@
  */
 
 import type Database from "better-sqlite3";
+import type { BrowserWindow } from "electron";
 import path from "path";
 import fs from "fs";
 import dagre from "@dagrejs/dagre";
@@ -20,6 +21,7 @@ import { callLLM, type LLMConfig } from "../lib/llm";
 import { TOOL_LABELS, type ChatRequest, type ToolArgs } from "../lib/tools";
 import { getKnowledgeGraph, getNeighbours } from "../db/graph-queries";
 import type { GraphFilters, EdgeType } from "../db/graph-queries";
+import { aiWriteLock } from "../lib/ai-write-lock";
 
 // ── Static reference constants (returned by get_dashboard_constants / get_idea_flow_rules) ──
 
@@ -73,6 +75,7 @@ export async function executeTool(
   name: string,
   args: ToolArgs,
   emit?: (event: { tool: string; label: string; args: Record<string, unknown> }) => void,
+  getWin?: () => BrowserWindow | null,
 ): Promise<unknown> {
   emit?.({ tool: name, label: TOOL_LABELS[name]?.(args) ?? name, args });
   const snap = q.getFullSnapshot(db) as CairnSnapshot;
@@ -176,14 +179,20 @@ export async function executeTool(
       const noteId = newId();
       const markdown = (args.content as string) ?? "";
       const folder = typeof args.folder === "string" ? args.folder : "";
-      const note = q.createNote(db, {
-        id: noteId, projectId: args.projectId, workspaceId: project.workspaceId,
-        title: args.title, content: markdown, contentText: stripMarkdown(markdown),
-        tagIds: Array.isArray(args.tagIds) ? args.tagIds as string[] : undefined,
-        folder,
-      });
-      writeNoteFile(workspacePath, { ...note, projectName: project.name });
-      return note;
+      const win = getWin?.() ?? null;
+      aiWriteLock.lock(noteId, win);
+      try {
+        const note = q.createNote(db, {
+          id: noteId, projectId: args.projectId, workspaceId: project.workspaceId,
+          title: args.title, content: markdown, contentText: stripMarkdown(markdown),
+          tagIds: Array.isArray(args.tagIds) ? args.tagIds as string[] : undefined,
+          folder,
+        });
+        writeNoteFile(workspacePath, { ...note, projectName: project.name });
+        return note;
+      } finally {
+        aiWriteLock.unlock(noteId, win);
+      }
     }
     case "import_note_from_file": {
       const project = snap.projects.find((p) => p.id === args.projectId);
@@ -232,42 +241,56 @@ export async function executeTool(
       const ensureTagIds = Array.isArray(args.tagIds) ? args.tagIds as string[] : undefined;
       const ensureIsPinned = typeof args.isPinned === "boolean" ? args.isPinned : undefined;
       const ensureFolder = typeof args.folder === "string" ? args.folder : undefined;
-      if (existing) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const patch: Record<string, any> = { content: markdown, contentText: stripMarkdown(markdown) };
-        if (ensureTagIds !== undefined) patch.tagIds = ensureTagIds;
-        if (ensureIsPinned !== undefined) patch.isPinned = ensureIsPinned;
-        if (ensureFolder !== undefined) patch.folder = ensureFolder;
-        const note = q.updateNote(db, existing.id, patch);
-        writeNoteFile(workspacePath, { ...note, projectName: project.name });
-        return { id: existing.id, title: existing.title, action: "updated", updatedAt: note.updatedAt };
-      } else {
-        const noteId = newId();
-        const note = q.createNote(db, {
-          id: noteId, projectId: args.projectId as string, workspaceId: project.workspaceId,
-          title: args.title as string, content: markdown, contentText: stripMarkdown(markdown),
-          tagIds: ensureTagIds,
-          isPinned: ensureIsPinned,
-          folder: ensureFolder ?? "",
-        });
-        writeNoteFile(workspacePath, { ...note, projectName: project.name });
-        return { id: noteId, title: args.title, action: "created", createdAt: note.createdAt };
+      const ensureNoteId = existing?.id ?? newId();
+      const win = getWin?.() ?? null;
+      aiWriteLock.lock(ensureNoteId, win);
+      try {
+        if (existing) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const patch: Record<string, any> = { content: markdown, contentText: stripMarkdown(markdown) };
+          if (ensureTagIds !== undefined) patch.tagIds = ensureTagIds;
+          if (ensureIsPinned !== undefined) patch.isPinned = ensureIsPinned;
+          if (ensureFolder !== undefined) patch.folder = ensureFolder;
+          const note = q.updateNote(db, existing.id, patch);
+          writeNoteFile(workspacePath, { ...note, projectName: project.name });
+          return { id: existing.id, title: existing.title, action: "updated", updatedAt: note.updatedAt };
+        } else {
+          const note = q.createNote(db, {
+            id: ensureNoteId, projectId: args.projectId as string, workspaceId: project.workspaceId,
+            title: args.title as string, content: markdown, contentText: stripMarkdown(markdown),
+            tagIds: ensureTagIds,
+            isPinned: ensureIsPinned,
+            folder: ensureFolder ?? "",
+          });
+          writeNoteFile(workspacePath, { ...note, projectName: project.name });
+          return { id: ensureNoteId, title: args.title, action: "created", createdAt: note.createdAt };
+        }
+      } finally {
+        aiWriteLock.unlock(ensureNoteId, win);
       }
     }
     case "append_to_note": {
       const note = snap.notes.find((n) => n.id === args.noteId);
       if (!note) return { error: "Note not found" };
-      const separator = (args.separator as string | undefined) ?? "\n\n";
-      const existing = note.content ?? "";
-      const newContent = existing ? existing + separator + (args.content as string) : (args.content as string);
-      const updated = q.updateNote(db, args.noteId as string, { content: newContent, contentText: stripMarkdown(newContent) });
-      const proj = snap.projects.find((p) => p.id === note.projectId);
-      writeNoteFile(workspacePath, { ...updated, projectName: proj?.name ?? note.projectId });
-      return { id: note.id, title: note.title, updatedAt: updated.updatedAt, newLength: newContent.length };
+      const appendNoteId = args.noteId as string;
+      const win = getWin?.() ?? null;
+      aiWriteLock.lock(appendNoteId, win);
+      try {
+        const separator = (args.separator as string | undefined) ?? "\n\n";
+        const existing = note.content ?? "";
+        const newContent = existing ? existing + separator + (args.content as string) : (args.content as string);
+        const updated = q.updateNote(db, appendNoteId, { content: newContent, contentText: stripMarkdown(newContent) });
+        const proj = snap.projects.find((p) => p.id === note.projectId);
+        writeNoteFile(workspacePath, { ...updated, projectName: proj?.name ?? note.projectId });
+        return { id: note.id, title: note.title, updatedAt: updated.updatedAt, newLength: newContent.length };
+      } finally {
+        aiWriteLock.unlock(appendNoteId, win);
+      }
     }
     case "patch_note": {
       const existing = snap.notes.find((n) => n.id === args.noteId);
       if (!existing) return { error: "Note not found" };
+      const patchNoteId = args.noteId as string;
       const oldStr = args.oldString as string;
       const newStr = args.newString as string;
       const all = (args.replaceAll as boolean | undefined) ?? false;
@@ -276,14 +299,21 @@ export async function executeTool(
       if (count === 0) return { error: "oldString not found in note content" };
       if (count > 1 && !all) return { error: `oldString matches ${count} times — set replaceAll: true to replace all, or provide more surrounding context to make it unique` };
       const newContent = all ? currentContent.split(oldStr).join(newStr) : currentContent.replace(oldStr, newStr);
-      const note = q.updateNote(db, args.noteId as string, { content: newContent, contentText: stripMarkdown(newContent) });
-      const proj = snap.projects.find((p) => p.id === existing.projectId);
-      writeNoteFile(workspacePath, { ...note, projectName: proj?.name ?? existing.projectId });
-      return { id: existing.id, title: existing.title, updatedAt: note.updatedAt, replacements: all ? count : 1 };
+      const win = getWin?.() ?? null;
+      aiWriteLock.lock(patchNoteId, win);
+      try {
+        const note = q.updateNote(db, patchNoteId, { content: newContent, contentText: stripMarkdown(newContent) });
+        const proj = snap.projects.find((p) => p.id === existing.projectId);
+        writeNoteFile(workspacePath, { ...note, projectName: proj?.name ?? existing.projectId });
+        return { id: existing.id, title: existing.title, updatedAt: note.updatedAt, replacements: all ? count : 1 };
+      } finally {
+        aiWriteLock.unlock(patchNoteId, win);
+      }
     }
     case "update_note": {
       const existing = snap.notes.find((n) => n.id === args.noteId);
       if (!existing) return { error: "Note not found" };
+      const updateNoteId = args.noteId as string;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const patch: Record<string, any> = {};
       if (args.title !== undefined && args.title !== "") patch.title = args.title as string;
@@ -293,10 +323,16 @@ export async function executeTool(
       }
       if (args.isPinned !== undefined) patch.isPinned = args.isPinned as boolean;
       if (Array.isArray(args.tagIds)) patch.tagIds = args.tagIds as string[];
-      const note = q.updateNote(db, args.noteId as string, patch);
-      const proj = snap.projects.find((p) => p.id === note.projectId);
-      writeNoteFile(workspacePath, { ...note, projectName: proj?.name ?? note.projectId });
-      return note;
+      const win = getWin?.() ?? null;
+      aiWriteLock.lock(updateNoteId, win);
+      try {
+        const note = q.updateNote(db, updateNoteId, patch);
+        const proj = snap.projects.find((p) => p.id === note.projectId);
+        writeNoteFile(workspacePath, { ...note, projectName: proj?.name ?? note.projectId });
+        return note;
+      } finally {
+        aiWriteLock.unlock(updateNoteId, win);
+      }
     }
     case "move_note": {
       const note = snap.notes.find((n) => n.id === args.noteId);

--- a/electron/ipc/chat.ts
+++ b/electron/ipc/chat.ts
@@ -8,6 +8,7 @@
  */
 
 import { ipcMain } from "electron";
+import type { BrowserWindow } from "electron";
 import type Database from "better-sqlite3";
 import { isLocalEndpoint, streamCompletion, type OpenAIMessage } from "../lib/llm";
 import { TOOLS, buildSystemPrompt, type ChatRequest } from "../lib/tools";
@@ -34,6 +35,7 @@ async function runToolLoop(
   messages: OpenAIMessage[],
   emitToolCall: (e: { tool: string; label: string; args: Record<string, unknown> }) => void,
   signal?: AbortSignal,
+  getWin?: () => BrowserWindow | null,
 ): Promise<{ exhausted: true; content: string } | { exhausted: false }> {
   const maxSteps = req.config?.maxSteps ?? 20;
   for (let round = 0; round < maxSteps; round++) {
@@ -75,7 +77,7 @@ async function runToolLoop(
       try { args = JSON.parse(call.function.arguments); } catch { args = {}; }
       let result: unknown;
       try {
-        result = await executeTool(db, req, workspacePath, { baseUrl, model, apiKey }, call.function.name, args, emitToolCall);
+        result = await executeTool(db, req, workspacePath, { baseUrl, model, apiKey }, call.function.name, args, emitToolCall, getWin);
       } catch (toolErr) {
         result = { error: `Tool "${call.function.name}" failed: ${String(toolErr)}` };
       }
@@ -89,7 +91,7 @@ async function runToolLoop(
   };
 }
 
-export function registerChatHandler(db: Database.Database, workspacePath: string): void {
+export function registerChatHandler(db: Database.Database, workspacePath: string, getWin?: () => BrowserWindow | null): void {
   // chat:abort — cancel the in-flight stream for this renderer
   ipcMain.on("chat:abort", (event) => {
     const ctrl = abortControllers.get(event.sender.id);
@@ -136,7 +138,7 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
       send("chat:tool-call", e);
     };
 
-    const loopResult = await runToolLoop(db, req, workspacePath, baseUrl, model, apiKey, messages, emitToolCall, abortCtrl.signal);
+    const loopResult = await runToolLoop(db, req, workspacePath, baseUrl, model, apiKey, messages, emitToolCall, abortCtrl.signal, getWin);
 
     abortControllers.delete(event.sender.id);
 

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -151,15 +151,19 @@ export function registerIpcHandlers(ctx: DbContext): void {
     if ("archivedAt" in patch && patch.archivedAt === null) {
       const rest = { ...patch };
       delete rest.archivedAt;
-      if (Object.keys(rest).length > 0) {
-        const enrichedRest = { ...rest };
-        if (rest.content !== undefined && rest.contentText === undefined) {
-          enrichedRest.contentText = stripMarkdown(rest.content);
+      // Wrap both SQL writes in a transaction so a crash between them leaves
+      // the DB in a consistent state (either both applied or neither).
+      const note = ctx.db.transaction(() => {
+        if (Object.keys(rest).length > 0) {
+          const enrichedRest = { ...rest };
+          if (rest.content !== undefined && rest.contentText === undefined) {
+            enrichedRest.contentText = stripMarkdown(rest.content);
+          }
+          q.updateNote(ctx.db, id, enrichedRest);
         }
-        q.updateNote(ctx.db, id, enrichedRest);
-      }
+        return q.restoreNote(ctx.db, id);
+      })();
       suppressNextChange(id);
-      const note = q.restoreNote(ctx.db, id);
       if (note.type !== "dashboard") {
         writeNoteFile(ctx.workspacePath, { ...note, projectName: getProjectName(ctx.db, note.projectId) });
       }

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -67,6 +67,8 @@ function getProjectName(db: Database.Database, projectId: string): string {
 export interface DbContext {
   db: Database.Database;
   workspacePath: string;
+  /** Returns the current BrowserWindow, or null before it is created. */
+  getWin: () => BrowserWindow | null;
 }
 
 export function registerIpcHandlers(ctx: DbContext): void {
@@ -463,7 +465,7 @@ export function registerIpcHandlers(ctx: DbContext): void {
   ipcMain.handle("db:chat:deleteThread",  (_e, { threadId }) => handle(() => q.deleteChatThread(ctx.db, threadId)));
 
   // ── AI Chat completions ────────────────────────────
-  registerChatHandler(ctx.db, ctx.workspacePath);
+  registerChatHandler(ctx.db, ctx.workspacePath, ctx.getWin);
 
   // ── AI PRD generation (direct, no chat loop) ──────
   ipcMain.handle("ai:generatePrd", async (_e, args: {

--- a/electron/lib/ai-write-lock.ts
+++ b/electron/lib/ai-write-lock.ts
@@ -1,0 +1,58 @@
+/**
+ * Cairn — AI write lock
+ *
+ * Tracks which note IDs are currently being written by the in-app AI chat
+ * executor. While a note is locked the renderer shows a read-only indicator
+ * so the user knows not to edit that note.
+ *
+ * Usage (in chat-executor.ts):
+ *   aiWriteLock.lock(noteId, win);
+ *   try { ...write... } finally { aiWriteLock.unlock(noteId, win); }
+ *
+ * The MCP server path (separate process) is handled via the mcp_active_writes
+ * SQLite table polled by mcp-poller.ts (Sync A3).
+ */
+
+import type { BrowserWindow } from "electron";
+
+const activeWrites = new Set<string>();
+
+function send(win: BrowserWindow | null, channel: string, payload: unknown): void {
+  if (win && !win.isDestroyed()) {
+    win.webContents.send(channel, payload);
+  }
+}
+
+export const aiWriteLock = {
+  /**
+   * Mark noteId as being written by the AI and notify the renderer.
+   * Safe to call multiple times for the same id (idempotent).
+   */
+  lock(noteId: string, win: BrowserWindow | null): void {
+    if (!activeWrites.has(noteId)) {
+      activeWrites.add(noteId);
+      send(win, "note:aiWriteStarted", { noteId });
+    }
+  },
+
+  /**
+   * Mark noteId as no longer being written and notify the renderer.
+   * Always call in a `finally` block to guarantee release.
+   */
+  unlock(noteId: string, win: BrowserWindow | null): void {
+    if (activeWrites.has(noteId)) {
+      activeWrites.delete(noteId);
+      send(win, "note:aiWriteEnded", { noteId });
+    }
+  },
+
+  /** Returns true if the note is currently being written by the AI. */
+  isLocked(noteId: string): boolean {
+    return activeWrites.has(noteId);
+  },
+
+  /** Snapshot of all currently locked note IDs (for debugging / tests). */
+  lockedIds(): ReadonlySet<string> {
+    return activeWrites;
+  },
+};

--- a/electron/lib/mcp-poller.ts
+++ b/electron/lib/mcp-poller.ts
@@ -54,14 +54,20 @@ export function startMcpNotificationPoller({
         onDbChanged();
 
         const unread = getUnreadMcpNotifications(db);
-        for (const n of unread) {
-          if (Notification.isSupported()) {
-            new Notification({ title: n.title, body: n.body, silent: false }).show();
-          }
-        }
         if (unread.length > 0) {
-          unreadCount += unread.length;
-          updateBadge(unreadCount);
+          // Suppress OS notifications and badge increment while the app is focused —
+          // the user can already see what is happening in the UI.
+          const appFocused = !win.isDestroyed() && win.isFocused();
+          if (!appFocused) {
+            for (const n of unread) {
+              if (Notification.isSupported()) {
+                new Notification({ title: n.title, body: n.body, silent: false }).show();
+              }
+            }
+            unreadCount += unread.length;
+            updateBadge(unreadCount);
+          }
+          // Always mark as read so they don't resurface on the next poll tick.
           markMcpNotificationsRead(db);
         }
       }

--- a/electron/lib/mcp-poller.ts
+++ b/electron/lib/mcp-poller.ts
@@ -8,7 +8,7 @@
 import { BrowserWindow, Notification } from "electron";
 import fs from "fs";
 import type Database from "better-sqlite3";
-import { getUnreadMcpNotifications, markMcpNotificationsRead } from "../db/queries";
+import { getUnreadMcpNotifications, markMcpNotificationsRead, getActiveMcpWrites } from "../db/queries";
 
 export interface McpPollerOptions {
   db: Database.Database;
@@ -26,7 +26,7 @@ export interface McpPoller {
 export function startMcpNotificationPoller({
   db,
   dbPath,
-  win: _win,
+  win,
   updateBadge,
   onDbChanged,
 }: McpPollerOptions): McpPoller {
@@ -34,10 +34,16 @@ export function startMcpNotificationPoller({
   let lastMtime = 0;
   // Accumulated unread count — incremented on new notifications, reset via resetCount()
   let unreadCount = 0;
+  // Previous snapshot of MCP-locked note IDs — diff each poll to fire started/ended events
+  let prevLocked = new Set<string>();
 
   try {
     lastMtime = fs.statSync(fs.existsSync(walPath) ? walPath : dbPath).mtimeMs;
   } catch { /* db not yet created */ }
+
+  function sendToWin(channel: string, payload: unknown): void {
+    if (win && !win.isDestroyed()) win.webContents.send(channel, payload);
+  }
 
   function check() {
     try {
@@ -59,6 +65,22 @@ export function startMcpNotificationPoller({
           markMcpNotificationsRead(db);
         }
       }
+
+      // Diff mcp_active_writes on every tick (independent of WAL mtime) so the
+      // renderer gets started/ended events promptly even if the write completes
+      // within the same WAL flush window.
+      const currentLocked = getActiveMcpWrites(db);
+      for (const noteId of currentLocked) {
+        if (!prevLocked.has(noteId)) {
+          sendToWin("note:aiWriteStarted", { noteId });
+        }
+      }
+      for (const noteId of prevLocked) {
+        if (!currentLocked.has(noteId)) {
+          sendToWin("note:aiWriteEnded", { noteId });
+        }
+      }
+      prevLocked = currentLocked;
     } catch { /* db file not yet created */ }
   }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -155,15 +155,19 @@ app.whenReady().then(async () => {
   syncNotesFromDisk(initialDb, initialWorkspacePath);
 
   // ── Mutable context — swapped in reinitialise() without relaunching ──
+  // getWin is a lazy getter so it works even though win is assigned after ctx.
+  let _win: import("electron").BrowserWindow | null = null;
   const ctx: import("./ipc/handlers").DbContext = {
     db: initialDb,
     workspacePath: initialWorkspacePath,
+    getWin: () => _win,
   };
 
   registerIpcHandlers(ctx);
   registerAgentHandlers(ctx.db);
 
   const win = createWindow();
+  _win = win;
 
   // ── File watcher for external .md edits ──────────────────────────────
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;

--- a/electron/mcp-server.ts
+++ b/electron/mcp-server.ts
@@ -311,6 +311,38 @@ export function getSnapshot(db: Database.Database) {
   };
 }
 
+// ── MCP active-write lock helpers ─────────────
+//
+// Tracks which note IDs are currently being written by this MCP process so the
+// Electron renderer can show a read-only indicator. Uses the mcp_active_writes
+// table (created by migration v11; also ensured inline here because applySchema
+// is not called in the MCP process due to the Node ABI boundary).
+//
+// Usage:  lockNote(db, noteId); try { ...write... } finally { unlockNote(db, noteId); }
+
+function ensureMcpActiveWritesTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS mcp_active_writes (
+      note_id    TEXT NOT NULL PRIMARY KEY,
+      started_at TEXT NOT NULL
+    );
+  `);
+  // Purge stale rows from a previous crashed process (> 30 s old)
+  db.prepare("DELETE FROM mcp_active_writes WHERE started_at < datetime('now', '-30 seconds')").run();
+}
+
+function lockNote(db: Database.Database, noteId: string): void {
+  try {
+    db.prepare("INSERT OR REPLACE INTO mcp_active_writes (note_id, started_at) VALUES (?, datetime('now'))").run(noteId);
+  } catch { /* best-effort */ }
+}
+
+function unlockNote(db: Database.Database, noteId: string): void {
+  try {
+    db.prepare("DELETE FROM mcp_active_writes WHERE note_id = ?").run(noteId);
+  } catch { /* best-effort */ }
+}
+
 // ── MCP notification helper ───────────────────
 
 function insertNotification(db: Database.Database, tool: string, title: string, body: string): void {
@@ -530,18 +562,23 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       const markdown = content ?? "";
       const resolvedTagIds = Array.isArray(tagIds) ? tagIds as string[] : [];
       const folder = typeof args.folder === "string" ? args.folder : "";
-      db.prepare(`
-        INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
-          tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', 0, 'note', ?, ?, ?)
-      `).run(noteId, projectId, project.workspaceId, title, markdown, stripMarkdown(markdown), j(resolvedTagIds), folder, now, now);
-      writeNoteFile(workspacePath, {
-        id: noteId, projectId, workspaceId: project.workspaceId, title, content: markdown,
-        tagIds: resolvedTagIds, linkedNoteIds: [], linkedCardIds: [], isPinned: false,
-        folder, createdAt: now, updatedAt: now, projectName: project.name,
-      });
-      insertNotification(db, "create_note", "Note created", `"${title}" added to ${project.name}${folder ? ` (${folder})` : ""}`);
-      return { id: noteId, title, folder, createdAt: now };
+      lockNote(db, noteId);
+      try {
+        db.prepare(`
+          INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
+            tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', 0, 'note', ?, ?, ?)
+        `).run(noteId, projectId, project.workspaceId, title, markdown, stripMarkdown(markdown), j(resolvedTagIds), folder, now, now);
+        writeNoteFile(workspacePath, {
+          id: noteId, projectId, workspaceId: project.workspaceId, title, content: markdown,
+          tagIds: resolvedTagIds, linkedNoteIds: [], linkedCardIds: [], isPinned: false,
+          folder, createdAt: now, updatedAt: now, projectName: project.name,
+        });
+        insertNotification(db, "create_note", "Note created", `"${title}" added to ${project.name}${folder ? ` (${folder})` : ""}`);
+        return { id: noteId, title, folder, createdAt: now };
+      } finally {
+        unlockNote(db, noteId);
+      }
     }
 
     case "import_note_from_file": {
@@ -586,22 +623,27 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       const markdown = content !== undefined ? content : null;
       const pinnedVal = isPinned !== undefined ? (isPinned ? 1 : 0) : null;
       const tagIdsJson = Array.isArray(tagIds) ? j(tagIds) : null;
-      db.prepare(`UPDATE notes SET title = COALESCE(?, title), content = COALESCE(?, content), content_text = COALESCE(?, content_text), is_pinned = COALESCE(?, is_pinned), tag_ids = COALESCE(?, tag_ids), updated_at = ? WHERE id = ?`)
-        .run(title ?? null, markdown, markdown !== null ? stripMarkdown(markdown) : null, pinnedVal, tagIdsJson, now, noteId);
-      const resolvedIsPinned = isPinned !== undefined ? (isPinned as boolean) : note.isPinned as boolean;
-      const updateProj = snap.projects.find((pr) => pr.id === note.projectId);
-      writeNoteFile(workspacePath, {
-        id: noteId, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
-        title: title ?? note.title as string,
-        content: markdown !== null ? markdown : note.content as string,
-        tagIds: Array.isArray(tagIds) ? tagIds as string[] : note.tagIds as string[], linkedNoteIds: note.linkedNoteIds as string[],
-        linkedCardIds: note.linkedCardIds as string[], isPinned: resolvedIsPinned,
-        createdAt: note.createdAt as string, updatedAt: now,
-        archivedAt: note.archivedAt as string | undefined,
-        projectName: updateProj?.name ?? note.projectId as string,
-      });
-      insertNotification(db, "update_note", "Note updated", `"${title ?? note.title}" was updated`);
-      return { id: noteId, title: title ?? note.title, isPinned: resolvedIsPinned, updatedAt: now };
+      lockNote(db, noteId as string);
+      try {
+        db.prepare(`UPDATE notes SET title = COALESCE(?, title), content = COALESCE(?, content), content_text = COALESCE(?, content_text), is_pinned = COALESCE(?, is_pinned), tag_ids = COALESCE(?, tag_ids), updated_at = ? WHERE id = ?`)
+          .run(title ?? null, markdown, markdown !== null ? stripMarkdown(markdown) : null, pinnedVal, tagIdsJson, now, noteId);
+        const resolvedIsPinned = isPinned !== undefined ? (isPinned as boolean) : note.isPinned as boolean;
+        const updateProj = snap.projects.find((pr) => pr.id === note.projectId);
+        writeNoteFile(workspacePath, {
+          id: noteId, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
+          title: title ?? note.title as string,
+          content: markdown !== null ? markdown : note.content as string,
+          tagIds: Array.isArray(tagIds) ? tagIds as string[] : note.tagIds as string[], linkedNoteIds: note.linkedNoteIds as string[],
+          linkedCardIds: note.linkedCardIds as string[], isPinned: resolvedIsPinned,
+          createdAt: note.createdAt as string, updatedAt: now,
+          archivedAt: note.archivedAt as string | undefined,
+          projectName: updateProj?.name ?? note.projectId as string,
+        });
+        insertNotification(db, "update_note", "Note updated", `"${title ?? note.title}" was updated`);
+        return { id: noteId, title: title ?? note.title, isPinned: resolvedIsPinned, updatedAt: now };
+      } finally {
+        unlockNote(db, noteId as string);
+      }
     }
 
     case "move_note": {
@@ -1020,42 +1062,47 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       const ensureResolvedTagIds = Array.isArray(ensureTagIds) ? ensureTagIds as string[] : undefined;
       const ensureResolvedIsPinned = typeof ensureIsPinned === "boolean" ? ensureIsPinned : undefined;
       const ensureFolder = typeof args.folder === "string" ? args.folder : undefined;
-      if (existing) {
-        const tagIdsJson = ensureResolvedTagIds ? j(ensureResolvedTagIds) : null;
-        const pinnedVal = ensureResolvedIsPinned !== undefined ? (ensureResolvedIsPinned ? 1 : 0) : null;
-        const folderVal = ensureFolder !== undefined ? ensureFolder : null;
-        db.prepare(`UPDATE notes SET content = ?, content_text = ?, tag_ids = COALESCE(?, tag_ids), is_pinned = COALESCE(?, is_pinned), folder = COALESCE(?, folder), updated_at = ? WHERE id = ?`)
-          .run(markdown, stripMarkdown(markdown), tagIdsJson, pinnedVal, folderVal, now, existing.id);
-        const updatedFolder = ensureFolder ?? (existing.folder as string) ?? "";
-        writeNoteFile(workspacePath, {
-          id: existing.id, projectId, workspaceId: existing.workspaceId as string,
-          title: existing.title as string, content: markdown,
-          tagIds: ensureResolvedTagIds ?? existing.tagIds as string[], linkedNoteIds: existing.linkedNoteIds as string[],
-          linkedCardIds: existing.linkedCardIds as string[], isPinned: ensureResolvedIsPinned ?? existing.isPinned as boolean,
-          folder: updatedFolder,
-          createdAt: existing.createdAt as string, updatedAt: now,
-          archivedAt: existing.archivedAt as string | undefined,
-          projectName: project.name,
-        });
-        insertNotification(db, "update_note", "Note updated", `"${title}" was updated (ensure_note)`);
-        return { id: existing.id, title, action: "updated", updatedAt: now };
-      } else {
-        const noteId = newId();
-        const newTagIds = ensureResolvedTagIds ?? [];
-        const newIsPinned = ensureResolvedIsPinned ?? false;
-        const newFolder = ensureFolder ?? "";
-        db.prepare(`
-          INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
-            tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', ?, 'note', ?, ?, ?)
-        `).run(noteId, projectId, project.workspaceId, title, markdown, stripMarkdown(markdown), j(newTagIds), newIsPinned ? 1 : 0, newFolder, now, now);
-        writeNoteFile(workspacePath, {
-          id: noteId, projectId, workspaceId: project.workspaceId, title, content: markdown,
-          tagIds: newTagIds, linkedNoteIds: [], linkedCardIds: [], isPinned: newIsPinned,
-          folder: newFolder, createdAt: now, updatedAt: now, projectName: project.name,
-        });
-        insertNotification(db, "create_note", "Note created", `"${title}" added to ${project.name}${newFolder ? ` (${newFolder})` : ""} (ensure_note)`);
-        return { id: noteId, title, folder: newFolder, action: "created", createdAt: now };
+      const ensureNoteId = existing?.id ?? newId();
+      lockNote(db, ensureNoteId);
+      try {
+        if (existing) {
+          const tagIdsJson = ensureResolvedTagIds ? j(ensureResolvedTagIds) : null;
+          const pinnedVal = ensureResolvedIsPinned !== undefined ? (ensureResolvedIsPinned ? 1 : 0) : null;
+          const folderVal = ensureFolder !== undefined ? ensureFolder : null;
+          db.prepare(`UPDATE notes SET content = ?, content_text = ?, tag_ids = COALESCE(?, tag_ids), is_pinned = COALESCE(?, is_pinned), folder = COALESCE(?, folder), updated_at = ? WHERE id = ?`)
+            .run(markdown, stripMarkdown(markdown), tagIdsJson, pinnedVal, folderVal, now, existing.id);
+          const updatedFolder = ensureFolder ?? (existing.folder as string) ?? "";
+          writeNoteFile(workspacePath, {
+            id: existing.id, projectId, workspaceId: existing.workspaceId as string,
+            title: existing.title as string, content: markdown,
+            tagIds: ensureResolvedTagIds ?? existing.tagIds as string[], linkedNoteIds: existing.linkedNoteIds as string[],
+            linkedCardIds: existing.linkedCardIds as string[], isPinned: ensureResolvedIsPinned ?? existing.isPinned as boolean,
+            folder: updatedFolder,
+            createdAt: existing.createdAt as string, updatedAt: now,
+            archivedAt: existing.archivedAt as string | undefined,
+            projectName: project.name,
+          });
+          insertNotification(db, "update_note", "Note updated", `"${title}" was updated (ensure_note)`);
+          return { id: existing.id, title, action: "updated", updatedAt: now };
+        } else {
+          const newTagIds = ensureResolvedTagIds ?? [];
+          const newIsPinned = ensureResolvedIsPinned ?? false;
+          const newFolder = ensureFolder ?? "";
+          db.prepare(`
+            INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
+              tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', ?, 'note', ?, ?, ?)
+          `).run(ensureNoteId, projectId, project.workspaceId, title, markdown, stripMarkdown(markdown), j(newTagIds), newIsPinned ? 1 : 0, newFolder, now, now);
+          writeNoteFile(workspacePath, {
+            id: ensureNoteId, projectId, workspaceId: project.workspaceId, title, content: markdown,
+            tagIds: newTagIds, linkedNoteIds: [], linkedCardIds: [], isPinned: newIsPinned,
+            folder: newFolder, createdAt: now, updatedAt: now, projectName: project.name,
+          });
+          insertNotification(db, "create_note", "Note created", `"${title}" added to ${project.name}${newFolder ? ` (${newFolder})` : ""} (ensure_note)`);
+          return { id: ensureNoteId, title, folder: newFolder, action: "created", createdAt: now };
+        }
+      } finally {
+        unlockNote(db, ensureNoteId);
       }
     }
 
@@ -1070,20 +1117,25 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       const newContent = existingContent
         ? existingContent + (separator as string) + (appendContent as string)
         : (appendContent as string);
-      db.prepare(`UPDATE notes SET content = ?, content_text = ?, updated_at = ? WHERE id = ?`)
-        .run(newContent, stripMarkdown(newContent), now, noteId);
-      const proj = snap.projects.find((p) => p.id === note.projectId);
-      writeNoteFile(workspacePath, {
-        id: noteId, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
-        title: note.title as string, content: newContent,
-        tagIds: note.tagIds as string[], linkedNoteIds: note.linkedNoteIds as string[],
-        linkedCardIds: note.linkedCardIds as string[], isPinned: note.isPinned as boolean,
-        createdAt: note.createdAt as string, updatedAt: now,
-        archivedAt: note.archivedAt as string | undefined,
-        projectName: proj?.name ?? note.projectId as string,
-      });
-      insertNotification(db, "update_note", "Note updated", `Content appended to "${note.title}"`);
-      return { id: noteId, title: note.title, updatedAt: now, newLength: newContent.length };
+      lockNote(db, noteId as string);
+      try {
+        db.prepare(`UPDATE notes SET content = ?, content_text = ?, updated_at = ? WHERE id = ?`)
+          .run(newContent, stripMarkdown(newContent), now, noteId);
+        const proj = snap.projects.find((p) => p.id === note.projectId);
+        writeNoteFile(workspacePath, {
+          id: noteId, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
+          title: note.title as string, content: newContent,
+          tagIds: note.tagIds as string[], linkedNoteIds: note.linkedNoteIds as string[],
+          linkedCardIds: note.linkedCardIds as string[], isPinned: note.isPinned as boolean,
+          createdAt: note.createdAt as string, updatedAt: now,
+          archivedAt: note.archivedAt as string | undefined,
+          projectName: proj?.name ?? note.projectId as string,
+        });
+        insertNotification(db, "update_note", "Note updated", `Content appended to "${note.title}"`);
+        return { id: noteId, title: note.title, updatedAt: now, newLength: newContent.length };
+      } finally {
+        unlockNote(db, noteId as string);
+      }
     }
 
     case "patch_note": {
@@ -1100,20 +1152,25 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       if (count > 1 && !all) return { error: `oldString matches ${count} times — set replaceAll: true to replace all, or provide more surrounding context to make it unique` };
       const now = ts();
       const newContent = all ? existing.split(oldString).join(replacement) : existing.replace(oldString, replacement);
-      db.prepare(`UPDATE notes SET content = ?, content_text = ?, updated_at = ? WHERE id = ?`)
-        .run(newContent, stripMarkdown(newContent), now, noteId);
-      const proj = snap.projects.find((p) => p.id === note.projectId);
-      writeNoteFile(workspacePath, {
-        id: noteId, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
-        title: note.title as string, content: newContent,
-        tagIds: note.tagIds as string[], linkedNoteIds: note.linkedNoteIds as string[],
-        linkedCardIds: note.linkedCardIds as string[], isPinned: note.isPinned as boolean,
-        createdAt: note.createdAt as string, updatedAt: now,
-        archivedAt: note.archivedAt as string | undefined,
-        projectName: proj?.name ?? note.projectId as string,
-      });
-      insertNotification(db, "update_note", "Note updated", `Patch applied to "${note.title}"`);
-      return { id: noteId, title: note.title, updatedAt: now, replacements: all ? count : 1 };
+      lockNote(db, noteId);
+      try {
+        db.prepare(`UPDATE notes SET content = ?, content_text = ?, updated_at = ? WHERE id = ?`)
+          .run(newContent, stripMarkdown(newContent), now, noteId);
+        const proj = snap.projects.find((p) => p.id === note.projectId);
+        writeNoteFile(workspacePath, {
+          id: noteId, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
+          title: note.title as string, content: newContent,
+          tagIds: note.tagIds as string[], linkedNoteIds: note.linkedNoteIds as string[],
+          linkedCardIds: note.linkedCardIds as string[], isPinned: note.isPinned as boolean,
+          createdAt: note.createdAt as string, updatedAt: now,
+          archivedAt: note.archivedAt as string | undefined,
+          projectName: proj?.name ?? note.projectId as string,
+        });
+        insertNotification(db, "update_note", "Note updated", `Patch applied to "${note.title}"`);
+        return { id: noteId, title: note.title, updatedAt: now, replacements: all ? count : 1 };
+      } finally {
+        unlockNote(db, noteId);
+      }
     }
 
     // ── Idea Flow tools ───────────────────────────────────────────────────────
@@ -1694,6 +1751,7 @@ if (require.main === module) {
   // PRAGMA foreign_keys must be set per-connection; applySchema is not called in the MCP process.
   db.pragma("foreign_keys = ON");
   db.pragma("journal_mode = WAL");
+  ensureMcpActiveWritesTable(db);
   const workspacePath = findWorkspacePath(dbPath);
   process.stderr.write(`[cairn:mcp] Workspace folder: ${workspacePath}\n`);
   const server = buildMcpServer(db, workspacePath);

--- a/electron/mcp-server.ts
+++ b/electron/mcp-server.ts
@@ -343,6 +343,27 @@ function unlockNote(db: Database.Database, noteId: string): void {
   } catch { /* best-effort */ }
 }
 
+// ── Optimistic-concurrency helper ─────────────
+// Returns null when no version column exists yet (pre-v12 DB).
+function getNoteVersion(db: Database.Database, noteId: string): number | null {
+  try {
+    const row = db.prepare("SELECT version FROM notes WHERE id = ?").get(noteId) as { version: number } | undefined;
+    return row?.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// Returns null when no version column exists yet (pre-v13 DB).
+function getCardVersion(db: Database.Database, cardId: string): number | null {
+  try {
+    const row = db.prepare("SELECT version FROM task_cards WHERE id = ?").get(cardId) as { version: number } | undefined;
+    return row?.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
 // ── MCP notification helper ───────────────────
 
 function insertNotification(db: Database.Database, tool: string, title: string, body: string): void {
@@ -564,17 +585,19 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       const folder = typeof args.folder === "string" ? args.folder : "";
       lockNote(db, noteId);
       try {
-        db.prepare(`
-          INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
-            tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', 0, 'note', ?, ?, ?)
-        `).run(noteId, projectId, project.workspaceId, title, markdown, stripMarkdown(markdown), j(resolvedTagIds), folder, now, now);
+        db.transaction(() => {
+          db.prepare(`
+            INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
+              tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', 0, 'note', ?, ?, ?)
+          `).run(noteId, projectId, project.workspaceId, title, markdown, stripMarkdown(markdown), j(resolvedTagIds), folder, now, now);
+          insertNotification(db, "create_note", "Note created", `"${title}" added to ${project.name}${folder ? ` (${folder})` : ""}`);
+        })();
         writeNoteFile(workspacePath, {
           id: noteId, projectId, workspaceId: project.workspaceId, title, content: markdown,
           tagIds: resolvedTagIds, linkedNoteIds: [], linkedCardIds: [], isPinned: false,
           folder, createdAt: now, updatedAt: now, projectName: project.name,
         });
-        insertNotification(db, "create_note", "Note created", `"${title}" added to ${project.name}${folder ? ` (${folder})` : ""}`);
         return { id: noteId, title, folder, createdAt: now };
       } finally {
         unlockNote(db, noteId);
@@ -601,34 +624,48 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       const now = ts();
       const noteId = newId();
       const importResolvedTagIds = Array.isArray(importTagIds) ? importTagIds as string[] : [];
-      db.prepare(`
-        INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
-          tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', 0, 'note', ?, ?)
-      `).run(noteId, projectId, project.workspaceId, title, markdown, stripMarkdown(markdown), j(importResolvedTagIds), now, now);
+      db.transaction(() => {
+        db.prepare(`
+          INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
+            tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', 0, 'note', ?, ?)
+        `).run(noteId, projectId, project.workspaceId, title, markdown, stripMarkdown(markdown), j(importResolvedTagIds), now, now);
+        insertNotification(db, "create_note", "Note imported", `"${title}" imported into ${project.name}`);
+      })();
       writeNoteFile(workspacePath, {
         id: noteId, projectId, workspaceId: project.workspaceId, title, content: markdown,
         tagIds: importResolvedTagIds, linkedNoteIds: [], linkedCardIds: [], isPinned: false,
         createdAt: now, updatedAt: now, projectName: project.name,
       });
-      insertNotification(db, "create_note", "Note imported", `"${title}" imported into ${project.name}`);
       return { id: noteId, title, createdAt: now, importedFrom: resolvedPath };
     }
 
     case "update_note": {
-      const { noteId, title, content, isPinned, tagIds } = args;
+      const { noteId, title, content, isPinned, tagIds, expectedVersion } = args;
       const note = snap.notes.find((n) => n.id === noteId);
       if (!note) return { error: "Note not found" };
+      // Optimistic-concurrency check — reject if the caller's snapshot is stale.
+      if (expectedVersion !== undefined) {
+        const currentVersion = getNoteVersion(db, noteId as string);
+        if (currentVersion !== null && currentVersion !== (expectedVersion as number)) {
+          return { error: `Version conflict: note has been modified (expected v${expectedVersion as number}, got v${currentVersion}). Fetch the latest content before retrying.` };
+        }
+      }
       const now = ts();
       const markdown = content !== undefined ? content : null;
       const pinnedVal = isPinned !== undefined ? (isPinned ? 1 : 0) : null;
       const tagIdsJson = Array.isArray(tagIds) ? j(tagIds) : null;
       lockNote(db, noteId as string);
       try {
-        db.prepare(`UPDATE notes SET title = COALESCE(?, title), content = COALESCE(?, content), content_text = COALESCE(?, content_text), is_pinned = COALESCE(?, is_pinned), tag_ids = COALESCE(?, tag_ids), updated_at = ? WHERE id = ?`)
-          .run(title ?? null, markdown, markdown !== null ? stripMarkdown(markdown) : null, pinnedVal, tagIdsJson, now, noteId);
         const resolvedIsPinned = isPinned !== undefined ? (isPinned as boolean) : note.isPinned as boolean;
         const updateProj = snap.projects.find((pr) => pr.id === note.projectId);
+        // Wrap both SQL writes in a transaction so a partial failure leaves the
+        // DB consistent (both committed or neither).
+        db.transaction(() => {
+          db.prepare(`UPDATE notes SET title = COALESCE(?, title), content = COALESCE(?, content), content_text = COALESCE(?, content_text), is_pinned = COALESCE(?, is_pinned), tag_ids = COALESCE(?, tag_ids), updated_at = ?, version = version + 1 WHERE id = ?`)
+            .run(title ?? null, markdown, markdown !== null ? stripMarkdown(markdown) : null, pinnedVal, tagIdsJson, now, noteId);
+          insertNotification(db, "update_note", "Note updated", `"${title ?? note.title}" was updated`);
+        })();
         writeNoteFile(workspacePath, {
           id: noteId, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
           title: title ?? note.title as string,
@@ -639,7 +676,6 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
           archivedAt: note.archivedAt as string | undefined,
           projectName: updateProj?.name ?? note.projectId as string,
         });
-        insertNotification(db, "update_note", "Note updated", `"${title ?? note.title}" was updated`);
         return { id: noteId, title: title ?? note.title, isPinned: resolvedIsPinned, updatedAt: now };
       } finally {
         unlockNote(db, noteId as string);
@@ -693,13 +729,19 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
     }
 
     case "update_task_status": {
-      const { cardId, targetColumnId } = args;
+      const { cardId, targetColumnId, expectedVersion: statusExpectedVersion } = args;
       const card = snap.cards.find((c) => c.id === cardId);
       const col = snap.columns.find((c) => c.id === targetColumnId);
       if (!card) return { error: "Card not found" };
       if (!col) return { error: "Column not found" };
+      if (statusExpectedVersion !== undefined) {
+        const currentVersion = getCardVersion(db, cardId as string);
+        if (currentVersion !== null && currentVersion !== (statusExpectedVersion as number)) {
+          return { error: `Version conflict: task has been modified (expected v${statusExpectedVersion as number}, got v${currentVersion}). Fetch the latest state before retrying.` };
+        }
+      }
       const now = ts();
-      db.prepare(`UPDATE task_cards SET column_id = ?, updated_at = ? WHERE id = ?`).run(targetColumnId, now, cardId);
+      db.prepare(`UPDATE task_cards SET column_id = ?, updated_at = ?, version = version + 1 WHERE id = ?`).run(targetColumnId, now, cardId);
       // When a task moves to a done column, clear it from any other task's blocked_by_ids
       // so get_task no longer reports it as a pending blocker.
       if (col.type === "done") {
@@ -709,7 +751,7 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
         for (const row of affected) {
           const ids: string[] = j2(row.blocked_by_ids);
           if (ids.includes(cardId as string)) {
-            db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ? WHERE id = ?")
+            db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ?, version = version + 1 WHERE id = ?")
               .run(j(ids.filter((bid) => bid !== cardId)), now, row.id);
           }
         }
@@ -731,7 +773,7 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
         if (!card) {
           results.push({ id, ok: false, error: "Task not found" });
         } else {
-          db.prepare(`UPDATE task_cards SET column_id = ?, updated_at = ? WHERE id = ?`).run(targetColumnId, now, id);
+          db.prepare(`UPDATE task_cards SET column_id = ?, updated_at = ?, version = version + 1 WHERE id = ?`).run(targetColumnId, now, id);
           results.push({ id, ok: true });
         }
       }
@@ -748,7 +790,7 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
             const ids: string[] = j2(row.blocked_by_ids);
             const cleaned = ids.filter((bid) => !movedIds.includes(bid));
             if (cleaned.length !== ids.length) {
-              db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ? WHERE id = ?")
+              db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ?, version = version + 1 WHERE id = ?")
                 .run(j(cleaned), now, row.id);
             }
           }
@@ -769,8 +811,8 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       const newCardIds = j(Array.from(new Set([...(note.linkedCardIds as string[]), cardId])));
       const newNoteIds = j(Array.from(new Set([...(card.linkedNoteIds as string[]), noteId])));
       const now = ts();
-      db.prepare(`UPDATE notes SET linked_card_ids = ?, updated_at = ? WHERE id = ?`).run(newCardIds, now, noteId);
-      db.prepare(`UPDATE task_cards SET linked_note_ids = ?, updated_at = ? WHERE id = ?`).run(newNoteIds, now, cardId);
+      db.prepare(`UPDATE notes SET linked_card_ids = ?, updated_at = ?, version = version + 1 WHERE id = ?`).run(newCardIds, now, noteId);
+      db.prepare(`UPDATE task_cards SET linked_note_ids = ?, updated_at = ?, version = version + 1 WHERE id = ?`).run(newNoteIds, now, cardId);
       insertNotification(db, "link_note_to_task", "Note linked to task", `"${note.title}" linked to "${card.title}"`);
       return { noteId, cardId, linked: true };
     }
@@ -782,7 +824,7 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
         id: note.id, title: note.title, content: note.content,
         projectId: note.projectId, isPinned: note.isPinned,
         linkedNoteIds: note.linkedNoteIds, linkedCardIds: note.linkedCardIds,
-        updatedAt: note.updatedAt,
+        updatedAt: note.updatedAt, version: note.version ?? 0,
       };
     }
 
@@ -815,7 +857,7 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
         priority: card.priority, dueDate: card.dueDate,
         columnId: card.columnId, columnName: col?.name ?? "Unknown", columnType: col?.type ?? "custom",
         linkedNoteIds: card.linkedNoteIds, blockedByIds: card.blockedByIds ?? [],
-        projectId: card.projectId, createdAt: card.createdAt, updatedAt: card.updatedAt,
+        projectId: card.projectId, createdAt: card.createdAt, updatedAt: card.updatedAt, version: card.version ?? 0,
       };
     }
 
@@ -877,7 +919,7 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       const ids: string[] = j2(row.blocked_by_ids);
       if (!ids.includes(args.blockerCardId as string)) {
         ids.push(args.blockerCardId as string);
-        db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ? WHERE id = ?").run(j(ids), nowB, args.cardId);
+        db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ?, version = version + 1 WHERE id = ?").run(j(ids), nowB, args.cardId);
       }
       insertNotification(db, "block_task", "Task blocked", `"${card.title}" is now blocked by "${blocker.title}"`);
       return { cardId: args.cardId, blockerCardId: args.blockerCardId, blocked: true };
@@ -891,7 +933,7 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       if (!rowU) return { error: "Task not found in DB" };
       const idsU: string[] = j2(rowU.blocked_by_ids);
       const updated = idsU.filter((id) => id !== args.blockerCardId);
-      db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ? WHERE id = ?").run(j(updated), nowU, args.cardId);
+      db.prepare("UPDATE task_cards SET blocked_by_ids = ?, updated_at = ?, version = version + 1 WHERE id = ?").run(j(updated), nowU, args.cardId);
       return { cardId: args.cardId, blockerCardId: args.blockerCardId, unblocked: true };
     }
 
@@ -935,28 +977,37 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
     }
 
     case "update_task": {
-      const { cardId, title, description, priority, dueDate, columnId, tagIds } = args;
+      const { cardId, title, description, priority, dueDate, columnId, tagIds, expectedVersion: taskExpectedVersion } = args;
       const card = snap.cards.find((c) => c.id === cardId);
       if (!card) return { error: "Task not found" };
+      if (taskExpectedVersion !== undefined) {
+        const currentVersion = getCardVersion(db, cardId as string);
+        if (currentVersion !== null && currentVersion !== (taskExpectedVersion as number)) {
+          return { error: `Version conflict: task has been modified (expected v${taskExpectedVersion as number}, got v${currentVersion}). Fetch the latest state before retrying.` };
+        }
+      }
       const now = ts();
-      db.prepare(`
-        UPDATE task_cards SET
-          column_id   = COALESCE(?, column_id),
-          title       = COALESCE(?, title),
-          description = COALESCE(?, description),
-          priority    = COALESCE(?, priority),
-          due_date    = COALESCE(?, due_date),
-          tag_ids     = COALESCE(?, tag_ids),
-          updated_at  = ?
-        WHERE id = ?
-      `).run(
-        columnId ?? null, title ?? null, description ?? null,
-        priority ?? null, dueDate ?? null,
-        tagIds != null ? (Array.isArray(tagIds) ? j(tagIds) : tagIds) : null,
-        now, cardId
-      );
+      db.transaction(() => {
+        db.prepare(`
+          UPDATE task_cards SET
+            column_id   = COALESCE(?, column_id),
+            title       = COALESCE(?, title),
+            description = COALESCE(?, description),
+            priority    = COALESCE(?, priority),
+            due_date    = COALESCE(?, due_date),
+            tag_ids     = COALESCE(?, tag_ids),
+            updated_at  = ?,
+            version     = version + 1
+          WHERE id = ?
+        `).run(
+          columnId ?? null, title ?? null, description ?? null,
+          priority ?? null, dueDate ?? null,
+          tagIds != null ? (Array.isArray(tagIds) ? j(tagIds) : tagIds) : null,
+          now, cardId
+        );
+        insertNotification(db, "update_task", "Task updated", `"${title ?? card.title}" was updated`);
+      })();
       const updated = db.prepare("SELECT * FROM task_cards WHERE id = ?").get(cardId) as Record<string, unknown> | undefined;
-      insertNotification(db, "update_task", "Task updated", `"${title ?? card.title}" was updated`);
       return updated ?? { error: "Task not found after update" };
     }
 
@@ -1069,9 +1120,12 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
           const tagIdsJson = ensureResolvedTagIds ? j(ensureResolvedTagIds) : null;
           const pinnedVal = ensureResolvedIsPinned !== undefined ? (ensureResolvedIsPinned ? 1 : 0) : null;
           const folderVal = ensureFolder !== undefined ? ensureFolder : null;
-          db.prepare(`UPDATE notes SET content = ?, content_text = ?, tag_ids = COALESCE(?, tag_ids), is_pinned = COALESCE(?, is_pinned), folder = COALESCE(?, folder), updated_at = ? WHERE id = ?`)
-            .run(markdown, stripMarkdown(markdown), tagIdsJson, pinnedVal, folderVal, now, existing.id);
           const updatedFolder = ensureFolder ?? (existing.folder as string) ?? "";
+          db.transaction(() => {
+            db.prepare(`UPDATE notes SET content = ?, content_text = ?, tag_ids = COALESCE(?, tag_ids), is_pinned = COALESCE(?, is_pinned), folder = COALESCE(?, folder), updated_at = ?, version = version + 1 WHERE id = ?`)
+              .run(markdown, stripMarkdown(markdown), tagIdsJson, pinnedVal, folderVal, now, existing.id);
+            insertNotification(db, "update_note", "Note updated", `"${title}" was updated (ensure_note)`);
+          })();
           writeNoteFile(workspacePath, {
             id: existing.id, projectId, workspaceId: existing.workspaceId as string,
             title: existing.title as string, content: markdown,
@@ -1082,23 +1136,24 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
             archivedAt: existing.archivedAt as string | undefined,
             projectName: project.name,
           });
-          insertNotification(db, "update_note", "Note updated", `"${title}" was updated (ensure_note)`);
           return { id: existing.id, title, action: "updated", updatedAt: now };
         } else {
           const newTagIds = ensureResolvedTagIds ?? [];
           const newIsPinned = ensureResolvedIsPinned ?? false;
           const newFolder = ensureFolder ?? "";
-          db.prepare(`
-            INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
-              tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', ?, 'note', ?, ?, ?)
-          `).run(ensureNoteId, projectId, project.workspaceId, title, markdown, stripMarkdown(markdown), j(newTagIds), newIsPinned ? 1 : 0, newFolder, now, now);
+          db.transaction(() => {
+            db.prepare(`
+              INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
+                tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?, '[]', '[]', ?, 'note', ?, ?, ?)
+            `).run(ensureNoteId, projectId, project.workspaceId, title, markdown, stripMarkdown(markdown), j(newTagIds), newIsPinned ? 1 : 0, newFolder, now, now);
+            insertNotification(db, "create_note", "Note created", `"${title}" added to ${project.name}${newFolder ? ` (${newFolder})` : ""} (ensure_note)`);
+          })();
           writeNoteFile(workspacePath, {
             id: ensureNoteId, projectId, workspaceId: project.workspaceId, title, content: markdown,
             tagIds: newTagIds, linkedNoteIds: [], linkedCardIds: [], isPinned: newIsPinned,
             folder: newFolder, createdAt: now, updatedAt: now, projectName: project.name,
           });
-          insertNotification(db, "create_note", "Note created", `"${title}" added to ${project.name}${newFolder ? ` (${newFolder})` : ""} (ensure_note)`);
           return { id: ensureNoteId, title, folder: newFolder, action: "created", createdAt: now };
         }
       } finally {
@@ -1109,9 +1164,15 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
     case "append_to_note": {
       // Appends content to the end of a note without requiring the agent to
       // fetch and re-send the full body.
-      const { noteId, content: appendContent, separator = "\n\n" } = args;
+      const { noteId, content: appendContent, separator = "\n\n", expectedVersion: appendExpectedVersion } = args;
       const note = snap.notes.find((n) => n.id === noteId);
       if (!note) return { error: "Note not found" };
+      if (appendExpectedVersion !== undefined) {
+        const currentVersion = getNoteVersion(db, noteId as string);
+        if (currentVersion !== null && currentVersion !== (appendExpectedVersion as number)) {
+          return { error: `Version conflict: note has been modified (expected v${appendExpectedVersion as number}, got v${currentVersion}). Fetch the latest content before retrying.` };
+        }
+      }
       const now = ts();
       const existingContent = (note.content as string) ?? "";
       const newContent = existingContent
@@ -1119,9 +1180,12 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
         : (appendContent as string);
       lockNote(db, noteId as string);
       try {
-        db.prepare(`UPDATE notes SET content = ?, content_text = ?, updated_at = ? WHERE id = ?`)
-          .run(newContent, stripMarkdown(newContent), now, noteId);
         const proj = snap.projects.find((p) => p.id === note.projectId);
+        db.transaction(() => {
+          db.prepare(`UPDATE notes SET content = ?, content_text = ?, updated_at = ?, version = version + 1 WHERE id = ?`)
+            .run(newContent, stripMarkdown(newContent), now, noteId);
+          insertNotification(db, "update_note", "Note updated", `Content appended to "${note.title}"`);
+        })();
         writeNoteFile(workspacePath, {
           id: noteId, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
           title: note.title as string, content: newContent,
@@ -1131,7 +1195,6 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
           archivedAt: note.archivedAt as string | undefined,
           projectName: proj?.name ?? note.projectId as string,
         });
-        insertNotification(db, "update_note", "Note updated", `Content appended to "${note.title}"`);
         return { id: noteId, title: note.title, updatedAt: now, newLength: newContent.length };
       } finally {
         unlockNote(db, noteId as string);
@@ -1141,11 +1204,17 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
     case "patch_note": {
       // Surgical in-place replacement — agent sends oldString + newString,
       // server does the substitution. Avoids re-sending full note content.
-      const { noteId, oldString, newString: replacement, replaceAll: all = false } = args as {
-        noteId: string; oldString: string; newString: string; replaceAll?: boolean;
+      const { noteId, oldString, newString: replacement, replaceAll: all = false, expectedVersion: patchExpectedVersion } = args as {
+        noteId: string; oldString: string; newString: string; replaceAll?: boolean; expectedVersion?: number;
       };
       const note = snap.notes.find((n) => n.id === noteId);
       if (!note) return { error: "Note not found" };
+      if (patchExpectedVersion !== undefined) {
+        const currentVersion = getNoteVersion(db, noteId);
+        if (currentVersion !== null && currentVersion !== patchExpectedVersion) {
+          return { error: `Version conflict: note has been modified (expected v${patchExpectedVersion}, got v${currentVersion}). Fetch the latest content before retrying.` };
+        }
+      }
       const existing = (note.content as string) ?? "";
       const count = existing.split(oldString).length - 1;
       if (count === 0) return { error: "oldString not found in note content" };
@@ -1154,9 +1223,12 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       const newContent = all ? existing.split(oldString).join(replacement) : existing.replace(oldString, replacement);
       lockNote(db, noteId);
       try {
-        db.prepare(`UPDATE notes SET content = ?, content_text = ?, updated_at = ? WHERE id = ?`)
-          .run(newContent, stripMarkdown(newContent), now, noteId);
         const proj = snap.projects.find((p) => p.id === note.projectId);
+        db.transaction(() => {
+          db.prepare(`UPDATE notes SET content = ?, content_text = ?, updated_at = ?, version = version + 1 WHERE id = ?`)
+            .run(newContent, stripMarkdown(newContent), now, noteId);
+          insertNotification(db, "update_note", "Note updated", `Patch applied to "${note.title}"`);
+        })();
         writeNoteFile(workspacePath, {
           id: noteId, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
           title: note.title as string, content: newContent,
@@ -1166,7 +1238,6 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
           archivedAt: note.archivedAt as string | undefined,
           projectName: proj?.name ?? note.projectId as string,
         });
-        insertNotification(db, "update_note", "Note updated", `Patch applied to "${note.title}"`);
         return { id: noteId, title: note.title, updatedAt: now, replacements: all ? count : 1 };
       } finally {
         unlockNote(db, noteId);

--- a/electron/notes-files.test.ts
+++ b/electron/notes-files.test.ts
@@ -470,20 +470,22 @@ describe("syncNotesFromDisk", () => {
     expect(parsed!.id).toBe(rows[0].id);
   });
 
-  it("does not overwrite an existing SQLite row for a Cairn note", () => {
+  it("does not overwrite an existing SQLite row when the DB row is newer than the file", () => {
     seedProjectInDb(db, "My Project", "proj1", "ws1");
     const note = makeNote({ projectName: "My Project", title: "Existing Note" });
     writeNoteFile(tmpDir, note);
-    // Pre-insert the note into SQLite with modified title
+    // Insert the DB row with an updated_at well in the future relative to the file,
+    // so both the frontmatter timestamp and the file mtime are definitively older.
+    const futureTs = new Date(Date.now() + 60_000).toISOString();
     db.prepare(`INSERT INTO notes (id, project_id, workspace_id, title, content, content_text,
       tag_ids, linked_note_ids, linked_card_ids, is_pinned, type, folder, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, '[]', '[]', '[]', 0, 'note', '', ?, ?)`)
       .run(note.id, note.projectId, note.workspaceId, "Modified Title", note.content, "",
-           note.createdAt, note.updatedAt);
+           note.createdAt, futureTs);
 
     syncNotesFromDisk(db, tmpDir);
 
-    // Should NOT overwrite — row was already present
+    // DB row is newer — file should NOT overwrite it
     const row = db.prepare("SELECT title FROM notes WHERE id = ?").get(note.id) as { title: string };
     expect(row.title).toBe("Modified Title");
   });

--- a/electron/notes-files.ts
+++ b/electron/notes-files.ts
@@ -153,8 +153,8 @@ export function writeNoteFile(workspacePath: string, note: NoteData): void {
   const newPath = resolveNoteFilePath(workspacePath, projectName, note.title, note.id, folder);
 
   if (existingPath && existingPath !== newPath) {
-    // Title or folder changed — delete old file, write new one
-    try { fs.unlinkSync(existingPath); } catch { /* ignore */ }
+    // Title or folder changed — delete old file after the new one is safely written
+    // (handled below — unlink happens after the atomic rename succeeds).
   }
 
   const frontmatter: Record<string, unknown> = {
@@ -172,7 +172,18 @@ export function writeNoteFile(workspacePath: string, note: NoteData): void {
   };
   if (note.archivedAt) frontmatter.archivedAt = note.archivedAt;
 
-  fs.writeFileSync(newPath, matter.stringify(note.content ?? "", frontmatter), "utf-8");
+  // Atomic write: write to a .tmp file first, then rename into place.
+  // fs.renameSync on the same filesystem is atomic at the VFS level, so a
+  // crash between the SQLite UPDATE and this call leaves a stale .tmp (cleaned
+  // up by syncNotesFromDisk on next startup) rather than a half-written .md.
+  const tmpPath = newPath + ".tmp";
+  fs.writeFileSync(tmpPath, matter.stringify(note.content ?? "", frontmatter), "utf-8");
+  fs.renameSync(tmpPath, newPath);
+
+  // Now safe to remove the old file (rename already succeeded)
+  if (existingPath && existingPath !== newPath) {
+    try { fs.unlinkSync(existingPath); } catch { /* ignore */ }
+  }
 }
 
 export function deleteNoteFile(
@@ -234,15 +245,39 @@ export function parseNoteFile(filePath: string): NoteData | null {
 
 // ── Startup sync ──────────────────────────────
 //
-// Walks the entire notes directory and upserts every .md file whose id is not
-// already present in SQLite. Runs once on startup (and after reinitialise) so
-// that notes written to disk but not committed to SQLite (e.g. due to a
-// fire-and-forget IPC race or an unexpected shutdown) are recovered.
+// Walks the entire notes directory on startup and reconciles .md files with
+// SQLite. Two cases are handled:
+//
+//  1. Note missing from SQLite → always import (crash recovery).
+//  2. Note present in SQLite but .md is newer → overwrite SQLite content.
+//     Detects notes edited in an external editor while Cairn was closed.
+//     Uses frontmatter updatedAt as primary signal; falls back to file mtime
+//     (with a 2-second buffer for filesystem precision differences).
+//
+// Also cleans up any stale *.md.tmp files left by a crash during an atomic write.
 
 export function syncNotesFromDisk(db: Database.Database, workspacePath: string): void {
   const root = notesDir(workspacePath);
   if (!fs.existsSync(root)) return;
+  cleanStaleTmpFiles(root);
   syncDir(db, root, workspacePath);
+}
+
+/** Remove any *.md.tmp files left by a crash during an atomic write. */
+function cleanStaleTmpFiles(dir: string): void {
+  try {
+    for (const entry of fs.readdirSync(dir)) {
+      const fp = path.join(dir, entry);
+      try {
+        const stat = fs.lstatSync(fp);
+        if (stat.isDirectory()) {
+          cleanStaleTmpFiles(fp);
+        } else if (entry.endsWith(".md.tmp")) {
+          fs.unlinkSync(fp);
+        }
+      } catch { /* skip unreadable entries */ }
+    }
+  } catch { /* root unreadable */ }
 }
 
 function syncDir(db: Database.Database, dir: string, workspacePath: string): void {
@@ -256,11 +291,29 @@ function syncDir(db: Database.Database, dir: string, workspacePath: string): voi
       // Plain .md without Cairn frontmatter — adopt it in-place
       if (!note) note = adoptExternalNoteFile(db, workspacePath, fp);
       if (!note) continue;
-      // Only upsert if the note is missing from SQLite — avoids overwriting
-      // in-memory state that is ahead of the file (e.g. unsaved edits).
-      const exists = db.prepare("SELECT id FROM notes WHERE id = ?").get(note.id);
-      if (!exists) {
+
+      const row = db.prepare("SELECT updated_at FROM notes WHERE id = ?")
+        .get(note.id) as { updated_at: string } | undefined;
+
+      if (!row) {
+        // Missing from SQLite — always import
         upsertNoteFromFile(db, note);
+      } else {
+        // Compare timestamps: import if file is demonstrably newer than DB row.
+        // Primary: frontmatter updatedAt (written by Cairn on every save).
+        const fileTs = new Date(note.updatedAt ?? note.createdAt).getTime();
+        const dbTs   = new Date(row.updated_at).getTime();
+        if (fileTs > dbTs) {
+          upsertNoteFromFile(db, note);
+        } else {
+          // Fallback: if frontmatter timestamp didn't change (external editor
+          // edited the body without touching frontmatter), use file mtime.
+          // 2-second buffer avoids spurious overwrites from FS precision drift.
+          const fileMtime = stat.mtimeMs;
+          if (fileMtime > dbTs + 2000) {
+            upsertNoteFromFile(db, note);
+          }
+        }
       }
     }
   }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -192,6 +192,23 @@ const api = {
     return () => ipcRenderer.off("db:changed", handler);
   },
 
+  // ── AI write lock events ──────────────────────
+  // Fired by the main process when the in-app AI chat executor starts or
+  // finishes writing to a note. The renderer uses these to show a read-only
+  // indicator on the active note editor.
+  onAiWriteStarted: (cb: (payload: { noteId: string }) => void) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handler = (_: any, payload: { noteId: string }) => cb(payload);
+    ipcRenderer.on("note:aiWriteStarted", handler);
+    return () => ipcRenderer.off("note:aiWriteStarted", handler);
+  },
+  onAiWriteEnded: (cb: (payload: { noteId: string }) => void) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handler = (_: any, payload: { noteId: string }) => cb(payload);
+    ipcRenderer.on("note:aiWriteEnded", handler);
+    return () => ipcRenderer.off("note:aiWriteEnded", handler);
+  },
+
   // ── Dashboard live query bridge ───────────────
   mcpQuery: (tool: string, args: Record<string, unknown>) => invoke<unknown>("db:mcpQuery", { tool, args }),
 

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -787,6 +787,7 @@ function IdeaFlowCanvas() {
       order: 0,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
+      version: 0,
     };
     historyManager.push(makePromoteToTaskCmd(node, newNode.id, createdCard, connectedEdges, activeProjectId));
   }, [nodes, edges, setNodes, setEdges, activeProjectId, activeWorkspaceId, columns]);

--- a/src/components/notes/markdown-editor.tsx
+++ b/src/components/notes/markdown-editor.tsx
@@ -9,7 +9,7 @@
 
 import React, { useEffect, useRef, useImperativeHandle, forwardRef } from "react";
 import { EditorView, ViewUpdate, keymap, placeholder as cmPlaceholder } from "@codemirror/view";
-import { EditorState } from "@codemirror/state";
+import { EditorState, Compartment } from "@codemirror/state";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { languages } from "@codemirror/language-data";
 import { defaultKeymap, indentWithTab, history, historyKeymap } from "@codemirror/commands";
@@ -30,6 +30,8 @@ interface MarkdownEditorProps {
   onSelectionChange?: (sel: { text: string; coords: { top: number; left: number } } | null) => void;
   placeholder?: string;
   className?: string;
+  /** When true, the editor is read-only (used during AI writes). */
+  readOnly?: boolean;
 }
 
 // ── Cairn theme ────────────────────────────────────────────────────────────
@@ -117,9 +119,12 @@ function buildTheme() {
 }
 
 const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(
-  ({ initialValue, onChange, onSelectionChange, placeholder = "Write here…", className }, ref) => {
+  ({ initialValue, onChange, onSelectionChange, placeholder = "Write here…", className, readOnly = false }, ref) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView | null>(null);
+    // Compartment allows reconfiguring editability after the editor is created
+    // without destroying and recreating the full EditorState.
+    const editableCompartment = useRef(new Compartment());
 
     useImperativeHandle(ref, () => ({
       getSelection() {
@@ -240,6 +245,8 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(
           updateListener,
           pasteHandler,
           EditorView.lineWrapping,
+          // Compartment-controlled editability — reconfigured via readOnly prop
+          editableCompartment.current.of(EditorView.editable.of(true)),
         ],
       });
 
@@ -253,6 +260,19 @@ const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorProps>(
       // Only run on mount — content updates handled below
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    // Toggle read-only mode — used when the AI is actively writing this note.
+    // Reconfigures the editable Compartment so the cursor and interactions are
+    // disabled without destroying editor state or undo history.
+    useEffect(() => {
+      const view = viewRef.current;
+      if (!view) return;
+      view.dispatch({
+        effects: editableCompartment.current.reconfigure(
+          EditorView.editable.of(!readOnly),
+        ),
+      });
+    }, [readOnly]);
 
     // When the note ID changes (different note selected), replace the full doc
     // without recreating the editor (preserves undo history isolation via key

--- a/src/components/notes/note-editor.tsx
+++ b/src/components/notes/note-editor.tsx
@@ -378,6 +378,22 @@ export function NoteEditor({ note }: NoteEditorProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [note.id]);
 
+  // ── AI write lock ─────────────────────────────────────────────────────────
+  // When the in-app AI or MCP server is actively writing this note, the editor
+  // goes read-only and a non-blocking banner is shown.
+  const [isAiWriting, setIsAiWriting] = useState(false);
+  useEffect(() => {
+    const electron = window.electron;
+    if (!electron) return;
+    const offStarted = electron.onAiWriteStarted(({ noteId }) => {
+      if (noteId === note.id) setIsAiWriting(true);
+    });
+    const offEnded = electron.onAiWriteEnded(({ noteId }) => {
+      if (noteId === note.id) setIsAiWriting(false);
+    });
+    return () => { offStarted(); offEnded(); };
+  }, [note.id]);
+
   // Spawn tasks state
   const [spawnLoading, setSpawnLoading] = useState(false);
   const [spawnResult, setSpawnResult] = useState<{ count: number } | null>(null);
@@ -1077,8 +1093,24 @@ export function NoteEditor({ note }: NoteEditorProps) {
 
       {/* ── Editor / Preview ────────────────────────────────────────────────── */}
       <div className="flex-1 min-h-0 overflow-hidden relative">
+        {/* AI write lock banner */}
+        {isAiWriting && (
+          <div
+            className="absolute top-0 inset-x-0 z-10 flex items-center gap-2 px-4 py-1.5 text-xs"
+            style={{
+              background: "color-mix(in srgb, var(--accent) 12%, transparent)",
+              borderBottom: "1px solid color-mix(in srgb, var(--accent) 30%, transparent)",
+              color: "var(--accent)",
+            }}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 animate-spin" style={{ animationDuration: "1.5s" }}>
+              <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            </svg>
+            AI is editing this note…
+          </div>
+        )}
         {/* CodeMirror — always mounted so state is preserved when toggling */}
-        <div className={cn("absolute inset-0 overflow-auto", mode === "read" && "invisible pointer-events-none")}>
+        <div className={cn("absolute inset-0 overflow-auto", mode === "read" && "invisible pointer-events-none", isAiWriting && "pt-8")}>
           <MarkdownEditor
             key={note.id}
             ref={editorRef}
@@ -1086,6 +1118,7 @@ export function NoteEditor({ note }: NoteEditorProps) {
             onChange={handleContentChange}
             onSelectionChange={handleSelectionChange}
             placeholder="Write here…"
+            readOnly={isAiWriting}
           />
         </div>
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -18,6 +18,7 @@ import type {
 } from "@/types";
 import { storage } from "@/lib/storage";
 import { historyManager } from "@/lib/history";
+import { isOwnNoteWrite } from "./ipc";
 import { DEFAULT_AI_CONFIG, AI_CONFIG_KEY, ACTIVE_PROJECT_KEY } from "@/lib/constants";
 
 // ── Slice imports ─────────────────────────────────────────────────────────────
@@ -230,10 +231,23 @@ export const useCairnStore = create<CairnStore>()(
       // External (MCP/AI) write refreshes invalidate the undo stack.
       if (isRefresh) historyManager.clear();
 
+      // Merge snapshot notes: preserve any note that was recently written by
+      // the user (within the own-write window) so we don't overwrite optimistic
+      // state with a stale snapshot triggered by the WAL poller.
+      const snapNotes: Note[] = snap.notes ?? [];
+      const mergedNotes = isRefresh
+        ? snapNotes.map((sn) => {
+            if (isOwnNoteWrite(sn.id)) {
+              return current.notes.find((cn) => cn.id === sn.id) ?? sn;
+            }
+            return sn;
+          })
+        : snapNotes;
+
       set({
         workspaces: snap.workspaces ?? [],
         projects: snap.projects ?? [],
-        notes: snap.notes ?? [],
+        notes: mergedNotes,
         columns: snap.columns ?? [],
         cards: snap.cards ?? [],
         tags: snap.tags ?? [],

--- a/src/store/ipc.ts
+++ b/src/store/ipc.ts
@@ -11,6 +11,25 @@
 import { CairnEvents } from "@/lib/events";
 import { ownWriteGuard } from "@/lib/history";
 
+// ── Per-note own-write map ────────────────────────────────────────────────────
+// Tracks the timestamp of the last own write per note ID so the db:changed
+// handler in page.tsx can skip re-hydrating notes that were just written by
+// the user (preventing optimistic state being overwritten by a stale snapshot).
+// Window is 1.5 s — long enough to outlast a WAL poll cycle (1 s) but short
+// enough not to suppress a legitimate MCP write to the same note immediately
+// after a user keystroke.
+const ownNoteWriteMap = new Map<string, number>();
+const OWN_NOTE_WRITE_WINDOW_MS = 1500;
+
+export function markOwnNoteWrite(noteId: string): void {
+  ownNoteWriteMap.set(noteId, Date.now());
+}
+
+export function isOwnNoteWrite(noteId: string): boolean {
+  const t = ownNoteWriteMap.get(noteId);
+  return t !== undefined && Date.now() - t < OWN_NOTE_WRITE_WINDOW_MS;
+}
+
 export function isElectron(): boolean {
   return typeof window !== "undefined" && !!window.electron;
 }

--- a/src/store/slices/board.ts
+++ b/src/store/slices/board.ts
@@ -160,6 +160,7 @@ export const createBoardSlice: StateCreator<CairnStore, [], [], BoardSlice> = (
       order: cards.length,
       createdAt: now(),
       updatedAt: now(),
+      version: 0,
       ...(extras?.dueDate ? { dueDate: extras.dueDate } : {}),
       ...(extras?.assignee ? { assignee: extras.assignee } : {}),
     };

--- a/src/store/slices/notes.ts
+++ b/src/store/slices/notes.ts
@@ -6,7 +6,7 @@ import type { StateCreator } from "zustand";
 import type { CairnStore } from "../index";
 import type { Note, ID, NoteType } from "@/types";
 import { id, now } from "@/lib/utils";
-import { ipc, isElectron } from "../ipc";
+import { ipc, isElectron, markOwnNoteWrite } from "../ipc";
 import { historyManager } from "@/lib/history";
 import {
   makeCreateNoteCmd,
@@ -63,9 +63,11 @@ export const createNotesSlice: StateCreator<CairnStore, [], [], NotesSlice> = (
       folder,
       createdAt: now(),
       updatedAt: now(),
+      version: 0,
     };
     set((s) => ({ notes: [...s.notes, note] }));
     get().persist();
+    markOwnNoteWrite(note.id);
     ipc((e) => e.note.create(note));
     historyManager.push(makeCreateNoteCmd(note, set));
     return note;
@@ -82,6 +84,7 @@ export const createNotesSlice: StateCreator<CairnStore, [], [], NotesSlice> = (
       ),
     }));
     get().persist();
+    markOwnNoteWrite(noteId);
     ipc((e) => e.note.update(noteId, patch));
     pushUpdateNoteCmd(noteId, prevPatch, patch, set);
   },
@@ -96,6 +99,7 @@ export const createNotesSlice: StateCreator<CairnStore, [], [], NotesSlice> = (
       })),
     }));
     get().persist();
+    markOwnNoteWrite(noteId);
     ipc((e) => e.note.delete(noteId));
     if (savedNote) historyManager.push(makeDeleteNoteCmd(savedNote, set));
   },
@@ -108,6 +112,7 @@ export const createNotesSlice: StateCreator<CairnStore, [], [], NotesSlice> = (
       ),
     }));
     get().persist();
+    markOwnNoteWrite(noteId);
     ipc((e) => e.note.update(noteId, { archivedAt }));
     historyManager.push(makeArchiveNoteCmd(noteId, archivedAt, set));
   },
@@ -119,6 +124,7 @@ export const createNotesSlice: StateCreator<CairnStore, [], [], NotesSlice> = (
       ),
     }));
     get().persist();
+    markOwnNoteWrite(noteId);
     ipc((e) => e.note.update(noteId, { archivedAt: null }));
     historyManager.push(makeRestoreNoteCmd(noteId, set));
   },
@@ -142,6 +148,7 @@ export const createNotesSlice: StateCreator<CairnStore, [], [], NotesSlice> = (
       ),
     }));
     get().persist();
+    markOwnNoteWrite(noteId);
     ipc((e) => e.note.update(noteId, { projectId: targetProjectId }));
     historyManager.push(makeMoveNoteCmd(
       noteId, prevProjectId, prevWorkspaceId,
@@ -157,6 +164,7 @@ export const createNotesSlice: StateCreator<CairnStore, [], [], NotesSlice> = (
       ),
     }));
     get().persist();
+    markOwnNoteWrite(noteId);
     ipc((e) => e.note.moveToFolder(noteId, folder));
   },
 
@@ -188,7 +196,7 @@ export const createNotesSlice: StateCreator<CairnStore, [], [], NotesSlice> = (
     get().persist();
     const note = get().notes.find((n) => n.id === noteId);
     const card = get().cards.find((c) => c.id === cardId);
-    if (note) ipc((e) => e.note.update(noteId, { linkedCardIds: note.linkedCardIds }));
+    if (note) { markOwnNoteWrite(noteId); ipc((e) => e.note.update(noteId, { linkedCardIds: note.linkedCardIds })); }
     if (card) ipc((e) => e.card.update(cardId, { linkedNoteIds: card.linkedNoteIds }));
     historyManager.push(makeLinkNoteToCardCmd(noteId, cardId, prevNoteLinkedCardIds, prevCardLinkedNoteIds, set));
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,6 +71,9 @@ export interface Note {
   createdAt: string;
   updatedAt: string;
   archivedAt?: string;
+  /** Monotonically incrementing write counter. Used for optimistic-concurrency
+   * checks by MCP tools that accept an optional expectedVersion argument. */
+  version: number;
 }
 
 // ── Board Column ──────────────────────────────
@@ -108,6 +111,8 @@ export interface TaskCard {
   createdAt: string;
   updatedAt: string;
   archivedAt?: string;
+  /** Monotonically incrementing write counter for optimistic concurrency. */
+  version: number;
 }
 
 // ── Chat ──────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

DB sync hardening across the note and task write path — AI edit lock (in-process and MCP), atomic file writes, per-note own-write guard, SQLite transactions, startup external-edit recovery, optimistic concurrency version columns on `notes` and `task_cards`, and a fix for MCP notifications firing while the app is focused.

## Type of change

- [x] Bug fix
- [x] New feature

## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

**AI edit lock — two mechanisms, one UX:**
The in-process chat executor uses a module-level `Set` (`ai-write-lock.ts`) and fires IPC events directly. The MCP server uses a new `mcp_active_writes` SQLite table as a cross-process signal — the WAL poller diffs it each second and fires the same events. Both paths result in the same read-only banner in the editor.

**`readOnly` via CM6 `Compartment`:**
The editor is never recreated — `EditorView.editable` is reconfigured via a `Compartment` so undo history is preserved across a lock/unlock cycle.

**Per-note own-write guard (`src/store/ipc.ts`):**
The previous global 3-second guard is replaced by a per-note timestamp map with a 1.5 s window. `hydrateFromElectron` on refresh now merges rather than replaces — notes with a recent own write are kept from in-memory state, others updated from the SQLite snapshot.

**Version columns (migrations v12, v13):**
`notes.version` and `task_cards.version` default to 0 for existing rows and increment on every write. The `expectedVersion` check in MCP tools is a soft guard — if the column doesn't exist yet (pre-migration DB), `getNoteVersion` / `getCardVersion` return `null` and the check is skipped gracefully.

**Notification suppression:**
`win.isFocused()` checked in the poller before firing OS notifications or incrementing the badge. `markMcpNotificationsRead` is still called unconditionally so notifications don't queue up for later.