### PR TITLE
v1.2.0 - Built in Pi inspired Agent.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected behaviour
+
+<!-- What did you expect to happen? -->
+
+## Actual behaviour
+
+<!-- What actually happened? Include any error messages or console output. -->
+
+## Screenshots / recording
+
+<!-- If applicable, add screenshots or a short screen recording to help explain the problem. -->
+
+## Environment
+
+- **Cairn version:** <!-- e.g. v1.1.4 — found in Settings → About -->
+- **OS:** <!-- e.g. macOS 14.5 (arm64) -->
+- **Node.js version (if running from source):** <!-- node --version -->
+
+## Additional context
+
+<!-- Anything else that might help: specific workspace content, AI config used, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Question or discussion
+    url: https://github.com/ddutchie/cairn/discussions
+    about: Ask a question, share what you've built, or start a conversation
+  - name: 🔒 Security vulnerability
+    url: https://github.com/ddutchie/cairn/security/advisories/new
+    about: Report a security issue privately

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## What problem does this solve?
+
+<!-- Describe the problem or limitation you're running into. A clear "I want to be able to…" statement is perfect. -->
+
+## Proposed solution
+
+<!-- Describe the solution you'd like. How would it work from the user's perspective? -->
+
+## Alternatives considered
+
+<!-- Have you considered any alternative approaches? Why did you rule them out? -->
+
+## Additional context
+
+<!-- Any mockups, prior art, related issues, or anything else that would help evaluate the request. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,9 +69,16 @@ That's it — `compile:watch` runs in parallel and rebuilds the Electron main pr
 npm run type-check        # tsc --noEmit — run this before every commit
 npm test                  # run all unit tests (vitest)
 npm run test:watch        # watch mode
+npm run test:e2e          # E2E smoke tests (headless Chromium) — run before any UI PR
 npm run compile           # one-shot rebuild of dist-electron/ + dist-mcp/
 npm run lint              # eslint
 ```
+
+### Getting help
+
+Not sure where to start? Open a [GitHub Discussion](https://github.com/ddutchie/cairn/discussions) — ask questions, share ideas, or introduce yourself. For bugs use [GitHub Issues](https://github.com/ddutchie/cairn/issues).
+
+> **Working with an AI coding agent?** Read [AGENTS.md](AGENTS.md) — it has architecture conventions and build commands tuned for LLM context windows (and is what powers the built-in Cairn agent).
 
 ---
 
@@ -572,13 +579,15 @@ vitest uses a SQLite shim (`vitest-sqlite-shim.cjs`) to ensure the system Node A
 
 ### PR checklist
 
-- [ ] `npm run type-check` passes
+- [ ] `npm run type-check` passes with zero errors
 - [ ] `npm test` passes
-- [ ] No raw colour values (use CSS variables)
-- [ ] No `text-[Npx]` pixel font classes (use rem equivalents)
+- [ ] `npm run test:e2e` passes (required for UI changes or release PRs)
+- [ ] No raw colour values — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
+- [ ] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
 - [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
 - [ ] New DB migrations appended (not edited) in `schema.ts`
-- [ ] Screenshots included for UI changes
+- [ ] `mcp-server.ts` changes use inlined SQL only — no `import` from `queries.ts`
+- [ ] Screenshots or recording included for any UI changes
 - [ ] `useCairnStore()` calls use narrow selectors (not full-store subscriptions)
 - [ ] List-item components wrapped in `React.memo`
 - [ ] Expensive derivations wrapped in `useMemo` (not recomputed every render)
@@ -587,16 +596,37 @@ vitest uses a SQLite shim (`vitest-sqlite-shim.cjs`) to ensure the system Node A
 
 ## Good first issues
 
-If you're new to the codebase, these are good places to start:
+If you're new to the codebase, these are good places to start. Each one is self-contained, won't conflict with ongoing work, and has clear acceptance criteria.
 
-- **No `404.html`** — GitHub Pages serves a default 404 for the docs site. A styled page would be a clean, self-contained contribution.
-- **Accessibility** — checking components for missing ARIA labels, keyboard navigation gaps, or colour contrast issues.
-- **Docs** — the `docs/` site at `cairn-site` always needs keeping up to date with new features. Pure HTML/CSS — no build step required.
-- **Zustand selector narrowing** — replacing `useCairnStore()` full-store calls with narrow `useShallow` selectors in a specific component. Self-contained, testable, and high-impact. Good candidates: `MCPSettings`, `GeneralSettings`, `InsightsView`.
-- **`React.memo` on list items** — wrapping `ProjectItem` in `React.memo` after narrowing its store subscriptions. `KanbanCard` and `NoteListItem` are already wrapped — `ProjectItem` is the remaining high-value candidate.
+### 🟢 No TypeScript required
+
+- **Accessibility audit** — check components for missing ARIA labels (`aria-label`, `role`), keyboard navigation gaps, or colour contrast issues. Focus on the Kanban board and the Settings panel first.
+- **Docs improvements** — the [cairn-site](https://github.com/ddutchie/cairn-site) docs always lag behind new features. Pure HTML/CSS — no build step.
+- **Improve the `Good first issues` list** — if you find something genuinely approachable that isn't listed here, add it and open a PR.
+
+### 🟡 TypeScript / React
+
+- **Zustand selector narrowing** — replace bare `useCairnStore()` calls (which subscribe to the *entire* store) with narrow `useShallow` selectors. Good candidates with real impact: `MCPSettings`, `GeneralSettings`, `InsightsView`. Each component is a single self-contained file.
+  ```ts
+  // Before — re-renders on every store write
+  const { cards, columns } = useCairnStore();
+  // After — only re-renders when these two fields change
+  const { cards, columns } = useCairnStore(useShallow((s) => ({ cards: s.cards, columns: s.columns })));
+  ```
+- **`React.memo` on `ProjectItem`** — `KanbanCard` and `NoteListItem` are already wrapped; `ProjectItem` (`src/components/layout/sidebar.tsx`) is the remaining high-value candidate. Wrap it after narrowing its store subscriptions.
+- **Test coverage for a utility function** — `electron/shared/text-utils.ts` (`toSlug`, `stripMarkdown`) and `electron/db/utils.ts` (`newId`, `ts`) have no dedicated tests. Add them to the nearest test file.
+
+### 🔴 Electron / SQLite
+
+- **New MCP tool** — pick a missing read-only query (e.g. `list_dashboards`) and add it end-to-end following the 6-step checklist in [Adding a new MCP / AI chat tool](#adding-a-new-mcp--ai-chat-tool).
+- **Bug fixes** — check the [open issues](https://github.com/ddutchie/cairn/issues) labelled `good first issue` for the current list.
+
+> **Tip:** if you're unsure which file to touch, drop a question in [Discussions](https://github.com/ddutchie/cairn/discussions) or leave a comment on the issue before writing code.
 
 ---
 
 ## Questions
 
-Open a [GitHub Discussion](https://github.com/ddutchie/cairn/discussions) or file an issue with the `question` label. We're happy to help orient you.
+Open a [GitHub Discussion](https://github.com/ddutchie/cairn/discussions) or file an issue with the `question` label. We read every one and are happy to help orient you.
+
+For security vulnerabilities, please see [SECURITY.md](SECURITY.md) rather than opening a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ This guide covers everything you need to go from zero to a working dev environme
 - [Coding conventions](#coding-conventions)
 - [Working on specific areas](#working-on-specific-areas)
   - [Working on the Agent workspace](#working-on-the-agent-workspace)
+  - [Working on the Cairn Agent](#working-on-the-cairn-agent)
 - [Tests](#tests)
 - [Submitting a pull request](#submitting-a-pull-request)
 - [Good first issues](#good-first-issues)
@@ -130,7 +131,7 @@ cairn/
 │   │   ├── flow/           # Idea Flow canvas + node components
 │   │   ├── graph/          # Knowledge Graph + all analytics canvases
 │   │   ├── insights/       # InsightsView (analytics hub)
-│   │   ├── agent/          # Agent workspace: file tree, CM6 editor, xterm terminal, diff viewer
+│   │   ├── agent/          # Agent workspace (PTY + Cairn native agent): PiAgentPane, PiMessageBubble, ContextRing, SpawnAgentModal, file tree, CM6 editor, xterm terminal, diff viewer
 │   │   ├── chat/           # AI chat panel
 │   │   ├── search/         # Global search panel
 │   │   ├── settings/       # Settings sections
@@ -167,7 +168,7 @@ cairn/
 | Notes | `⌘2` | Project | Split-pane markdown editor + dashboard renderer |
 | Board | `⌘3` | Project | Kanban with drag-and-drop |
 | Idea Flow | `⌘4` | Project | Freeform node canvas |
-| Agent | `⌘5` | Project | Coding agent workspace — file tree, CM6 editor, xterm.js terminal, git diff viewer |
+| Agent | `⌘5` | Project | Coding agent workspace — Cairn native agent (chat UI) or external PTY agent (Claude Code, OpenCode, Aider); file tree, CM6 editor, xterm.js terminal, git diff viewer |
 | Knowledge Graph | `⌘6` | Workspace | Force-directed and Radial tree of notes/cards/tags (`GraphLayoutMode = "force" \| "radial"`) |
 | Insights | `⌘7` | Workspace | Analytics canvases: Ridgeline, Beeswarm, Bullet, Sankey, Timeline, Matrix, Table |
 | Settings | — | App | General, AI & Chat, Coding Agents, Tags, Shortcuts, Data, About |
@@ -180,7 +181,16 @@ Cairn has two processes that share the same `cairn.db` (SQLite WAL mode):
 
 **Main process** (Node.js) — everything in `electron/`. Owns the SQLite database, the filesystem, and the AI chat loop. Returns `{ data: T } | { error: string }` from every IPC handler.
 
-**Agent workspace** (`electron/ipc/agent.ts`) — PTY sessions spawned via `node-pty` in the main process. File I/O is validated against registered `code_directory` paths before any read/write. Sessions are keyed by `sessionId`; PTY output is streamed to the renderer via `agent:data` IPC events. The renderer-side `TerminalManager` singleton holds `xterm.js` instances so they survive view navigation.
+**External agent workspace** (`electron/ipc/agent.ts`) — PTY sessions spawned via `node-pty` in the main process. File I/O is validated against registered `code_directory` paths before any read/write. Sessions are keyed by `sessionId`; PTY output is streamed to the renderer via `agent:data` IPC events. The renderer-side `TerminalManager` singleton holds `xterm.js` instances so they survive view navigation.
+
+**Cairn native agent** — a stateful multi-turn tool-call loop running entirely in the main process. No external binary required. Session type `"pi"` in the terminal sessions store; rendered by `PiAgentPane` instead of xterm. Key files:
+
+- `electron/ipc/pi-agent.ts` — IPC handler; `sessions Map<sessionId, PiAgentSession>`; registers all `pi-agent:*` channels
+- `electron/lib/pi-agent-loop.ts` — `runAgentLoop()`; SSE stream parsing; tool execution; callbacks (`onToken`, `onToolsReady`, `onToolStart`, `onToolEnd`, `onStepStart`, `onUsage`, `onSubagent`, `onDone`, `onError`)
+- `electron/lib/pi-agent-prompt.ts` — system prompt builder; mandatory Cairn workflow injected here
+- `electron/lib/coding-tools/` — 7 ported file-system tools (`read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`) + `spawn_subagent` + `file-mutex.ts`
+
+The agent has access to a curated subset of Cairn's data tools (notes CRUD, task management, idea flow) via the same `executeTool` path used by the AI chat. `ensure_note` is the preferred write tool — idempotent by title, no duplicates. `AgentView` is always mounted (CSS-hidden when inactive) so `PiAgentPane` refs and IPC subscriptions survive view switches.
 
 **MCP server** (`electron/mcp-server.ts`) — a separate compiled binary that external AI agents connect to. Shares the same SQLite database and writes `.md` files directly; the Electron UI refreshes automatically via WAL mtime polling. Has one important constraint: it cannot import from `electron/db/queries.ts` due to the Node ABI boundary — it uses inlined SQL only.
 
@@ -350,6 +360,10 @@ Shared modules live in `src/components/graph/`: `analyticsUtils.ts`, `analyticsH
 | `electron/ipc/agent.ts` | All `agent:*` IPC channels — PTY spawn/kill, file I/O, git diff, `assertWithinCodeDirectory` |
 | `electron/ipc/chat.ts` | AI chat loop — `runToolLoop` + IPC handler registration |
 | `electron/ipc/chat-executor.ts` | `executeTool` — all AI tool implementations |
+| `electron/ipc/pi-agent.ts` | Cairn native agent IPC handler — `sessions` Map, all `pi-agent:*` channels |
+| `electron/lib/pi-agent-loop.ts` | `runAgentLoop()` — multi-turn SSE loop, tool execution, all callbacks |
+| `electron/lib/pi-agent-prompt.ts` | System prompt builder; mandatory Cairn workflow; `spawn_subagent` description |
+| `electron/lib/coding-tools/` | 8 coding tools (`read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `spawn_subagent`) + `file-mutex.ts` |
 | `electron/lib/llm.ts` | `LLMConfig`, `callLLM`, `streamCompletion`, `isLocalEndpoint` |
 | `electron/lib/tools.ts` | `TOOLS` (OpenAI function definitions), `TOOL_LABELS`, `buildSystemPrompt` |
 | `electron/lib/context.ts` | `buildContextResponse` — canonical `get_cairn_context` response |
@@ -386,8 +400,11 @@ Shared modules live in `src/components/graph/`: `analyticsUtils.ts`, `analyticsH
 | `src/components/graph/ForceGraphCanvas.tsx` | Force-directed canvas via `react-force-graph-2d` |
 | `src/components/graph/RadialTreeCanvas.tsx` | Radial hierarchy tree via D3 |
 | `src/components/graph/graphUtils.ts` | `resolveCssVar()` shared by graph canvases |
-| `src/components/agent/AgentView.tsx` | Three-pane layout — drag-resize dividers, Editor/Diff tab bar |
-| `src/components/agent/AgentTerminalPane.tsx` | xterm.js sessions, tab strip, font-scale sync, SpawnAgentModal integration |
+| `src/components/agent/AgentView.tsx` | Three-pane layout — drag-resize dividers, Editor/Diff tab bar; always mounted (CSS-hidden when inactive) |
+| `src/components/agent/AgentTerminalPane.tsx` | Session tab strip; branches on `sessionType`: `"pi"` → `PiAgentPane`, `"pty"` → `SessionMount` (xterm.js) |
+| `src/components/agent/PiAgentPane.tsx` | Cairn native agent chat UI — IPC subscriptions, `sendPrompt`, `initialPrompt` effect, context ring |
+| `src/components/agent/PiMessageBubble.tsx` | Message renderer — user/assistant/error bubbles, `ToolChip` (running → done), `CairnRefChip`, `SubagentBlock` |
+| `src/components/agent/ContextRing.tsx` | Reusable SVG context usage ring; `size` and `stroke` props; colour shifts at 65 % and 85 % |
 | `src/components/agent/AgentEditor.tsx` | Multi-file tabbed editor — tab management, preview toggle, save |
 | `src/components/agent/FileEditorInner.tsx` | Single CM6 editor instance per file — CSS-hidden when inactive |
 | `src/components/agent/DiffViewer.tsx` | Git diff polling, toolbar, collapsible files, view mode toggle |
@@ -509,6 +526,56 @@ The Agent workspace has its own IPC namespace (`agent:*`) entirely separate from
 - **CM6 editor** — one `EditorView` instance per open file, CSS-hidden when inactive. `buildTheme(fontScale)` in `editorTheme.ts` accepts `fontScale` so the editor respects the user's font size setting. CM6 `HighlightStyle.define` requires static colour strings — CSS variables cannot be used there (documented in `editorTheme.ts`). The editor includes a find/replace panel via `@codemirror/search` (`⌘F`); `buildSearchTheme()` must be appended **after** `buildTheme()` in the extensions array to override CM6's default `.cm-button`/`.cm-textfield` gradient styles with Cairn CSS variables.
 - **File search** — `agent:searchFiles` IPC (registered in `electron/ipc/agent.ts`) recursively walks the `code_directory` for filename matches, triggered by `⌘⇧F` in `FileTree.tsx` via a capture-phase listener that fires before the global `page.tsx` handler. Subject to the same `assertWithinCodeDirectory` security check as all file operations. Returns up to 50 results; skips `node_modules`, `.git`, `.next`, `dist*`, and similar build directories.
 - **`code_directory`** — stored on the `projects` table (migration v10). Set from the Project Overview inline row, not from AgentSettings. Written via the generic `db:project:update` IPC channel.
+
+### Working on the Cairn Agent
+
+The Cairn native agent (`sessionType: "pi"`) runs in the Electron main process. Its IPC namespace is `pi-agent:*`, entirely separate from `agent:*` (PTY) and `db:*` (data).
+
+**Adding a new coding tool**
+
+1. Create `electron/lib/coding-tools/<name>.ts` — export `<name>Tool(args, cwd)` and `<name>ToolDefinition` (OpenAI function schema)
+2. Add it to the barrel in `electron/lib/coding-tools/index.ts`
+3. Add a `case "<name>":` in `executeSingleTool()` in `pi-agent-loop.ts`
+4. Add it to `CODING_TOOL_DEFS` in `pi-agent-loop.ts`
+5. Add a human-readable label to `CODING_LABELS` if it takes a `path` or `command` arg
+6. If the tool produces output worth expanding in the UI, it will appear automatically. Add the tool name to `READ_ONLY_TOOLS` in `PiAgentPane.tsx` if it is read-only and the output should be suppressed.
+
+**Adding a new Cairn data tool to the agent**
+
+The agent exposes a curated subset of Cairn tools defined in `CAIRN_TOOL_NAMES` in `pi-agent-loop.ts`. To expose a new tool:
+
+1. Add the tool name to `CAIRN_TOOL_NAMES`
+2. Update the system prompt in `pi-agent-prompt.ts` if the tool warrants explicit mention
+3. If it is a write tool that returns `{ id, title }`, add it to `NOTE_WRITE_TOOLS` or `TASK_WRITE_TOOLS` in `PiAgentPane.tsx` so it renders as a clickable `CairnRefChip`
+4. If it is read-only, add it to `READ_ONLY_TOOLS` to suppress output expansion
+
+**IPC event flow for a single agent turn**
+
+```
+renderer                         main process
+   │                                  │
+   ├─ pi-agent:prompt ──────────────► runAgentLoop()
+   │                                  │  POST /v1/chat/completions (stream)
+   │ ◄── pi-agent:token (×N) ─────────┤  token deltas
+   │                                  │  [DONE] received
+   │ ◄── pi-agent:tools-ready ────────┤  ensures streaming message exists
+   │                                  │  for each tool call:
+   │ ◄── pi-agent:tool (start) ───────┤    onToolStart → spinner chip
+   │                                  │    execute tool (may take seconds)
+   │ ◄── pi-agent:tool (end) ─────────┤    onToolEnd → update chip + output
+   │                                  │  if more turns:
+   │ ◄── pi-agent:step ───────────────┤    seal message, start next
+   │ ◄── pi-agent:usage ──────────────┤    token counts → context ring
+   │ ◄── pi-agent:done ───────────────┤  turn complete
+```
+
+**Subagents**
+
+`spawn_subagent` in `electron/lib/coding-tools/subagent.ts` runs a nested `runAgentLoop` with a child session ID (`${parentId}:sub:${hex}`). All child events are sent on the child session ID — the renderer routes them based on the prefix. Parent context ring and child ring are independent. The child's final assistant message is returned to the parent as the tool result.
+
+**System prompt**
+
+`buildPiAgentSystemPrompt()` in `pi-agent-prompt.ts` injects the project name, `cwd`, active task title, and date. The mandatory workflow section (orient → document → capture → wrap up) is enforced here — if you want the agent to adopt a new habit, add it to this file rather than relying on per-turn instructions.
 
 ### Adding a new analytics canvas
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
   <a href="https://ddutchie.github.io/cairn-site/index.html"><img src="https://img.shields.io/badge/Website-Live-blue" alt="Website"></a>
   <a href="https://ddutchie.github.io/cairn-site/docs"><img src="https://img.shields.io/badge/Docs-Read-green" alt="Docs"></a>
   <a href="https://github.com/ddutchie/cairn/releases"><img src="https://img.shields.io/github/v/release/ddutchie/cairn?label=Releases" alt="Releases"></a>
+  <a href="https://github.com/ddutchie/cairn/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <a href="https://github.com/ddutchie/cairn/issues"><img src="https://img.shields.io/github/issues/ddutchie/cairn" alt="Open Issues"></a>
+  <a href="https://github.com/ddutchie/cairn/discussions"><img src="https://img.shields.io/badge/Discussions-Ask%20or%20share-blueviolet" alt="GitHub Discussions"></a>
   <a href="https://deepwiki.com/ddutchie/cairn/"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>
 
@@ -30,12 +33,12 @@ Cairn is a desktop app (Electron + Next.js) that combines markdown notes with a 
 - **Drag notes into folders** — Drag any note in the sidebar directly onto a folder row to move it; a "Move to root" drop zone appears while dragging
 - **Linked context** — Notes and cards reference each other bidirectionally
 - **Global search** — Instant full-text search across all notes and tasks (`⌘K` or `⌘⇧F`)
-- **AI chat** — Integrated assistant with live project context; reads and writes your data (`⌘/`); supports inline `ask_questions` forms for structured clarification
-- **Interactive PRD generation** — Describe what you want to build; the agent reads your project context, asks targeted clarifying questions via an inline form, then writes and saves a full PRD to your notes
-- **Idea Flow** — A freeform node canvas per project (`⌘4`): add idea, note reference, task reference, group, URL, and AI summary nodes; connect them with labelled edges; the AI and MCP can read and write the canvas as first-class authors
-- **Live dashboards** — Ask the AI to generate an interactive HTML dashboard for any project; choose from a template gallery or start blank; dashboards fetch live data on every load via a sandboxed `window.cairn.query()` bridge; runtime errors surface an inline "Fix with AI" button; HTML editable directly via a built-in CodeMirror overlay
+- **AI chat** — Integrated assistant with live project context; reads and writes your data (`⌘/`)
+- **Interactive PRD generation** — Describe what you want to build; the agent asks clarifying questions then writes and saves a full PRD to your notes
+- **Idea Flow** — Freeform node canvas per project (`⌘4`): ideas, note/task refs, groups, URLs, AI summaries — connected with labelled edges
+- **Live dashboards** — AI-generated interactive HTML dashboards with a live `window.cairn.query()` data bridge; inline "Fix with AI" on runtime errors; editable via built-in CodeMirror overlay
 - **MCP server** — Exposes your workspace to external AI agents (OpenCode, Claude Desktop, etc.) via the Model Context Protocol
-- **Agent workspace** — Dedicated three-pane view (`⌘5`) for running AI coding agents (Claude Code, OpenCode, Aider, or any CLI binary) connected directly to project tasks. Spawn from a kanban card or ad-hoc. Includes a resizable file tree with `⌘⇧F` filename search, multi-file CodeMirror 6 editor (syntax highlighting, `⌘S` save, `⌘F` find/replace, markdown preview, image viewer), xterm.js terminal with persistent sessions, and a git diff viewer (unified / split / changes-only modes with syntax highlighting)
+- **Agent workspace** — Three-pane view (`⌘5`) for running AI coding agents (Claude Code, OpenCode, Aider, or any CLI) connected to project tasks; file tree, multi-file CodeMirror 6 editor, xterm.js terminal, and git diff viewer
 - **Knowledge Graph** — Workspace-wide graph of every note, card, project, and tag; Force-directed and Radial tree layouts; auto-discovered relationships (`⌘6`)
 - **Insights** — Analytics view: Ridgeline joy plot, Beeswarm, Bullet health bars, Sankey pipeline flow, Timeline, Matrix heatmap, Table (`⌘7`)
 - **Font scaling** — Five-step UI font size preference (XS–XL, default M) in Settings → General
@@ -73,7 +76,7 @@ Cairn is a desktop app (Electron + Next.js) that combines markdown notes with a 
 ### Install and run in development
 
 ```bash
-git clone https://github.com/YOUR_ORG/cairn
+git clone https://github.com/ddutchie/cairn
 cd cairn
 npm install
 npm run rebuild   # build better-sqlite3 native binaries for Electron + system Node
@@ -92,7 +95,7 @@ npm run build:all      # All three platforms
 
 Output goes to `dist-app/`.
 
-> **Note:** `npm run rebuild` must be re-run after updating the Electron version. It builds three native binaries: one for the Electron ABI (`electron-native/`), one for the Node 22 ABI used by the MCP binary (`pkg-native/`), and one for the current system Node ABI used by vitest (`vitest-native/`). The MCP server is then bundled into a self-contained binary by `scripts/build-mcp-binary.js` — no separate Node installation needed to run it.
+> **Note:** Re-run `npm run rebuild` after any Electron version bump. It builds native binaries for three ABIs (Electron, Node 22/MCP, system Node/vitest) and bundles the MCP server into a self-contained binary via `scripts/build-mcp-binary.js`.
 
 ## AI chat setup
 
@@ -265,54 +268,30 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ## Architecture
 
-Cairn is an Electron + Next.js desktop app with two processes that share a single SQLite database (WAL mode), plus a separately-invokable MCP binary for external agent access:
+Two processes share a single SQLite database (WAL mode):
 
-- **Renderer** (`src/`) — React/Next.js. Never touches the filesystem or database directly. All data flows through IPC via `window.electron.*`.
-- **Main process** (`electron/`) — Node.js. Owns SQLite, file I/O, the AI chat loop, and PTY sessions for coding agents.
-- **MCP server** (`electron/mcp-server.ts`) — a self-contained binary connecting external AI agents (OpenCode, Claude Desktop, etc.) to the same database via WAL polling.
+- **Renderer** (`src/`) — React/Next.js. All data flows through IPC via `window.electron.*`; never touches the DB or filesystem directly.
+- **Main process** (`electron/`) — Node.js. Owns SQLite, file I/O, AI chat loop, and PTY sessions for coding agents.
+- **MCP server** (`electron/mcp-server.ts`) — self-contained binary; connects external agents to the same DB via WAL polling.
 
-Notes are plain `.md` files with YAML frontmatter; SQLite is the read/search cache. Every note write goes through `writeNoteFile()` which writes to a `.tmp` file and renames it into place (atomic). A chokidar file watcher syncs external edits back on startup and at runtime; on startup, `syncNotesFromDisk` compares file timestamps against the DB and overwrites SQLite if the file is newer. The **Agent workspace** (`⌘5`) runs coding agent CLIs via `node-pty` PTY sessions, with all file I/O path-validated against registered project `code_directory` values.
+Notes are plain `.md` files (YAML frontmatter); SQLite is the read/search cache. Writes are atomic (`.tmp` rename). A chokidar watcher syncs external edits at runtime. `notes` and `task_cards` carry a `version` integer; MCP write tools accept `expectedVersion` for conflict detection.
 
-When the AI (chat executor or MCP server) is writing to a note, the editor enters read-only mode with a pulsing banner. The in-process chat executor uses a module-level lock set (`ai-write-lock.ts`); the MCP server signals via a `mcp_active_writes` SQLite table that the WAL poller diffs every second.
-
-`notes` and `task_cards` each carry a `version` integer that increments on every write. MCP write tools accept an optional `expectedVersion` argument and return a conflict error if the row has been modified since the caller last read it.
-
-State in the renderer is managed by Zustand domain slices (`ui`, `workspace`, `board`, `notes`, `tags`, `chat`, `graph`, `selectors`), composed in `src/store/index.ts`. Analytics canvases in Insights follow a shared pattern: `useContainerDims` + `useScopedData` + `useFontScale` + D3/SVG rendering.
-
-For the full architecture reference — process model, storage split, data model, dashboard rendering, write paths, font scaling, analytics canvas pattern, and key files — see [CONTRIBUTING.md](CONTRIBUTING.md#architecture).
+For the full architecture reference see [CONTRIBUTING.md](CONTRIBUTING.md#architecture). AI coding agents should read [AGENTS.md](AGENTS.md) for conventions tuned to LLM context windows.
 
 ## Testing
 
-### Unit & integration tests (Vitest)
-
 ```bash
-npm test              # run all tests
-npm run test:watch    # watch mode
-npm run test:coverage # coverage report
+npm test                 # unit & integration (Vitest)
+npm run test:watch       # watch mode
+npm run test:coverage    # coverage report
+npm run test:e2e         # E2E smoke tests — headless Chromium, no Electron required
+npm run test:e2e:ui      # Playwright UI mode
+npm run test:e2e:headed  # headed for local debugging
 ```
 
-Tests live alongside the code they cover:
+Unit/integration tests (`electron/**/*.test.ts`) cover SQLite queries, file I/O, MCP tools end-to-end, chat executor tool cases, IPC handlers, and MCP↔chat tool parity. The E2E suite runs against the Next.js dev server with a full IPC mock — covers boot, all 8 views, and sidebar content in ~10s.
 
-| File | Tests | What's covered |
-|------|-------|---------------|
-| `electron/db/queries.test.ts` | 22 | SQLite query helpers — CRUD, search, soft-delete, snapshot |
-| `electron/notes-files.test.ts` | 40 | File I/O, slug generation, frontmatter round-trip, atomic writes, startup sync (tmp dirs) |
-| `electron/mcp-server.test.ts` | 134 | MCP `executeTool` end-to-end via in-memory SQLite — all tools, edge cases, blocker chains |
-| `electron/ipc/chat-executor.test.ts` | 98 | Every tool case in the AI chat executor — happy path, missing entities, error returns |
-| `electron/ipc/handlers.test.ts` | 14 | IPC data layer — `executeReadTool`, `buildContextResponse`, `getBy*` queries |
-| `electron/ipc/tool-parity.test.ts` | 33 | Cross-executor key parity between MCP and chat paths for all shared tools |
-
-### E2E smoke tests (Playwright)
-
-```bash
-npm run test:e2e         # headless Chromium (starts Next.js dev server automatically)
-npm run test:e2e:ui      # Playwright UI mode — interactive, with time-travel debugger
-npm run test:e2e:headed  # headed run for local debugging
-```
-
-The E2E suite runs against the Next.js dev server with a full `window.electron` IPC mock injected before React boots — no Electron or packaged app required. It covers app boot, crash-free render of all 8 views, and sidebar content. Runs in ~10s.
-
-**Run the E2E suite before cutting a release** to catch renderer crashes that unit tests can't reach.
+**Run `npm run test:e2e` before cutting a release** to catch renderer crashes unit tests can't reach.
 
 ## Tech stack
 
@@ -392,36 +371,6 @@ The E2E suite runs against the Next.js dev server with a full `window.electron` 
 
 > The **Settings → About** screen in the app shows real installed versions grouped by category (Platform, Data, AI, UI, Editor, Agent, Visualisation) and all open source licenses. These are generated automatically at build time — see below.
 
-## About screen & license generation
-
-<details>
-<summary>How license generation works</summary>
-
-The About section in Settings is populated from `src/generated/licenses.json`, which is generated by `scripts/generate-licenses.js` before each build. It reads installed versions and license identifiers directly from `node_modules` — so it is always accurate and never needs manual updates.
-
-### When to run it
-
-It runs automatically as part of `npm run build:*` and `npm run dev`. You should not need to run it manually unless you want to preview changes to the About screen without starting the full dev server:
-
-```bash
-node scripts/generate-licenses.js
-```
-
-`src/generated/` is `.gitignore`d since it is build output.
-
-### Adding a new dependency
-
-If you add a package that should appear in the **Stack** grid in the About screen (not just the full license list), add an entry to the `ROLE_MAP` object in `scripts/generate-licenses.js`:
-
-```js
-// scripts/generate-licenses.js — ROLE_MAP
-"your-package-name": ["Display Name", "Short role description", "Category"],
-```
-
-The key must exactly match the package name in `package.json`. Valid categories are `Platform`, `Data`, `AI`, `UI`, `Editor`, `Agent`, and `Visualisation` — entries are grouped under these headings in the About screen. All installed packages (whether in `ROLE_MAP` or not) are automatically included in the full **Open Source Licenses** list.
-
-</details>
-
 ## Star History
 <p align="center">
 <a href="https://www.star-history.com/?repos=ddutchie%2Fcairn&type=date&legend=top-left">
@@ -432,6 +381,12 @@ The key must exactly match the package name in `package.json`. Valid categories 
  </picture>
 </a>
 </p>
+
+## Contributing
+
+Contributions are welcome — bug fixes, features, docs, and tests. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide: dev setup, architecture, coding conventions, and PR checklist.
+
+For security issues please see [SECURITY.md](SECURITY.md) rather than filing a public issue.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Cairn is a desktop app (Electron + Next.js) that combines markdown notes with a 
 - **Idea Flow** — Freeform node canvas per project (`⌘4`): ideas, note/task refs, groups, URLs, AI summaries — connected with labelled edges
 - **Live dashboards** — AI-generated interactive HTML dashboards with a live `window.cairn.query()` data bridge; inline "Fix with AI" on runtime errors; editable via built-in CodeMirror overlay
 - **MCP server** — Exposes your workspace to external AI agents (OpenCode, Claude Desktop, etc.) via the Model Context Protocol
-- **Agent workspace** — Three-pane view (`⌘5`) for running AI coding agents (Claude Code, OpenCode, Aider, or any CLI) connected to project tasks; file tree, multi-file CodeMirror 6 editor, xterm.js terminal, and git diff viewer
+- **Cairn Agent** — Native coding agent (`⌘5`) with board and notes integration: moves tasks, writes session notes, captures discovered work; supports subagents for deep sub-tasks; context usage ring; works with any OpenAI-compatible endpoint
+- **Agent workspace** — Three-pane view (`⌘5`) for running external AI coding agents (Claude Code, OpenCode, Aider, or any CLI) connected to project tasks; file tree, multi-file CodeMirror 6 editor, xterm.js terminal, and git diff viewer
 - **Knowledge Graph** — Workspace-wide graph of every note, card, project, and tag; Force-directed and Radial tree layouts; auto-discovered relationships (`⌘6`)
 - **Insights** — Analytics view: Ridgeline joy plot, Beeswarm, Bullet health bars, Sankey pipeline flow, Timeline, Matrix heatmap, Table (`⌘7`)
 - **Font scaling** — Five-step UI font size preference (XS–XL, default M) in Settings → General
@@ -108,6 +109,29 @@ Configure the AI endpoint in **Settings → AI & Chat** (no restart needed):
 | API Key | _(blank)_ | Not required for local endpoints |
 
 **Quick presets** — one click to switch between OpenAI, Ollama (`localhost:11434`), and LM Studio (`localhost:1234`). Local servers don't need an API key.
+
+## Cairn Agent
+
+Cairn includes a native coding agent that runs directly inside the app — no external CLI binary required. It is accessible from the Agent view (`⌘5`) by choosing **Cairn Agent** in the spawn modal.
+
+The agent is inspired by [pi](https://github.com/earendil-works/pi), an open-source agentic coding framework. The tool implementations (`read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`) are ported directly into the Electron main process and adapted for Cairn's architecture — same semantics, no npm dependency.
+
+### What makes it Cairn-specific
+
+Unlike a general coding agent, the Cairn Agent is a first-class participant in your project:
+
+- **Board integration** — when you attach a task at spawn time, the agent moves it to In Progress immediately and to Review (or Done) when it finishes
+- **Automatic notes** — findings, decisions, and bugs discovered during a session are written to project notes via `ensure_note` (idempotent — no duplicates on re-run)
+- **Session summary** — a summary note is created at the end of every session documenting what changed and what needs follow-up
+- **Out-of-scope capture** — issues found beyond the current task are automatically added to the board as new tasks
+
+### Subagents
+
+The agent can delegate contained sub-tasks to a fresh sub-agent via `spawn_subagent`. The sub-agent runs a full tool-call loop with its own message history — only its final answer is returned to the parent. This keeps the parent context lean for long multi-step tasks. The sub-agent trace is rendered inline and collapsible in the chat UI, with its own context usage ring.
+
+### Context usage ring
+
+A small ring in the agent pane header shows how full the model's context window is after each step. Configure the limit for your model in **Settings → AI & Chat → Context window** (presets: 8k / 32k / 128k / 200k).
 
 ## MCP server
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the **latest release** only. We recommend always running the most recent version.
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | ✅        |
+| Older   | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities via public GitHub issues.**
+
+Instead, report them privately via [GitHub Security Advisories](https://github.com/ddutchie/cairn/security/advisories/new). This keeps the details confidential until a fix is ready.
+
+Include:
+
+- A clear description of the vulnerability and its impact
+- Steps to reproduce (a minimal proof of concept if possible)
+- The version of Cairn you're running
+
+You should receive an acknowledgement within **72 hours**. We aim to publish a fix within **14 days** for critical issues.
+
+## Scope
+
+Cairn is a **local-first desktop app** — it never transmits your notes or project data to any server. Potential security concerns include:
+
+- **XSS in the dashboard iframe** — dashboards render in a sandboxed `<iframe srcdoc>` with no `allow-same-origin` and no network access
+- **Path traversal in the Agent workspace** — all file IPC calls validate paths against registered `code_directory` values via `assertWithinCodeDirectory`
+- **MCP server access control** — the MCP server connects directly to your local SQLite database; it should only be exposed to agents you trust
+
+Out of scope: issues requiring physical access to the machine, or issues in third-party dependencies that have no direct impact on Cairn users.
+
+## Disclosure policy
+
+We follow [coordinated disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure). Once a fix is released we'll publish a security advisory crediting the reporter (unless you prefer to remain anonymous).

--- a/changelogs/v1.2.0.md
+++ b/changelogs/v1.2.0.md
@@ -1,0 +1,122 @@
+# v1.2.0
+
+## Cairn Agent
+
+A native coding agent built directly into Cairn. Unlike the existing external agent workspace (which shells out to Claude Code, OpenCode, Aider, etc.), the Cairn Agent runs entirely inside the app — no CLI binary required. It reads and writes your code, and keeps your board and notes up to date as it works.
+
+### Agent loop
+
+A stateful multi-turn tool-call loop (`electron/lib/pi-agent-loop.ts`) powered by any OpenAI-compatible endpoint. The loop supports up to 30 steps, accumulates message history across turns, and streams tokens to the renderer in real time. Tool calls are fully parallelised within a turn and results are fed back into the next LLM request automatically.
+
+### Coding tools
+
+Seven file-system tools ported directly into the Electron main process — no external dependencies:
+
+| Tool | Description |
+|------|-------------|
+| `read` | Read file contents with line ranges and pagination hints |
+| `write` | Write or overwrite a file entirely (with parent dir creation) |
+| `edit` | Targeted string replacements — requires exact match, CRLF-safe, mutex-serialised |
+| `bash` | Execute shell commands with streaming output, abort signal, and 120 s timeout |
+| `grep` | Regex search across files with `include` glob filter |
+| `find` | Filename pattern search |
+| `ls` | Directory listing, dirs first |
+
+A `file-mutex.ts` module serialises concurrent writes to the same path while allowing parallel writes to different files.
+
+### Cairn tools
+
+The agent has direct access to a curated subset of Cairn's data tools: `get_active_context`, `get_project_context_pack`, notes CRUD (`create_note`, `ensure_note`, `patch_note`, `append_to_note`, `update_note`, `search_notes`, `get_note`, `list_notes`), task management (`create_task`, `update_task`, `update_task_status`, `list_tasks`, `search_tasks`, `list_ready_tasks`, `get_task`), and idea flow (`get_idea_flow`, `create_idea_flow_node`, `create_idea_flow_edge`).
+
+### Mandatory Cairn workflow
+
+The system prompt enforces a non-optional four-step workflow on every session:
+
+1. **Orient** — call `get_active_context` first; if a task is attached, move it to In Progress immediately
+2. **Document as you go** — write notes with `ensure_note` (idempotent, no duplicates) as findings emerge
+3. **Capture out-of-scope work** — create tasks for anything discovered beyond the current scope
+4. **Wrap up** — write a session summary note and move the task to Review or Done before replying
+
+### Subagent support
+
+The agent can spawn focused sub-agents via `spawn_subagent { prompt, cwd?, model? }`. The sub-agent runs a full nested tool-call loop with its own message history. Only the final answer is returned to the parent, keeping the parent context lean. The sub-agent trace is rendered inline and collapsible in the parent message bubble. Users can expand it to step through the sub-agent's reasoning and tool calls.
+
+### Chat UI
+
+A new `PiAgentPane` replaces the xterm terminal for `sessionType: "pi"` sessions. Features:
+
+- **Per-step message bubbles** — each LLM turn produces a separate bubble; empty tool-only steps are dropped
+- **Live tool chips** — appear immediately when a tool starts (spinner), transition to a check/cross when done
+- **Expandable tool output** — click any chip to expand the raw output inline; `edit` calls render a colour-coded unified diff
+- **Cairn item links** — write tool chips (`create_note`, `ensure_note`, `update_task`, etc.) render as clickable linked bubbles that navigate directly to the note or task
+- **Subagent blocks** — collapsible inline trace with its own tool chips and message list
+- **Context usage ring** — small SVG ring in the header showing prompt token usage against the configured context limit; colour shifts from accent → amber → red as the window fills; tooltip shows exact counts
+- **Multi-turn** — subsequent messages continue the same session history; Clear resets both the UI and main-process history
+
+### IPC channels
+
+| Channel | Direction | Description |
+|---------|-----------|-------------|
+| `pi-agent:prompt` | renderer → main | Send a prompt to a session |
+| `pi-agent:abort` | renderer → main | Abort the running turn |
+| `pi-agent:clear` | renderer → main | Clear session history |
+| `pi-agent:destroy` | renderer → main | Free session memory |
+| `pi-agent:token` | main → renderer | Streaming text delta |
+| `pi-agent:tools-ready` | main → renderer | Stream ended, tools about to execute — ensures a streaming message exists |
+| `pi-agent:tool` | main → renderer | Tool start (`status: "start"`) and end (`status: "end"`, with output) |
+| `pi-agent:step` | main → renderer | New LLM turn starting — seal previous message |
+| `pi-agent:usage` | main → renderer | Token usage after each step |
+| `pi-agent:subagent` | main → renderer | Subagent start/done with child session ID |
+| `pi-agent:done` | main → renderer | Turn complete |
+| `pi-agent:error` | main → renderer | Unrecoverable error |
+
+### Settings
+
+- **Context window** — new field in Settings → AI & Chat; presets for 8k / 32k / 128k / 200k; used by the context ring
+- `contextLimit` added to `AIConfig` (default 128 000)
+
+---
+
+## Fixes
+
+- **`no such table: settings`** — removed a bogus `SELECT value FROM settings` query in the pi-agent IPC handler; the settings table was never created and the config is already passed from the renderer
+- **Initial prompt not delivered** — React StrictMode double-invokes effects; the `setTimeout` cleanup was cancelling the timer before it fired; removed the cleanup and deferred by 100 ms instead of 0
+- **Tool chips missing during execution** — `addPiToolCall` required `isStreaming: true` on the last message, but when the LLM emits tool calls with no preceding text the streaming message was never created; `onToolsReady` event now fires before tool execution and `ensurePiStreamingMessage` creates the message if absent
+- **Empty message bubbles between steps** — `finalisePiMessage` now drops the message entirely if it has no content, tool calls, or subagents
+- **Duplicate notes** — `ensure_note` was not in `CAIRN_TOOL_NAMES`; added it, and the system prompt now mandates `ensure_note` as the default note-writing tool with an explicit explanation of why `create_note` creates duplicates
+- **Tab switch re-fires initial prompt** — `AgentView` was conditionally rendered (`activeView === "agent" && <AgentView />`); switching away unmounted it, resetting `firedInitial`; it is now always mounted and CSS-hidden when inactive
+- **Cairn item links not navigating** — `setView()` + `window.dispatchEvent(CairnEvents.selectNote())` fired synchronously before the target view mounted its listener; deferred by 50 ms
+- **Read tool chips showing expandable JSON** — output is now suppressed for all read-only tools (`read`, `grep`, `find`, `ls`, `get_active_context`, `get_note`, `list_tasks`, etc.)
+- **Subagent usage polluting parent context ring** — subagent token usage now updates the subagent's own inline ring only; the parent ring updates from parent steps only
+
+---
+
+## Changed files
+
+| File | Change |
+|------|--------|
+| `electron/lib/pi-agent-loop.ts` | Multi-turn agent loop; SSE parser; tool execution; `onToolsReady`, `onStepStart`, `onUsage` callbacks; `stream_options: { include_usage: true }` |
+| `electron/lib/pi-agent-prompt.ts` | System prompt with mandatory Cairn workflow, `ensure_note` guidance, `spawn_subagent` description |
+| `electron/lib/coding-tools/read.ts` | File reader with pagination |
+| `electron/lib/coding-tools/write.ts` | Full-file writer with mutex |
+| `electron/lib/coding-tools/edit.ts` | String-replacement editor with mutex |
+| `electron/lib/coding-tools/bash.ts` | Shell executor with streaming + abort |
+| `electron/lib/coding-tools/grep.ts` | Regex file search |
+| `electron/lib/coding-tools/find.ts` | Filename search |
+| `electron/lib/coding-tools/ls.ts` | Directory lister |
+| `electron/lib/coding-tools/file-mutex.ts` | Per-path write serialisation |
+| `electron/lib/coding-tools/subagent.ts` | New — `spawn_subagent` tool; nested `runAgentLoop` with child session IPC events |
+| `electron/lib/coding-tools/index.ts` | Barrel; `CODING_TOOL_DEFINITIONS` array |
+| `electron/ipc/pi-agent.ts` | IPC handler; sessions Map; all pi-agent:* channels |
+| `electron/preload.ts` | `piAgent` namespace: `prompt`, `abort`, `clear`, `destroy`, `onToken`, `onTool`, `onToolsReady`, `onStep`, `onUsage`, `onSubagent`, `onDone`, `onError` |
+| `electron/db/schema.ts` | Migration v14: `tool_calls` column on `chat_messages` |
+| `src/store/slices/terminal-sessions.ts` | `PiAgentMessage`, `PiSubagentMessage` types; `TerminalSession` fields (`sessionType`, `piMessages`, `initialPrompt`, `lastUsage`); `addPiMessage`, `appendPiToken`, `finalisePiMessage`, `ensurePiStreamingMessage`, `addPiToolCall`, `updatePiToolCall`, `addPiSubagent`, `appendPiSubagentToken`, `finalisePiSubagentMessage`, `addPiSubagentToolCall`, `updatePiSubagentToolCall`, `completePiSubagent`, `stepPiSubagent`, `updatePiUsage`, `updatePiSubagentUsage`, `clearPiMessages` |
+| `src/store/slices/ui.ts` | `AIConfig` gains `contextLimit: number` |
+| `src/lib/constants.ts` | `DEFAULT_AI_CONFIG` gains `contextLimit: 128000` |
+| `src/components/agent/PiAgentPane.tsx` | Chat UI; IPC subscriptions; `sendPrompt`; `initialPrompt` effect; `ContextRing` import |
+| `src/components/agent/PiMessageBubble.tsx` | User/assistant/error bubbles; `ToolChip` (running spinner → done); `CairnRefChip`; `ToolOutputPanel` (diff + pre); `SubagentBlock` with inline context ring |
+| `src/components/agent/ContextRing.tsx` | New — reusable SVG ring; `size` and `stroke` props |
+| `src/components/agent/SpawnAgentModal.tsx` | `sessionType` toggle; stores `initialPrompt` on session |
+| `src/components/agent/AgentTerminalPane.tsx` | Branches on `sessionType`; `MessageSquare` icon for pi tabs |
+| `src/components/settings/AISettings.tsx` | Context window row with presets |
+| `src/app/page.tsx` | `AgentView` always mounted, CSS-hidden when inactive |

--- a/electron/db/queries.ts
+++ b/electron/db/queries.ts
@@ -164,6 +164,7 @@ function toChatMessage(row: any) {
     role: row.role as string,
     content: row.content as string,
     contextRefs: row.context_refs ? JSON.parse(row.context_refs) : undefined,
+    toolCalls: row.tool_calls ? JSON.parse(row.tool_calls) : undefined,
     createdAt: row.created_at as string,
   };
 }
@@ -645,13 +646,13 @@ export function getChatMessages(db: Database.Database, threadId: string) {
 }
 
 export function addChatMessage(db: Database.Database, m: {
-  id: string; threadId: string; role: string; content: string; contextRefs?: unknown;
+  id: string; threadId: string; role: string; content: string; contextRefs?: unknown; toolCalls?: unknown;
 }) {
   const now = ts();
   db.prepare(`
-    INSERT INTO chat_messages (id, thread_id, role, content, context_refs, created_at)
-    VALUES (?, ?, ?, ?, ?, ?)
-  `).run(m.id, m.threadId, m.role, m.content, m.contextRefs ? JSON.stringify(m.contextRefs) : null, now);
+    INSERT INTO chat_messages (id, thread_id, role, content, context_refs, tool_calls, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(m.id, m.threadId, m.role, m.content, m.contextRefs ? JSON.stringify(m.contextRefs) : null, m.toolCalls ? JSON.stringify(m.toolCalls) : null, now);
   return toChatMessage(db.prepare("SELECT * FROM chat_messages WHERE id = ?").get(m.id));
 }
 

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -317,6 +317,15 @@ const MIGRATIONS: Migration[] = [
       db.exec("ALTER TABLE task_cards ADD COLUMN version INTEGER NOT NULL DEFAULT 0");
     }
   },
+
+  // v14: Persist tool calls on chat messages so they survive the streaming
+  // phase and remain visible in the message history after the response is done.
+  (db) => {
+    const cols = db.prepare("PRAGMA table_info(chat_messages)").all() as { name: string }[];
+    if (!cols.some((c) => c.name === "tool_calls")) {
+      db.exec("ALTER TABLE chat_messages ADD COLUMN tool_calls TEXT");
+    }
+  },
 ];
 
 export function applySchema(db: Database.Database): void {

--- a/electron/ipc/pi-agent.ts
+++ b/electron/ipc/pi-agent.ts
@@ -1,0 +1,166 @@
+/**
+ * Cairn Native Agent — IPC handler
+ *
+ * Registers pi-agent:* channels. Each session is a stateful PiAgentSession
+ * (message history + AbortController) held in a Map for the app lifetime.
+ *
+ * Channels (fire-and-forget, renderer → main):
+ *   pi-agent:prompt  { sessionId, prompt, projectId, cwd, taskTitle?, config }
+ *   pi-agent:abort   { sessionId }
+ *
+ * Events (main → renderer):
+ *   pi-agent:token     { sessionId, delta: string }
+ *   pi-agent:tool      { sessionId, name: string, label: string, status: "start"|"end", ok?: boolean }
+ *   pi-agent:done      { sessionId }
+ *   pi-agent:error     { sessionId, error: string }
+ */
+
+import { ipcMain } from "electron";
+import { runAgentLoop, type PiAgentSession, type AgentLLMConfig } from "../lib/pi-agent-loop";
+import { buildPiAgentSystemPrompt } from "../lib/pi-agent-prompt";
+import type { ChatRequest } from "../lib/tools";
+import type { DbContext } from "./handlers";
+
+// ── Session registry ──────────────────────────────────────────────────────────
+
+const sessions = new Map<string, PiAgentSession>();
+
+// ── Request shape ──────────────────────────────────────────────────────────────
+
+interface PiAgentPromptRequest {
+  sessionId: string;
+  prompt: string;
+  projectId?: string;
+  workspaceId?: string;
+  cwd: string;
+  taskTitle?: string;
+  config?: {
+    baseUrl?: string;
+    model?: string;
+    apiKey?: string;
+  };
+}
+
+// ── Registration ───────────────────────────────────────────────────────────────
+
+export function registerPiAgentHandler(
+  ctx: DbContext,
+): void {
+  // Read db/workspacePath from ctx at call-time so workspace reinitialise is transparent
+  const getWin = ctx.getWin;
+
+  // ── pi-agent:abort ────────────────────────────────────────────────────────
+  ipcMain.on("pi-agent:abort", (_event, { sessionId }: { sessionId: string }) => {
+    const session = sessions.get(sessionId);
+    if (session) {
+      session.abortCtrl.abort();
+    }
+  });
+
+  // ── pi-agent:prompt ───────────────────────────────────────────────────────
+  ipcMain.on("pi-agent:prompt", async (event, req: PiAgentPromptRequest) => {
+    const { sessionId, prompt, projectId, workspaceId, cwd, taskTitle } = req;
+
+    const send = (channel: string, payload: unknown) => {
+      const win = getWin();
+      if (win && !win.webContents.isDestroyed()) {
+        win.webContents.send(channel, payload);
+      }
+    };
+
+    // Resolve LLM config from settings stored in DB
+    const settingsRow = ctx.db
+      .prepare("SELECT value FROM settings WHERE key = 'aiConfig' LIMIT 1")
+      .get() as { value: string } | undefined;
+
+    let storedConfig: { baseUrl?: string; model?: string; apiKey?: string } = {};
+    if (settingsRow?.value) {
+      try { storedConfig = JSON.parse(settingsRow.value); } catch { /* ignore */ }
+    }
+
+    const llmConfig: AgentLLMConfig = {
+      baseUrl: (req.config?.baseUrl || storedConfig.baseUrl || "https://api.openai.com").replace(/\/$/, ""),
+      model:   req.config?.model   || storedConfig.model   || "gpt-4o",
+      apiKey:  req.config?.apiKey  || storedConfig.apiKey  || "",
+    };
+
+    // Get or create session
+    let session = sessions.get(sessionId);
+    if (!session) {
+      session = {
+        messages: [],
+        abortCtrl: new AbortController(),
+      };
+      sessions.set(sessionId, session);
+    } else {
+      // New prompt in existing session — create fresh abort controller
+      session.abortCtrl = new AbortController();
+    }
+
+    // Append the user message to history
+    session.messages.push({ role: "user", content: prompt });
+
+    // Resolve project name for system prompt
+    const projectName = projectId
+      ? (ctx.db.prepare("SELECT name FROM projects WHERE id = ?").get(projectId) as { name: string } | undefined)?.name ?? "Project"
+      : "Project";
+
+    const systemPrompt = buildPiAgentSystemPrompt({
+      projectName,
+      cwd,
+      taskTitle,
+      workspaceId,
+      projectId,
+    });
+
+    // Build a minimal ChatRequest for Cairn tool execution
+    const chatReq: ChatRequest = {
+      message: prompt,
+      threadId: sessionId,
+      projectId,
+      workspaceId,
+      config: {
+        baseUrl: llmConfig.baseUrl,
+        model: llmConfig.model,
+        apiKey: llmConfig.apiKey,
+      },
+    };
+
+    await runAgentLoop(
+      session,
+      systemPrompt,
+      cwd,
+      llmConfig,
+      ctx.db,
+      chatReq,
+      ctx.workspacePath,
+      {
+        onToken: (delta) => send("pi-agent:token", { sessionId, delta }),
+        onToolStart: (name, label) => send("pi-agent:tool", { sessionId, name, label, status: "start" }),
+        onToolEnd: (name, label, ok) => send("pi-agent:tool", { sessionId, name, label, status: "end", ok }),
+        onDone: () => send("pi-agent:done", { sessionId }),
+        onError: (error) => send("pi-agent:error", { sessionId, error }),
+      },
+      getWin,
+    );
+  });
+
+  // ── pi-agent:clear ────────────────────────────────────────────────────────
+  // Clears a session's message history (new conversation within same session)
+  ipcMain.on("pi-agent:clear", (_event, { sessionId }: { sessionId: string }) => {
+    const session = sessions.get(sessionId);
+    if (session) {
+      session.messages = [];
+    }
+  });
+
+  // ── pi-agent:destroy ──────────────────────────────────────────────────────
+  // Called when a pi session tab is closed — frees memory
+  ipcMain.on("pi-agent:destroy", (_event, { sessionId }: { sessionId: string }) => {
+    const session = sessions.get(sessionId);
+    if (session) {
+      session.abortCtrl.abort();
+      sessions.delete(sessionId);
+    }
+  });
+}

--- a/electron/ipc/pi-agent.ts
+++ b/electron/ipc/pi-agent.ts
@@ -128,13 +128,18 @@ export function registerPiAgentHandler(
       chatReq,
       ctx.workspacePath,
       {
-        onToken: (delta) => send("pi-agent:token", { sessionId, delta }),
-        onToolStart: (name, label) => send("pi-agent:tool", { sessionId, name, label, status: "start" }),
-        onToolEnd: (name, label, ok) => send("pi-agent:tool", { sessionId, name, label, status: "end", ok }),
-        onDone: () => send("pi-agent:done", { sessionId }),
-        onError: (error) => send("pi-agent:error", { sessionId, error }),
+        onToken:      (delta) => send("pi-agent:token",      { sessionId, delta }),
+        onToolsReady: ()     => send("pi-agent:tools-ready", { sessionId }),
+        onToolStart:  (name, label) => send("pi-agent:tool", { sessionId, name, label, status: "start" }),
+        onToolEnd:    (name, label, ok, output) => send("pi-agent:tool", { sessionId, name, label, status: "end", ok, output }),
+        onStepStart:  () => send("pi-agent:step",  { sessionId }),
+        onUsage:      (promptTokens, completionTokens) => send("pi-agent:usage", { sessionId, promptTokens, completionTokens }),
+        onDone:       () => send("pi-agent:done",  { sessionId }),
+        onError:      (error) => send("pi-agent:error", { sessionId, error }),
       },
       getWin,
+      sessionId,
+      send,
     );
   });
 

--- a/electron/ipc/pi-agent.ts
+++ b/electron/ipc/pi-agent.ts
@@ -75,8 +75,6 @@ export function registerPiAgentHandler(
       apiKey:  req.config?.apiKey  || "",
     };
 
-    console.log("[pi-agent] prompt received", { sessionId, cwd, projectId, model: llmConfig.model, baseUrl: llmConfig.baseUrl, hasApiKey: !!llmConfig.apiKey });
-
     // Get or create session
     let session = sessions.get(sessionId);
     if (!session) {

--- a/electron/ipc/pi-agent.ts
+++ b/electron/ipc/pi-agent.ts
@@ -68,21 +68,14 @@ export function registerPiAgentHandler(
       }
     };
 
-    // Resolve LLM config from settings stored in DB
-    const settingsRow = ctx.db
-      .prepare("SELECT value FROM settings WHERE key = 'aiConfig' LIMIT 1")
-      .get() as { value: string } | undefined;
-
-    let storedConfig: { baseUrl?: string; model?: string; apiKey?: string } = {};
-    if (settingsRow?.value) {
-      try { storedConfig = JSON.parse(settingsRow.value); } catch { /* ignore */ }
-    }
-
+    // Resolve LLM config — renderer passes config from its aiConfig store
     const llmConfig: AgentLLMConfig = {
-      baseUrl: (req.config?.baseUrl || storedConfig.baseUrl || "https://api.openai.com").replace(/\/$/, ""),
-      model:   req.config?.model   || storedConfig.model   || "gpt-4o",
-      apiKey:  req.config?.apiKey  || storedConfig.apiKey  || "",
+      baseUrl: (req.config?.baseUrl || "https://api.openai.com").replace(/\/$/, ""),
+      model:   req.config?.model   || "gpt-4o",
+      apiKey:  req.config?.apiKey  || "",
     };
+
+    console.log("[pi-agent] prompt received", { sessionId, cwd, projectId, model: llmConfig.model, baseUrl: llmConfig.baseUrl, hasApiKey: !!llmConfig.apiKey });
 
     // Get or create session
     let session = sessions.get(sessionId);

--- a/electron/lib/coding-tools/bash.ts
+++ b/electron/lib/coding-tools/bash.ts
@@ -1,0 +1,118 @@
+/**
+ * bash tool — execute shell commands with streaming output + abort.
+ *
+ * Ported from pi packages/coding-agent/src/core/tools/bash.ts
+ * Keeps: output truncation, abort signal, timeout, streaming onUpdate.
+ * Removed: TUI rendering, TypeBox schemas, pluggable Operations.
+ */
+
+import { spawn } from "child_process";
+import path from "path";
+
+const MAX_OUTPUT_BYTES = 50_000;
+const DEFAULT_TIMEOUT_MS = 120_000; // 2 minutes
+
+export interface BashArgs {
+  command: string;
+  timeout?: number; // seconds
+}
+
+export interface BashOptions {
+  onUpdate?: (output: string) => void;
+  signal?: AbortSignal;
+}
+
+export async function bashTool(
+  args: BashArgs,
+  cwd: string,
+  opts: BashOptions = {}
+): Promise<string> {
+  const { onUpdate, signal } = opts;
+  const timeoutMs = args.timeout ? args.timeout * 1000 : DEFAULT_TIMEOUT_MS;
+
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error("Command aborted"));
+      return;
+    }
+
+    let output = "";
+    let truncated = false;
+
+    const child = spawn("bash", ["-c", args.command], {
+      cwd,
+      env: { ...process.env, TERM: "xterm-256color" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const onData = (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      if (!truncated) {
+        const available = MAX_OUTPUT_BYTES - Buffer.byteLength(output, "utf8");
+        if (available <= 0) {
+          truncated = true;
+          output += "\n[Output truncated — exceeded 50 KB limit]";
+        } else {
+          output += text.slice(0, available);
+          if (Buffer.byteLength(text, "utf8") > available) {
+            truncated = true;
+            output += "\n[Output truncated — exceeded 50 KB limit]";
+          }
+        }
+      }
+      onUpdate?.(output);
+    };
+
+    child.stdout.on("data", onData);
+    child.stderr.on("data", onData);
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`Command timed out after ${args.timeout ?? DEFAULT_TIMEOUT_MS / 1000} seconds\n\n${output}`));
+    }, timeoutMs);
+
+    const abortHandler = () => {
+      clearTimeout(timer);
+      child.kill("SIGKILL");
+      reject(new Error(`Command aborted\n\n${output}`));
+    };
+    signal?.addEventListener("abort", abortHandler);
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", abortHandler);
+      if (signal?.aborted) return; // already rejected above
+      if (code !== 0 && code !== null) {
+        reject(new Error(`Command exited with code ${code}\n\n${output}`));
+      } else {
+        resolve(output || "(no output)");
+      }
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", abortHandler);
+      reject(new Error(`Failed to execute command: ${err.message}`));
+    });
+  });
+}
+
+export const bashToolDefinition = {
+  type: "function" as const,
+  function: {
+    name: "bash",
+    description:
+      "Execute a bash command in the project's root directory. " +
+      "Output is streamed and capped at 50 KB. " +
+      "Use for running tests, builds, grep, git commands, etc. " +
+      "Avoid interactive commands or long-running processes.",
+    parameters: {
+      type: "object",
+      properties: {
+        command: { type: "string", description: "Bash command to execute" },
+        timeout: { type: "number", description: "Timeout in seconds (default: 120)" },
+      },
+      required: ["command"],
+    },
+  },
+};

--- a/electron/lib/coding-tools/edit.ts
+++ b/electron/lib/coding-tools/edit.ts
@@ -1,0 +1,124 @@
+/**
+ * edit tool — targeted string replacement in files.
+ *
+ * Ported from pi packages/coding-agent/src/core/tools/edit.ts
+ * Keeps: diff-based edit, file mutex, BOM/line-ending normalisation.
+ * Removed: TUI rendering, TypeBox schemas, pluggable Operations.
+ */
+
+import fs from "fs";
+import path from "path";
+import { withFileMutex } from "./file-mutex";
+
+export interface EditEntry {
+  oldText: string;
+  newText: string;
+}
+
+export interface EditArgs {
+  path: string;
+  edits: EditEntry[];
+}
+
+function stripBom(s: string): { content: string; hasBom: boolean } {
+  if (s.charCodeAt(0) === 0xFEFF) return { content: s.slice(1), hasBom: true };
+  return { content: s, hasBom: false };
+}
+
+type LineEnding = "\r\n" | "\n";
+
+function detectLineEnding(s: string): LineEnding {
+  return s.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function normalise(s: string): string {
+  return s.replace(/\r\n/g, "\n");
+}
+
+function restore(s: string, le: LineEnding): string {
+  if (le === "\r\n") return s.replace(/\n/g, "\r\n");
+  return s;
+}
+
+function applyEdits(content: string, edits: EditEntry[]): string {
+  let result = content;
+  for (const { oldText, newText } of edits) {
+    const normOld = normalise(oldText);
+    const idx = result.indexOf(normOld);
+    if (idx === -1) {
+      throw new Error(
+        `edit: oldText not found in file.\n` +
+        `Looking for:\n${oldText.slice(0, 200)}${oldText.length > 200 ? "…" : ""}`
+      );
+    }
+    const count = result.split(normOld).length - 1;
+    if (count > 1) {
+      throw new Error(
+        `edit: oldText matches ${count} locations — provide more surrounding context to make it unique.`
+      );
+    }
+    result = result.slice(0, idx) + normalise(newText) + result.slice(idx + normOld.length);
+  }
+  return result;
+}
+
+export async function editTool(args: EditArgs, cwd: string): Promise<string> {
+  if (!args.edits || args.edits.length === 0) {
+    throw new Error("edit: edits array must not be empty");
+  }
+
+  const filePath = path.isAbsolute(args.path) ? args.path : path.join(cwd, args.path);
+
+  return withFileMutex(filePath, async () => {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(filePath, "utf8");
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException;
+      if (err.code === "ENOENT") throw new Error(`File not found: ${args.path}`);
+      throw new Error(`Cannot read ${args.path}: ${err.message}`);
+    }
+
+    const { content: noBom, hasBom } = stripBom(raw);
+    const lineEnding = detectLineEnding(noBom);
+    const normalised = normalise(noBom);
+
+    const updated = applyEdits(normalised, args.edits);
+
+    const final = (hasBom ? "\uFEFF" : "") + restore(updated, lineEnding);
+    fs.writeFileSync(filePath, final, "utf8");
+
+    const editCount = args.edits.length;
+    return `Applied ${editCount} edit${editCount === 1 ? "" : "s"} to ${args.path}`;
+  });
+}
+
+export const editToolDefinition = {
+  type: "function" as const,
+  function: {
+    name: "edit",
+    description:
+      "Make targeted string replacements in a file. Each edit replaces an exact oldText with newText. " +
+      "oldText must match exactly — include enough surrounding lines to make it unique. " +
+      "Always read the file first to get the exact content.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string", description: "File path relative to the project root" },
+        edits: {
+          type: "array",
+          description: "List of replacements to apply in order",
+          items: {
+            type: "object",
+            properties: {
+              oldText: { type: "string", description: "Exact text to find (must be unique in the file)" },
+              newText: { type: "string", description: "Text to replace it with" },
+            },
+            required: ["oldText", "newText"],
+          },
+        },
+      },
+      required: ["path", "edits"],
+    },
+  },
+};

--- a/electron/lib/coding-tools/file-mutex.ts
+++ b/electron/lib/coding-tools/file-mutex.ts
@@ -1,0 +1,23 @@
+/**
+ * Per-file write serialisation queue.
+ *
+ * Concurrent edits to the same file path are queued and executed one at a
+ * time so partial-write races are impossible. Separate files run in parallel.
+ *
+ * Ported from pi packages/coding-agent/src/core/tools/file-mutation-queue.ts
+ */
+
+const queues = new Map<string, Promise<void>>();
+
+export function withFileMutex<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  const prev = queues.get(filePath) ?? Promise.resolve();
+  let resolve!: () => void;
+  const next = new Promise<void>((r) => { resolve = r; });
+  queues.set(filePath, next);
+
+  return prev.then(() => fn()).finally(() => {
+    resolve();
+    // Clean up if this is still the tail of the queue
+    if (queues.get(filePath) === next) queues.delete(filePath);
+  });
+}

--- a/electron/lib/coding-tools/find.ts
+++ b/electron/lib/coding-tools/find.ts
@@ -1,0 +1,87 @@
+/**
+ * find tool — find files by name pattern.
+ *
+ * Ported from pi packages/coding-agent/src/core/tools/find.ts
+ */
+
+import fs from "fs";
+import path from "path";
+
+const MAX_RESULTS = 50;
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", ".next", "out", "build", ".turbo"]);
+
+export interface FindArgs {
+  pattern: string; // substring or glob-style pattern to match against filenames
+  path?: string;   // directory to search (default: cwd)
+}
+
+function matchesPattern(name: string, pattern: string): boolean {
+  // Support simple glob: * matches anything except /
+  if (pattern.includes("*")) {
+    const re = new RegExp("^" + pattern.replace(/\./g, "\\.").replace(/\*/g, ".*") + "$", "i");
+    return re.test(name);
+  }
+  return name.toLowerCase().includes(pattern.toLowerCase());
+}
+
+function findFiles(
+  dirPath: string,
+  pattern: string,
+  results: string[],
+  cwd: string
+): void {
+  if (results.length >= MAX_RESULTS) return;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  } catch { return; }
+
+  for (const entry of entries) {
+    if (results.length >= MAX_RESULTS) break;
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      findFiles(path.join(dirPath, entry.name), pattern, results, cwd);
+    } else if (entry.isFile()) {
+      if (matchesPattern(entry.name, pattern)) {
+        results.push(path.relative(cwd, path.join(dirPath, entry.name)));
+      }
+    }
+  }
+}
+
+export async function findTool(args: FindArgs, cwd: string): Promise<string> {
+  const searchPath = args.path
+    ? (path.isAbsolute(args.path) ? args.path : path.join(cwd, args.path))
+    : cwd;
+
+  try {
+    fs.statSync(searchPath);
+  } catch {
+    throw new Error(`Directory not found: ${args.path ?? "."}`);
+  }
+
+  const results: string[] = [];
+  findFiles(searchPath, args.pattern, results, cwd);
+
+  if (results.length === 0) return `No files matching "${args.pattern}" found.`;
+
+  const output = results.join("\n");
+  const suffix = results.length >= MAX_RESULTS ? `\n\n[Showing first ${MAX_RESULTS} results]` : "";
+  return output + suffix;
+}
+
+export const findToolDefinition = {
+  type: "function" as const,
+  function: {
+    name: "find",
+    description: "Find files by name pattern. Searches recursively, skipping node_modules, .git, dist etc.",
+    parameters: {
+      type: "object",
+      properties: {
+        pattern: { type: "string", description: "Filename pattern to match (substring or glob with *)" },
+        path:    { type: "string", description: "Directory to search (default: project root)" },
+      },
+      required: ["pattern"],
+    },
+  },
+};

--- a/electron/lib/coding-tools/grep.ts
+++ b/electron/lib/coding-tools/grep.ts
@@ -1,0 +1,124 @@
+/**
+ * grep tool — search file contents with regex.
+ *
+ * Ported from pi packages/coding-agent/src/core/tools/grep.ts
+ */
+
+import fs from "fs";
+import path from "path";
+
+const MAX_RESULTS = 100;
+
+export interface GrepArgs {
+  pattern: string;
+  path?: string;   // directory or file to search (default: cwd)
+  include?: string; // glob pattern to filter files e.g. "*.ts"
+}
+
+interface GrepMatch {
+  file: string;
+  line: number;
+  content: string;
+}
+
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", ".next", "out", "build", ".turbo"]);
+
+function matchesInclude(filePath: string, include?: string): boolean {
+  if (!include) return true;
+  // Simple glob: support *.ext and **/*.ext
+  const pattern = include.replace(/\*\*/g, "__GLOB__").replace(/\*/g, "[^/]*").replace(/__GLOB__/g, ".*");
+  return new RegExp(pattern + "$").test(filePath);
+}
+
+function searchDir(
+  dirPath: string,
+  regex: RegExp,
+  include: string | undefined,
+  results: GrepMatch[]
+): void {
+  if (results.length >= MAX_RESULTS) return;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  } catch { return; }
+
+  for (const entry of entries) {
+    if (results.length >= MAX_RESULTS) break;
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      searchDir(path.join(dirPath, entry.name), regex, include, results);
+    } else if (entry.isFile()) {
+      const filePath = path.join(dirPath, entry.name);
+      if (!matchesInclude(filePath, include)) continue;
+      try {
+        const content = fs.readFileSync(filePath, "utf8");
+        const lines = content.split("\n");
+        lines.forEach((line, i) => {
+          if (results.length >= MAX_RESULTS) return;
+          if (regex.test(line)) {
+            results.push({ file: filePath, line: i + 1, content: line.trim() });
+          }
+        });
+      } catch { /* skip unreadable files */ }
+    }
+  }
+}
+
+export async function grepTool(args: GrepArgs, cwd: string): Promise<string> {
+  let regex: RegExp;
+  try {
+    regex = new RegExp(args.pattern);
+  } catch {
+    throw new Error(`Invalid regex pattern: ${args.pattern}`);
+  }
+
+  const searchPath = args.path
+    ? (path.isAbsolute(args.path) ? args.path : path.join(cwd, args.path))
+    : cwd;
+
+  const results: GrepMatch[] = [];
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(searchPath);
+  } catch {
+    throw new Error(`Path not found: ${args.path ?? "."}`);
+  }
+
+  if (stat.isFile()) {
+    const content = fs.readFileSync(searchPath, "utf8");
+    content.split("\n").forEach((line, i) => {
+      if (regex.test(line)) results.push({ file: searchPath, line: i + 1, content: line.trim() });
+    });
+  } else {
+    searchDir(searchPath, regex, args.include, results);
+  }
+
+  if (results.length === 0) return "No matches found.";
+
+  const lines = results.map((r) => {
+    const rel = path.relative(cwd, r.file);
+    return `${rel}:${r.line}: ${r.content}`;
+  });
+
+  const output = lines.join("\n");
+  const suffix = results.length >= MAX_RESULTS ? `\n\n[Showing first ${MAX_RESULTS} matches]` : "";
+  return output + suffix;
+}
+
+export const grepToolDefinition = {
+  type: "function" as const,
+  function: {
+    name: "grep",
+    description: "Search file contents using a regex pattern. Returns file paths, line numbers, and matching lines.",
+    parameters: {
+      type: "object",
+      properties: {
+        pattern: { type: "string", description: "Regex pattern to search for" },
+        path:    { type: "string", description: "Directory or file to search (default: project root)" },
+        include: { type: "string", description: "Glob pattern to filter files, e.g. \"*.ts\" or \"**/*.tsx\"" },
+      },
+      required: ["pattern"],
+    },
+  },
+};

--- a/electron/lib/coding-tools/index.ts
+++ b/electron/lib/coding-tools/index.ts
@@ -13,6 +13,7 @@ export { bashTool,  bashToolDefinition  } from "./bash";
 export { grepTool,  grepToolDefinition  } from "./grep";
 export { findTool,  findToolDefinition  } from "./find";
 export { lsTool,    lsToolDefinition    } from "./ls";
+export { spawnSubagentDefinition, spawnSubagentTool } from "./subagent";
 
 export type { ReadArgs  } from "./read";
 export type { WriteArgs } from "./write";
@@ -21,6 +22,7 @@ export type { BashArgs, BashOptions } from "./bash";
 export type { GrepArgs  } from "./grep";
 export type { FindArgs  } from "./find";
 export type { LsArgs    } from "./ls";
+export type { SpawnSubagentArgs } from "./subagent";
 
 import { readToolDefinition  } from "./read";
 import { writeToolDefinition } from "./write";
@@ -29,6 +31,7 @@ import { bashToolDefinition  } from "./bash";
 import { grepToolDefinition  } from "./grep";
 import { findToolDefinition  } from "./find";
 import { lsToolDefinition    } from "./ls";
+import { spawnSubagentDefinition } from "./subagent";
 
 /** All coding tool definitions in OpenAI function-calling format. */
 export const CODING_TOOL_DEFINITIONS = [
@@ -39,4 +42,5 @@ export const CODING_TOOL_DEFINITIONS = [
   grepToolDefinition,
   findToolDefinition,
   lsToolDefinition,
+  spawnSubagentDefinition,
 ] as const;

--- a/electron/lib/coding-tools/index.ts
+++ b/electron/lib/coding-tools/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Cairn coding tools — barrel export.
+ *
+ * All 7 tools ported from pi packages/coding-agent/src/core/tools/
+ * adapted for direct Node.js use in the Electron main process.
+ * No external dependencies beyond Node.js built-ins.
+ */
+
+export { readTool,  readToolDefinition  } from "./read";
+export { writeTool, writeToolDefinition } from "./write";
+export { editTool,  editToolDefinition  } from "./edit";
+export { bashTool,  bashToolDefinition  } from "./bash";
+export { grepTool,  grepToolDefinition  } from "./grep";
+export { findTool,  findToolDefinition  } from "./find";
+export { lsTool,    lsToolDefinition    } from "./ls";
+
+export type { ReadArgs  } from "./read";
+export type { WriteArgs } from "./write";
+export type { EditArgs, EditEntry } from "./edit";
+export type { BashArgs, BashOptions } from "./bash";
+export type { GrepArgs  } from "./grep";
+export type { FindArgs  } from "./find";
+export type { LsArgs    } from "./ls";
+
+import { readToolDefinition  } from "./read";
+import { writeToolDefinition } from "./write";
+import { editToolDefinition  } from "./edit";
+import { bashToolDefinition  } from "./bash";
+import { grepToolDefinition  } from "./grep";
+import { findToolDefinition  } from "./find";
+import { lsToolDefinition    } from "./ls";
+
+/** All coding tool definitions in OpenAI function-calling format. */
+export const CODING_TOOL_DEFINITIONS = [
+  readToolDefinition,
+  writeToolDefinition,
+  editToolDefinition,
+  bashToolDefinition,
+  grepToolDefinition,
+  findToolDefinition,
+  lsToolDefinition,
+] as const;

--- a/electron/lib/coding-tools/ls.ts
+++ b/electron/lib/coding-tools/ls.ts
@@ -1,0 +1,55 @@
+/**
+ * ls tool — list directory contents.
+ *
+ * Ported from pi packages/coding-agent/src/core/tools/ls.ts
+ */
+
+import fs from "fs";
+import path from "path";
+
+export interface LsArgs {
+  path?: string; // directory to list (default: cwd)
+}
+
+export async function lsTool(args: LsArgs, cwd: string): Promise<string> {
+  const dirPath = args.path
+    ? (path.isAbsolute(args.path) ? args.path : path.join(cwd, args.path))
+    : cwd;
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") throw new Error(`Directory not found: ${args.path ?? "."}`);
+    if (err.code === "ENOTDIR") throw new Error(`Not a directory: ${args.path}`);
+    throw new Error(`Cannot list ${args.path ?? "."}: ${err.message}`);
+  }
+
+  if (entries.length === 0) return "(empty directory)";
+
+  const lines = entries
+    .sort((a, b) => {
+      // Directories first, then files, alphabetical within each group
+      if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    })
+    .map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
+
+  return lines.join("\n");
+}
+
+export const lsToolDefinition = {
+  type: "function" as const,
+  function: {
+    name: "ls",
+    description: "List the contents of a directory. Directories are shown with a trailing slash.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string", description: "Directory to list (default: project root)" },
+      },
+      required: [],
+    },
+  },
+};

--- a/electron/lib/coding-tools/read.ts
+++ b/electron/lib/coding-tools/read.ts
@@ -1,0 +1,81 @@
+/**
+ * read tool — read file contents with optional line range.
+ *
+ * Ported from pi packages/coding-agent/src/core/tools/read.ts
+ * TUI rendering, TypeBox schemas, and pluggable Operations removed.
+ */
+
+import fs from "fs";
+import path from "path";
+
+const MAX_LINES = 2000;
+const MAX_BYTES = 200_000;
+
+export interface ReadArgs {
+  path: string;
+  offset?: number; // 1-indexed line to start from
+  limit?: number;  // max lines to return
+}
+
+export async function readTool(args: ReadArgs, cwd: string): Promise<string> {
+  const filePath = path.isAbsolute(args.path) ? args.path : path.join(cwd, args.path);
+
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, "utf8");
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") throw new Error(`File not found: ${args.path}`);
+    if (err.code === "EISDIR") throw new Error(`Path is a directory: ${args.path}`);
+    throw new Error(`Cannot read ${args.path}: ${err.message}`);
+  }
+
+  const lines = content.split("\n");
+  const total = lines.length;
+
+  const offset = Math.max(1, args.offset ?? 1);
+  const limit  = Math.min(args.limit ?? MAX_LINES, MAX_LINES);
+
+  const start = offset - 1; // convert to 0-indexed
+  const end   = Math.min(start + limit, total);
+  const slice = lines.slice(start, end);
+
+  let result = slice.map((line, i) => `${start + i + 1}: ${line}`).join("\n");
+
+  // Byte cap
+  if (Buffer.byteLength(result, "utf8") > MAX_BYTES) {
+    const truncated: string[] = [];
+    let bytes = 0;
+    for (const line of slice) {
+      const lineBytes = Buffer.byteLength(line + "\n", "utf8");
+      if (bytes + lineBytes > MAX_BYTES) break;
+      truncated.push(line);
+      bytes += lineBytes;
+    }
+    result = truncated.map((line, i) => `${start + i + 1}: ${line}`).join("\n");
+    result += `\n\n[Output truncated. Use offset=${start + truncated.length + 1} to continue.]`;
+  }
+
+  if (end < total) {
+    result += `\n\n[Showing lines ${offset}–${end} of ${total}. Use offset=${end + 1} to continue.]`;
+  }
+
+  return result;
+}
+
+export const readToolDefinition = {
+  type: "function" as const,
+  function: {
+    name: "read",
+    description: "Read file contents. Supports line ranges via offset/limit. Returns line-numbered output.",
+    parameters: {
+      type: "object",
+      properties: {
+        path:   { type: "string", description: "File path relative to the project root" },
+        offset: { type: "number", description: "1-indexed line to start from (default: 1)" },
+        limit:  { type: "number", description: `Max lines to return (default: ${MAX_LINES})` },
+      },
+      required: ["path"],
+    },
+  },
+};

--- a/electron/lib/coding-tools/subagent.ts
+++ b/electron/lib/coding-tools/subagent.ts
@@ -1,0 +1,135 @@
+/**
+ * spawn_subagent — coding tool
+ *
+ * Runs a nested PiAgentLoop with a fresh message history and returns only the
+ * final assistant message to the parent agent. This keeps the parent context
+ * lean while allowing deep multi-step sub-tasks.
+ *
+ * The subagent streams its own pi-agent:* events on a child session ID
+ * (`${parentSessionId}:sub:<uuid>`) so the renderer can render it inline.
+ */
+
+import { randomBytes } from "crypto";
+import type Database from "better-sqlite3";
+import type { BrowserWindow } from "electron";
+import { runAgentLoop, type PiAgentSession, type AgentLLMConfig } from "../pi-agent-loop";
+import type { ChatRequest } from "../tools";
+
+export interface SpawnSubagentArgs {
+  prompt: string;
+  /** Override cwd for the subagent — defaults to parent cwd */
+  cwd?: string;
+  /** Override model for the subagent — defaults to parent model */
+  model?: string;
+}
+
+export const spawnSubagentDefinition = {
+  type: "function" as const,
+  function: {
+    name: "spawn_subagent",
+    description:
+      "Spawn a focused sub-agent to handle a contained research or coding task without polluting the parent context. " +
+      "The sub-agent runs a full tool-calling loop and returns only its final answer. " +
+      "Use this for deep file searches, multi-file refactors, or any task that would generate many tool calls. " +
+      "The user can expand the subagent trace inline to inspect its reasoning.",
+    parameters: {
+      type: "object",
+      properties: {
+        prompt: {
+          type: "string",
+          description: "The task for the sub-agent to complete. Be specific and self-contained.",
+        },
+        cwd: {
+          type: "string",
+          description: "Working directory override. Defaults to the parent agent's cwd.",
+        },
+        model: {
+          type: "string",
+          description: "LLM model override for the sub-agent (e.g. gpt-4o-mini for lighter tasks).",
+        },
+      },
+      required: ["prompt"],
+    },
+  },
+};
+
+export async function spawnSubagentTool(
+  args: SpawnSubagentArgs,
+  parentCwd: string,
+  parentLlmConfig: AgentLLMConfig,
+  db: Database.Database,
+  parentReq: ChatRequest,
+  workspacePath: string,
+  parentSessionId: string,
+  send: (channel: string, payload: unknown) => void,
+  getWin?: () => BrowserWindow | null,
+): Promise<string> {
+  const childSessionId = `${parentSessionId}:sub:${randomBytes(4).toString("hex")}`;
+  const cwd = args.cwd ?? parentCwd;
+  const llmConfig: AgentLLMConfig = {
+    ...parentLlmConfig,
+    model: args.model ?? parentLlmConfig.model,
+  };
+
+  // Tell the renderer a subagent is starting
+  send("pi-agent:subagent", {
+    parentSessionId,
+    childSessionId,
+    status: "start",
+  });
+
+  const session: PiAgentSession = {
+    messages: [{ role: "user", content: args.prompt }],
+    abortCtrl: new AbortController(),
+  };
+
+  const systemPrompt =
+    "You are a focused sub-agent. Complete the given task thoroughly, use tools as needed, " +
+    "then respond with a clear, concise final answer. Do not ask clarifying questions.";
+
+  let finalAnswer = "";
+  let errorMessage = "";
+
+  await runAgentLoop(
+    session,
+    systemPrompt,
+    cwd,
+    llmConfig,
+    db,
+    { ...parentReq, threadId: childSessionId },
+    workspacePath,
+    {
+      onToken:      (delta) => send("pi-agent:token",      { sessionId: childSessionId, delta }),
+      onToolsReady: ()     => send("pi-agent:tools-ready", { sessionId: childSessionId }),
+      onToolStart:  (name, label) => send("pi-agent:tool", { sessionId: childSessionId, name, label, status: "start" }),
+      onToolEnd:    (name, label, ok, output) => send("pi-agent:tool", { sessionId: childSessionId, name, label, status: "end", ok, output }),
+      onStepStart:  () => send("pi-agent:step", { sessionId: childSessionId }),
+      onUsage:      (pt, ct) => send("pi-agent:usage", { sessionId: childSessionId, promptTokens: pt, completionTokens: ct }),
+      onDone:       () => { /* handled below */ },
+      onError:      (msg) => { errorMessage = msg; },
+    },
+    getWin,
+  );
+
+  // Extract the final assistant message from history
+  const lastAssistant = [...session.messages]
+    .reverse()
+    .find((m) => m.role === "assistant");
+  if (lastAssistant && "content" in lastAssistant && lastAssistant.content) {
+    finalAnswer = lastAssistant.content;
+  }
+
+  const result = errorMessage
+    ? `Sub-agent error: ${errorMessage}`
+    : finalAnswer || "(sub-agent produced no output)";
+
+  // Notify renderer the subagent is done
+  send("pi-agent:subagent", {
+    parentSessionId,
+    childSessionId,
+    status: "done",
+    result,
+  });
+
+  return result;
+}

--- a/electron/lib/coding-tools/write.ts
+++ b/electron/lib/coding-tools/write.ts
@@ -1,0 +1,41 @@
+/**
+ * write tool — write/overwrite a file entirely.
+ *
+ * Ported from pi packages/coding-agent/src/core/tools/write.ts
+ */
+
+import fs from "fs";
+import path from "path";
+import { withFileMutex } from "./file-mutex";
+
+export interface WriteArgs {
+  path: string;
+  content: string;
+}
+
+export async function writeTool(args: WriteArgs, cwd: string): Promise<string> {
+  const filePath = path.isAbsolute(args.path) ? args.path : path.join(cwd, args.path);
+
+  return withFileMutex(filePath, async () => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, args.content, "utf8");
+    const bytes = Buffer.byteLength(args.content, "utf8");
+    return `Successfully wrote ${bytes} bytes to ${args.path}`;
+  });
+}
+
+export const writeToolDefinition = {
+  type: "function" as const,
+  function: {
+    name: "write",
+    description: "Write or overwrite a file with the given content. Creates parent directories as needed.",
+    parameters: {
+      type: "object",
+      properties: {
+        path:    { type: "string", description: "File path relative to the project root" },
+        content: { type: "string", description: "Full file content to write" },
+      },
+      required: ["path", "content"],
+    },
+  },
+};

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -186,7 +186,10 @@ export async function runAgentLoop(
   const allTools = getAllToolDefs();
 
   const { baseUrl, model, apiKey } = llmConfig;
+  console.log("[pi-agent-loop] starting", { baseUrl, model, hasApiKey: !!apiKey, cwd, tools: allTools.length });
+
   if (!apiKey && !isLocalEndpoint(baseUrl)) {
+    console.log("[pi-agent-loop] no API key, aborting");
     callbacks.onError("No API key configured. Set one in Settings → AI & Chat.");
     return;
   }
@@ -196,6 +199,7 @@ export async function runAgentLoop(
   while (steps < MAX_STEPS) {
     if (signal.aborted) { callbacks.onDone(); return; }
     steps++;
+    console.log(`[pi-agent-loop] step ${steps}, messages=${session.messages.length}`);
 
     // Build messages array for this request
     const messages: AgentMessage[] = [
@@ -229,8 +233,10 @@ export async function runAgentLoop(
       return;
     }
 
+    console.log(`[pi-agent-loop] response status ${response.status}`);
     if (!response.ok) {
       const text = await response.text().catch(() => response.statusText);
+      console.log(`[pi-agent-loop] error response: ${text.slice(0, 300)}`);
       callbacks.onError(`AI error (${response.status}): ${text.slice(0, 300)}`);
       return;
     }
@@ -242,15 +248,21 @@ export async function runAgentLoop(
     const decoder = new TextDecoder();
     let contentBuffer = "";
     const toolCallBuffers: Map<number, { id: string; name: string; args: string }> = new Map();
+    let streamDone = false;
 
-    while (true) {
+    while (!streamDone) {
       const { done, value } = await reader.read();
       if (done) break;
       for (const line of decoder.decode(value, { stream: true }).split("\n")) {
         const trimmed = line.trim();
         if (!trimmed.startsWith("data:")) continue;
         const jsonStr = trimmed.slice(5).trim();
-        if (jsonStr === "[DONE]") break;
+        if (jsonStr === "[DONE]") {
+          // Mark done and break the inner loop — the outer while condition
+          // catches this on the next iteration so we don't call reader.read() again.
+          streamDone = true;
+          break;
+        }
         try {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const chunk = JSON.parse(jsonStr) as any;
@@ -280,9 +292,12 @@ export async function runAgentLoop(
       }
     }
 
+    console.log(`[pi-agent-loop] stream done: contentBuffer.length=${contentBuffer.length}, toolCalls=${toolCallBuffers.size}`);
+
     // ── No tool calls → turn complete ─────────────────────────────────────
     if (toolCallBuffers.size === 0) {
       session.messages.push({ role: "assistant", content: contentBuffer });
+      console.log("[pi-agent-loop] no tool calls → onDone");
       callbacks.onDone();
       return;
     }
@@ -314,6 +329,7 @@ export async function runAgentLoop(
         CODING_LABELS[tc.function.name]?.(args) ??
         `${tc.function.name}`;
 
+      console.log(`[pi-agent-loop] executing tool: ${tc.function.name}`, args);
       callbacks.onToolStart(tc.function.name, label);
 
       let resultContent: string;
@@ -335,6 +351,7 @@ export async function runAgentLoop(
         resultContent = `Error: ${(e as Error).message}`;
       }
 
+      console.log(`[pi-agent-loop] tool ${tc.function.name} done, ok=${ok}, result.length=${resultContent.length}`);
       callbacks.onToolEnd(tc.function.name, label, ok);
 
       session.messages.push({

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -208,10 +208,7 @@ export async function runAgentLoop(
   const allTools = getAllToolDefs();
 
   const { baseUrl, model, apiKey } = llmConfig;
-  console.log("[pi-agent-loop] starting", { baseUrl, model, hasApiKey: !!apiKey, cwd, tools: allTools.length });
-
   if (!apiKey && !isLocalEndpoint(baseUrl)) {
-    console.log("[pi-agent-loop] no API key, aborting");
     callbacks.onError("No API key configured. Set one in Settings → AI & Chat.");
     return;
   }
@@ -221,7 +218,6 @@ export async function runAgentLoop(
   while (steps < MAX_STEPS) {
     if (signal.aborted) { callbacks.onDone(); return; }
     steps++;
-    console.log(`[pi-agent-loop] step ${steps}, messages=${session.messages.length}`);
     // From step 2 onwards, signal the renderer to finalise the previous
     // assistant message and start a fresh one for this turn's tokens.
     if (steps > 1) callbacks.onStepStart();
@@ -259,10 +255,8 @@ export async function runAgentLoop(
       return;
     }
 
-    console.log(`[pi-agent-loop] response status ${response.status}`);
     if (!response.ok) {
       const text = await response.text().catch(() => response.statusText);
-      console.log(`[pi-agent-loop] error response: ${text.slice(0, 300)}`);
       callbacks.onError(`AI error (${response.status}): ${text.slice(0, 300)}`);
       return;
     }
@@ -327,12 +321,9 @@ export async function runAgentLoop(
       }
     }
 
-    console.log(`[pi-agent-loop] stream done: contentBuffer.length=${contentBuffer.length}, toolCalls=${toolCallBuffers.size}`);
-
     // ── No tool calls → turn complete ─────────────────────────────────────
     if (toolCallBuffers.size === 0) {
       session.messages.push({ role: "assistant", content: contentBuffer });
-      console.log("[pi-agent-loop] no tool calls → onDone");
       callbacks.onDone();
       return;
     }
@@ -370,7 +361,6 @@ export async function runAgentLoop(
         CODING_LABELS[tc.function.name]?.(args) ??
         `${tc.function.name}`;
 
-      console.log(`[pi-agent-loop] executing tool: ${tc.function.name}`, args);
       callbacks.onToolStart(tc.function.name, label);
 
       let resultContent: string;
@@ -395,7 +385,6 @@ export async function runAgentLoop(
         resultContent = `Error: ${(e as Error).message}`;
       }
 
-      console.log(`[pi-agent-loop] tool ${tc.function.name} done, ok=${ok}, result.length=${resultContent.length}`);
       callbacks.onToolEnd(tc.function.name, label, ok, resultContent);
 
       session.messages.push({

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -24,6 +24,7 @@ import {
   grepTool,  grepToolDefinition,
   findTool,  findToolDefinition,
   lsTool,    lsToolDefinition,
+  spawnSubagentDefinition, spawnSubagentTool,
 } from "./coding-tools/index";
 import { executeTool } from "../ipc/chat-executor";
 import type { ChatRequest, ToolArgs } from "./tools";
@@ -68,11 +69,14 @@ const CODING_LABELS: Record<string, (args: ToolArgs) => string> = {
 // ── Events interface ──────────────────────────────────────────────────────────
 
 export interface AgentLoopCallbacks {
-  onToken:     (delta: string) => void;
-  onToolStart: (name: string, label: string) => void;
-  onToolEnd:   (name: string, label: string, ok: boolean) => void;
-  onDone:      () => void;
-  onError:     (message: string) => void;
+  onToken:      (delta: string) => void;
+  onToolsReady: () => void;
+  onToolStart:  (name: string, label: string) => void;
+  onToolEnd:    (name: string, label: string, ok: boolean, output: string) => void;
+  onStepStart:  () => void;
+  onUsage:      (promptTokens: number, completionTokens: number) => void;
+  onDone:       () => void;
+  onError:      (message: string) => void;
 }
 
 // ── Session state ─────────────────────────────────────────────────────────────
@@ -92,6 +96,7 @@ const CODING_TOOL_DEFS = [
   grepToolDefinition,
   findToolDefinition,
   lsToolDefinition,
+  spawnSubagentDefinition,
 ];
 
 // Cairn data tool names we expose to the coding agent (subset of chat tools)
@@ -101,6 +106,7 @@ const CAIRN_TOOL_NAMES = new Set([
   "list_notes",
   "get_note",
   "create_note",
+  "ensure_note",
   "update_note",
   "patch_note",
   "append_to_note",
@@ -138,6 +144,9 @@ async function executeSingleTool(
   workspacePath: string,
   llmConfig: AgentLLMConfig,
   onUpdate: (output: string) => void,
+  sessionId: string,
+  send: (channel: string, payload: unknown) => void,
+  getWin?: () => BrowserWindow | null,
 ): Promise<string> {
   switch (name) {
     case "read":  return readTool(args as Parameters<typeof readTool>[0],  cwd);
@@ -151,6 +160,17 @@ async function executeSingleTool(
     case "grep":  return grepTool(args as Parameters<typeof grepTool>[0], cwd);
     case "find":  return findTool(args as Parameters<typeof findTool>[0], cwd);
     case "ls":    return lsTool(args as Parameters<typeof lsTool>[0],    cwd);
+    case "spawn_subagent": return spawnSubagentTool(
+      args as Parameters<typeof spawnSubagentTool>[0],
+      cwd,
+      llmConfig,
+      db,
+      req,
+      workspacePath,
+      sessionId,
+      send,
+      getWin,
+    );
     default: {
       // Delegate to Cairn chat executor
       if (CAIRN_TOOL_NAMES.has(name)) {
@@ -181,6 +201,8 @@ export async function runAgentLoop(
   workspacePath: string,
   callbacks: AgentLoopCallbacks,
   getWin?: () => BrowserWindow | null,
+  sessionId?: string,
+  send?: (channel: string, payload: unknown) => void,
 ): Promise<void> {
   const { signal } = session.abortCtrl;
   const allTools = getAllToolDefs();
@@ -200,6 +222,9 @@ export async function runAgentLoop(
     if (signal.aborted) { callbacks.onDone(); return; }
     steps++;
     console.log(`[pi-agent-loop] step ${steps}, messages=${session.messages.length}`);
+    // From step 2 onwards, signal the renderer to finalise the previous
+    // assistant message and start a fresh one for this turn's tokens.
+    if (steps > 1) callbacks.onStepStart();
 
     // Build messages array for this request
     const messages: AgentMessage[] = [
@@ -225,6 +250,7 @@ export async function runAgentLoop(
           max_tokens: 8192,
           temperature: 0.3,
           stream: true,
+          stream_options: { include_usage: true },
         }),
       });
     } catch (e) {
@@ -266,6 +292,15 @@ export async function runAgentLoop(
         try {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const chunk = JSON.parse(jsonStr) as any;
+
+          // Usage chunk — sent as the final SSE chunk when stream_options.include_usage is set.
+          // It has an empty choices array and a top-level usage object.
+          if (chunk.usage) {
+            const pt = chunk.usage.prompt_tokens ?? 0;
+            const ct = chunk.usage.completion_tokens ?? 0;
+            callbacks.onUsage(pt, ct);
+          }
+
           const delta = chunk.choices?.[0]?.delta;
           if (!delta) continue;
 
@@ -318,6 +353,12 @@ export async function runAgentLoop(
       tool_calls: toolCalls,
     });
 
+    // ── Ensure renderer has a streaming message to attach tool chips to ───
+    // When the LLM emits tool calls with no preceding text tokens, onToken
+    // was never called, so no streaming message exists. onToolsReady tells
+    // the renderer to create one before we start firing onToolStart/onToolEnd.
+    callbacks.onToolsReady();
+
     // ── Execute each tool ─────────────────────────────────────────────────
     for (const tc of toolCalls) {
       if (signal.aborted) { callbacks.onDone(); return; }
@@ -345,6 +386,9 @@ export async function runAgentLoop(
           workspacePath,
           llmConfig,
           (output) => callbacks.onToolStart(tc.function.name, `${label}: ${output.slice(-80)}`),
+          sessionId ?? "",
+          send ?? (() => {}),
+          getWin,
         );
       } catch (e) {
         ok = false;
@@ -352,7 +396,7 @@ export async function runAgentLoop(
       }
 
       console.log(`[pi-agent-loop] tool ${tc.function.name} done, ok=${ok}, result.length=${resultContent.length}`);
-      callbacks.onToolEnd(tc.function.name, label, ok);
+      callbacks.onToolEnd(tc.function.name, label, ok, resultContent);
 
       session.messages.push({
         role: "tool",

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -1,0 +1,353 @@
+/**
+ * Cairn Native Agent Loop
+ *
+ * A stateful multi-turn tool-call loop. Reuses streamCompletion from llm.ts
+ * (OpenAI-compatible). Each session keeps its own message history in the
+ * PiAgentSession object managed by the IPC handler.
+ *
+ * Events emitted (via callbacks, forwarded to renderer over IPC):
+ *   onToken(delta)              — streaming text chunk
+ *   onToolStart(name, label)    — tool execution beginning
+ *   onToolEnd(name, label, ok)  — tool execution finished
+ *   onDone()                    — turn complete, no more tool calls
+ *   onError(message)            — unrecoverable error
+ */
+
+import type Database from "better-sqlite3";
+import type { BrowserWindow } from "electron";
+import { isLocalEndpoint } from "./llm";
+import {
+  readTool,  readToolDefinition,
+  writeTool, writeToolDefinition,
+  editTool,  editToolDefinition,
+  bashTool,  bashToolDefinition,
+  grepTool,  grepToolDefinition,
+  findTool,  findToolDefinition,
+  lsTool,    lsToolDefinition,
+} from "./coding-tools/index";
+import { executeTool } from "../ipc/chat-executor";
+import type { ChatRequest, ToolArgs } from "./tools";
+
+// ── LLM config ───────────────────────────────────────────────────────────────
+
+export interface AgentLLMConfig {
+  baseUrl: string;
+  model: string;
+  apiKey: string;
+}
+
+// ── Message types ─────────────────────────────────────────────────────────────
+
+export interface AgentUserMessage    { role: "user";      content: string }
+export interface AgentAssistantMsg   { role: "assistant"; content: string | null; tool_calls?: ToolCallSpec[] }
+export interface AgentToolResultMsg  { role: "tool";      tool_call_id: string; content: string }
+
+export type AgentMessage =
+  | AgentUserMessage
+  | AgentAssistantMsg
+  | AgentToolResultMsg;
+
+interface ToolCallSpec {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+}
+
+// ── Tool label helper ─────────────────────────────────────────────────────────
+
+const CODING_LABELS: Record<string, (args: ToolArgs) => string> = {
+  read:  (a) => `Reading ${a.path as string}`,
+  write: (a) => `Writing ${a.path as string}`,
+  edit:  (a) => `Editing ${a.path as string}`,
+  bash:  (a) => `$ ${(a.command as string).slice(0, 60)}${(a.command as string).length > 60 ? "…" : ""}`,
+  grep:  (a) => `Searching for "${a.pattern as string}"`,
+  find:  (a) => `Finding "${a.pattern as string}"`,
+  ls:    (a) => `Listing ${(a.path as string) ?? "."}`,
+};
+
+// ── Events interface ──────────────────────────────────────────────────────────
+
+export interface AgentLoopCallbacks {
+  onToken:     (delta: string) => void;
+  onToolStart: (name: string, label: string) => void;
+  onToolEnd:   (name: string, label: string, ok: boolean) => void;
+  onDone:      () => void;
+  onError:     (message: string) => void;
+}
+
+// ── Session state ─────────────────────────────────────────────────────────────
+
+export interface PiAgentSession {
+  messages: AgentMessage[];
+  abortCtrl: AbortController;
+}
+
+// ── All tool definitions ──────────────────────────────────────────────────────
+
+const CODING_TOOL_DEFS = [
+  readToolDefinition,
+  writeToolDefinition,
+  editToolDefinition,
+  bashToolDefinition,
+  grepToolDefinition,
+  findToolDefinition,
+  lsToolDefinition,
+];
+
+// Cairn data tool names we expose to the coding agent (subset of chat tools)
+const CAIRN_TOOL_NAMES = new Set([
+  "get_active_context",
+  "get_project_context_pack",
+  "list_notes",
+  "get_note",
+  "create_note",
+  "update_note",
+  "patch_note",
+  "append_to_note",
+  "search_notes",
+  "list_tasks",
+  "get_task",
+  "create_task",
+  "update_task",
+  "update_task_status",
+  "search_tasks",
+  "list_ready_tasks",
+  "get_idea_flow",
+  "create_idea_flow_node",
+  "create_idea_flow_edge",
+]);
+
+// ── Fetch all tool definitions (coding + Cairn subset) ────────────────────────
+
+import { TOOLS as ALL_CAIRN_TOOLS } from "./tools";
+
+function getAllToolDefs() {
+  const cairnSubset = ALL_CAIRN_TOOLS.filter((t) => CAIRN_TOOL_NAMES.has(t.function.name));
+  return [...CODING_TOOL_DEFS, ...cairnSubset];
+}
+
+// ── Execute a single tool call ────────────────────────────────────────────────
+
+async function executeSingleTool(
+  name: string,
+  args: ToolArgs,
+  cwd: string,
+  signal: AbortSignal,
+  db: Database.Database,
+  req: ChatRequest,
+  workspacePath: string,
+  llmConfig: AgentLLMConfig,
+  onUpdate: (output: string) => void,
+): Promise<string> {
+  switch (name) {
+    case "read":  return readTool(args as Parameters<typeof readTool>[0],  cwd);
+    case "write": return writeTool(args as Parameters<typeof writeTool>[0], cwd);
+    case "edit":  return editTool(args as Parameters<typeof editTool>[0],  cwd);
+    case "bash":  return bashTool(
+      args as Parameters<typeof bashTool>[0],
+      cwd,
+      { signal, onUpdate }
+    );
+    case "grep":  return grepTool(args as Parameters<typeof grepTool>[0], cwd);
+    case "find":  return findTool(args as Parameters<typeof findTool>[0], cwd);
+    case "ls":    return lsTool(args as Parameters<typeof lsTool>[0],    cwd);
+    default: {
+      // Delegate to Cairn chat executor
+      if (CAIRN_TOOL_NAMES.has(name)) {
+        const result = await executeTool(
+          db, req, workspacePath,
+          { baseUrl: llmConfig.baseUrl, model: llmConfig.model, apiKey: llmConfig.apiKey },
+          name, args,
+          undefined,
+        );
+        return typeof result === "string" ? result : JSON.stringify(result, null, 2);
+      }
+      throw new Error(`Unknown tool: ${name}`);
+    }
+  }
+}
+
+// ── Main loop ─────────────────────────────────────────────────────────────────
+
+const MAX_STEPS = 30;
+
+export async function runAgentLoop(
+  session: PiAgentSession,
+  systemPrompt: string,
+  cwd: string,
+  llmConfig: AgentLLMConfig,
+  db: Database.Database,
+  req: ChatRequest,
+  workspacePath: string,
+  callbacks: AgentLoopCallbacks,
+  getWin?: () => BrowserWindow | null,
+): Promise<void> {
+  const { signal } = session.abortCtrl;
+  const allTools = getAllToolDefs();
+
+  const { baseUrl, model, apiKey } = llmConfig;
+  if (!apiKey && !isLocalEndpoint(baseUrl)) {
+    callbacks.onError("No API key configured. Set one in Settings → AI & Chat.");
+    return;
+  }
+
+  let steps = 0;
+
+  while (steps < MAX_STEPS) {
+    if (signal.aborted) { callbacks.onDone(); return; }
+    steps++;
+
+    // Build messages array for this request
+    const messages: AgentMessage[] = [
+      { role: "user", content: systemPrompt } as AgentUserMessage,
+      ...session.messages,
+    ];
+
+    // ── Stream assistant response ─────────────────────────────────────────
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+    let response: Response;
+    try {
+      response = await fetch(`${baseUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers,
+        signal,
+        body: JSON.stringify({
+          model,
+          messages,
+          tools: allTools,
+          tool_choice: "auto",
+          max_tokens: 8192,
+          temperature: 0.3,
+          stream: true,
+        }),
+      });
+    } catch (e) {
+      if (signal.aborted) { callbacks.onDone(); return; }
+      callbacks.onError(`Cannot reach AI endpoint: ${(e as Error).message}`);
+      return;
+    }
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => response.statusText);
+      callbacks.onError(`AI error (${response.status}): ${text.slice(0, 300)}`);
+      return;
+    }
+
+    // ── Parse SSE stream, accumulate tool calls ───────────────────────────
+    const reader = response.body?.getReader();
+    if (!reader) { callbacks.onError("No response stream"); return; }
+
+    const decoder = new TextDecoder();
+    let contentBuffer = "";
+    const toolCallBuffers: Map<number, { id: string; name: string; args: string }> = new Map();
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      for (const line of decoder.decode(value, { stream: true }).split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("data:")) continue;
+        const jsonStr = trimmed.slice(5).trim();
+        if (jsonStr === "[DONE]") break;
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const chunk = JSON.parse(jsonStr) as any;
+          const delta = chunk.choices?.[0]?.delta;
+          if (!delta) continue;
+
+          // Text token
+          if (delta.content) {
+            contentBuffer += delta.content;
+            callbacks.onToken(delta.content);
+          }
+
+          // Tool call chunks
+          if (delta.tool_calls) {
+            for (const tc of delta.tool_calls) {
+              const idx: number = tc.index ?? 0;
+              if (!toolCallBuffers.has(idx)) {
+                toolCallBuffers.set(idx, { id: tc.id ?? "", name: tc.function?.name ?? "", args: "" });
+              }
+              const buf = toolCallBuffers.get(idx)!;
+              if (tc.id) buf.id = tc.id;
+              if (tc.function?.name) buf.name = tc.function.name;
+              if (tc.function?.arguments) buf.args += tc.function.arguments;
+            }
+          }
+        } catch { /* skip malformed SSE lines */ }
+      }
+    }
+
+    // ── No tool calls → turn complete ─────────────────────────────────────
+    if (toolCallBuffers.size === 0) {
+      session.messages.push({ role: "assistant", content: contentBuffer });
+      callbacks.onDone();
+      return;
+    }
+
+    // ── Build tool call list from accumulated buffers ─────────────────────
+    const toolCalls: ToolCallSpec[] = Array.from(toolCallBuffers.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([, buf]) => ({
+        id: buf.id,
+        type: "function" as const,
+        function: { name: buf.name, arguments: buf.args },
+      }));
+
+    // Persist assistant message with tool_calls
+    session.messages.push({
+      role: "assistant",
+      content: contentBuffer || null,
+      tool_calls: toolCalls,
+    });
+
+    // ── Execute each tool ─────────────────────────────────────────────────
+    for (const tc of toolCalls) {
+      if (signal.aborted) { callbacks.onDone(); return; }
+
+      let args: ToolArgs = {};
+      try { args = JSON.parse(tc.function.arguments) as ToolArgs; } catch { args = {}; }
+
+      const label =
+        CODING_LABELS[tc.function.name]?.(args) ??
+        `${tc.function.name}`;
+
+      callbacks.onToolStart(tc.function.name, label);
+
+      let resultContent: string;
+      let ok = true;
+      try {
+        resultContent = await executeSingleTool(
+          tc.function.name,
+          args,
+          cwd,
+          signal,
+          db,
+          req,
+          workspacePath,
+          llmConfig,
+          (output) => callbacks.onToolStart(tc.function.name, `${label}: ${output.slice(-80)}`),
+        );
+      } catch (e) {
+        ok = false;
+        resultContent = `Error: ${(e as Error).message}`;
+      }
+
+      callbacks.onToolEnd(tc.function.name, label, ok);
+
+      session.messages.push({
+        role: "tool",
+        tool_call_id: tc.id,
+        content: resultContent,
+      });
+    }
+    // Loop continues → next LLM call with tool results appended
+  }
+
+  // Exceeded max steps
+  callbacks.onError(
+    `Reached the maximum of ${MAX_STEPS} steps. Any changes made have been saved. Try a more focused request.`
+  );
+}

--- a/electron/lib/pi-agent-prompt.ts
+++ b/electron/lib/pi-agent-prompt.ts
@@ -1,0 +1,59 @@
+/**
+ * System prompt builder for the Cairn native coding agent.
+ *
+ * Context-aware: includes project name, cwd, active task title, and date.
+ */
+
+export interface PiAgentPromptContext {
+  projectName: string;
+  cwd: string;
+  taskTitle?: string;
+  workspaceId?: string;
+  projectId?: string;
+}
+
+export function buildPiAgentSystemPrompt(ctx: PiAgentPromptContext): string {
+  const date = new Date().toLocaleDateString("en-US", {
+    weekday: "long", year: "numeric", month: "long", day: "numeric",
+  });
+
+  const taskLine = ctx.taskTitle
+    ? `\n**Active task:** ${ctx.taskTitle}`
+    : "";
+
+  return `You are the Cairn coding agent — an expert software engineer embedded inside the Cairn desktop app.
+
+## Context
+**Project:** ${ctx.projectName}${taskLine}
+**Code directory:** ${ctx.cwd}
+**Date:** ${date}
+
+## Coding tools
+You have direct access to the project's code directory via these tools:
+- **read** — read file contents with line ranges
+- **write** — write or overwrite a file entirely
+- **edit** — make targeted string replacements (always read first to get exact content)
+- **bash** — execute shell commands (tests, builds, git, grep, etc.)
+- **grep** — search file contents with regex
+- **find** — find files by name pattern
+- **ls** — list directory contents
+
+## Cairn tools
+You can also interact with the Cairn project directly:
+- **get_active_context** — get IDs for the current workspace/project/columns
+- **create_note** — document findings, decisions, or architecture notes
+- **create_task** — add work items to the board
+- **update_task_status** — move tasks between columns
+- **list_tasks**, **search_notes**, **get_note**, etc.
+
+## Guidelines
+1. **Read before editing.** Always use \`read\` to see exact content before using \`edit\`.
+2. **Use \`edit\` for targeted changes**, \`write\` only when creating new files or fully replacing content.
+3. **Run tests after changes.** Use \`bash\` to verify your work compiles and tests pass.
+4. **Document important findings.** Use \`create_note\` for architecture decisions, bugs found, or anything the team should know.
+5. **Create tasks for discovered work.** If you find issues beyond the current scope, use \`create_task\` to capture them.
+6. **Be concise.** Summarise what you did and why — don't repeat file contents back.
+7. **Security.** Never read or write outside the project's code directory.
+
+Tone: direct, technical, like a senior engineer pairing with the user.`;
+}

--- a/electron/lib/pi-agent-prompt.ts
+++ b/electron/lib/pi-agent-prompt.ts
@@ -21,15 +21,19 @@ export function buildPiAgentSystemPrompt(ctx: PiAgentPromptContext): string {
     ? `\n**Active task:** ${ctx.taskTitle}`
     : "";
 
+  const taskSection = ctx.taskTitle
+    ? `\n\nThe active task is **"${ctx.taskTitle}"**. Your first tool call must be \`get_active_context\` to obtain column IDs, then immediately move this task to the **In Progress** column via \`update_task_status\`. When your work is complete, move it to **Review** (or **Done** if it is fully resolved).`
+    : "";
+
   return `You are the Cairn coding agent — an expert software engineer embedded inside the Cairn desktop app.
+You are not just a code executor. You are an active participant in the project: you read and write code, AND you keep the Cairn board and notes up to date as you work. This is non-negotiable.
 
 ## Context
 **Project:** ${ctx.projectName}${taskLine}
 **Code directory:** ${ctx.cwd}
-**Date:** ${date}
+**Date:** ${date}${taskSection}
 
 ## Coding tools
-You have direct access to the project's code directory via these tools:
 - **read** — read file contents with line ranges
 - **write** — write or overwrite a file entirely
 - **edit** — make targeted string replacements (always read first to get exact content)
@@ -37,23 +41,46 @@ You have direct access to the project's code directory via these tools:
 - **grep** — search file contents with regex
 - **find** — find files by name pattern
 - **ls** — list directory contents
+- **spawn_subagent** — delegate a contained, deep sub-task to a fresh agent with its own context window; only the final answer is returned to you
 
 ## Cairn tools
-You can also interact with the Cairn project directly:
-- **get_active_context** — get IDs for the current workspace/project/columns
-- **create_note** — document findings, decisions, or architecture notes
-- **create_task** — add work items to the board
-- **update_task_status** — move tasks between columns
-- **list_tasks**, **search_notes**, **get_note**, etc.
+- **get_active_context** — get IDs for the current workspace, project, and board columns
+- **get_project_context_pack** — get full project state: tasks, notes, recent activity
+- **ensure_note** — idempotent create-or-update by title; use this as your default for writing notes
+- **create_note** / **patch_note** / **append_to_note** — write and update project notes
+- **create_task** / **update_task** / **update_task_status** — manage board tasks
+- **list_tasks** / **search_tasks** / **list_ready_tasks** — read the board
+- **search_notes** / **get_note** — read project notes
 
-## Guidelines
+## Mandatory Cairn workflow
+
+You MUST follow this workflow on every session — it is not optional:
+
+**1. Orient (first thing)**
+Call \`get_active_context\` to get column IDs and project state.
+If there is an active task, immediately move it to In Progress with \`update_task_status\`.
+
+**2. Document as you go**
+- When you discover something significant (a bug, a design decision, an architectural insight, a gotcha), write a note immediately. Do not wait until the end.
+- **Always use \`ensure_note\` to write notes** — it creates the note if it doesn't exist, or updates it if it does. Never use \`create_note\` for notes you might write more than once; that always creates a new duplicate.
+- Note titles should be specific and stable so \`ensure_note\` can match them: "Bug: X causes Y in Z", "Decision: use approach A over B", "Finding: module X has no tests", "Agent session: <task>".
+- Use \`append_to_note\` only when you want to add content without replacing what's already there.
+
+**3. Capture out-of-scope work**
+If you discover issues or improvements beyond the current task, create a task for each with \`create_task\`. Set priority appropriately. Do not silently ignore things that need fixing.
+
+**4. Wrap up (last thing)**
+Before writing your final response to the user:
+- Use \`ensure_note\` to write a session summary titled "Agent session: <short description>" documenting what changed, what was found, and any follow-up needed. Using \`ensure_note\` means re-running the same task will update the same note rather than create a new one.
+- Move the active task to **Review** if changes were made, or **Done** if it is fully resolved and verified.
+
+## Coding guidelines
 1. **Read before editing.** Always use \`read\` to see exact content before using \`edit\`.
 2. **Use \`edit\` for targeted changes**, \`write\` only when creating new files or fully replacing content.
 3. **Run tests after changes.** Use \`bash\` to verify your work compiles and tests pass.
-4. **Document important findings.** Use \`create_note\` for architecture decisions, bugs found, or anything the team should know.
-5. **Create tasks for discovered work.** If you find issues beyond the current scope, use \`create_task\` to capture them.
-6. **Be concise.** Summarise what you did and why — don't repeat file contents back.
-7. **Security.** Never read or write outside the project's code directory.
+4. **Be concise in your final reply.** Summarise what you did and why — don't repeat file contents back.
+5. **Security.** Never read or write outside the project's code directory.
+6. **Use \`spawn_subagent\` for deep sub-tasks** — e.g. "research all usages of X", "refactor this module end-to-end", "investigate and summarise the bug". The subagent has the same tools. Pass it a fully self-contained prompt.
 
 Tone: direct, technical, like a senior engineer pairing with the user.`;
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -20,6 +20,7 @@ import { autoUpdater } from "electron-updater";
 import { initDb } from "./db/client";
 import { registerIpcHandlers, registerAppHandlers } from "./ipc/handlers";
 import { registerAgentHandlers } from "./ipc/agent";
+import { registerPiAgentHandler } from "./ipc/pi-agent";
 import { readWorkspaceConfig, getDbPathForWorkspace } from "./workspace-config";
 import { startFileWatcher } from "./file-watcher";
 import { syncNotesFromDisk } from "./notes-files";
@@ -165,6 +166,7 @@ app.whenReady().then(async () => {
 
   registerIpcHandlers(ctx);
   registerAgentHandlers(ctx.db);
+  registerPiAgentHandler(ctx);
 
   const win = createWindow();
   _win = win;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -266,6 +266,43 @@ const api = {
     },
   },
 
+  // ── Cairn native agent (pi) ───────────────────
+  piAgent: {
+    /** Send a prompt to an existing or new session. Fire-and-forget. */
+    prompt: (req: unknown) => ipcRenderer.send("pi-agent:prompt", req),
+    /** Abort the current in-flight turn for this session. */
+    abort: (sessionId: string) => ipcRenderer.send("pi-agent:abort", { sessionId }),
+    /** Clear message history for a session (start fresh). */
+    clear: (sessionId: string) => ipcRenderer.send("pi-agent:clear", { sessionId }),
+    /** Destroy a session when the tab is closed. */
+    destroy: (sessionId: string) => ipcRenderer.send("pi-agent:destroy", { sessionId }),
+
+    onToken: (cb: (e: { sessionId: string; delta: string }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { sessionId: string; delta: string }) => cb(e);
+      ipcRenderer.on("pi-agent:token", handler);
+      return () => ipcRenderer.off("pi-agent:token", handler);
+    },
+    onTool: (cb: (e: { sessionId: string; name: string; label: string; status: "start" | "end"; ok?: boolean }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { sessionId: string; name: string; label: string; status: "start" | "end"; ok?: boolean }) => cb(e);
+      ipcRenderer.on("pi-agent:tool", handler);
+      return () => ipcRenderer.off("pi-agent:tool", handler);
+    },
+    onDone: (cb: (e: { sessionId: string }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { sessionId: string }) => cb(e);
+      ipcRenderer.on("pi-agent:done", handler);
+      return () => ipcRenderer.off("pi-agent:done", handler);
+    },
+    onError: (cb: (e: { sessionId: string; error: string }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { sessionId: string; error: string }) => cb(e);
+      ipcRenderer.on("pi-agent:error", handler);
+      return () => ipcRenderer.off("pi-agent:error", handler);
+    },
+  },
+
 } as const;
 
 contextBridge.exposeInMainWorld("electron", api);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -283,7 +283,7 @@ const api = {
       ipcRenderer.on("pi-agent:token", handler);
       return () => ipcRenderer.off("pi-agent:token", handler);
     },
-    onTool: (cb: (e: { sessionId: string; name: string; label: string; status: "start" | "end"; ok?: boolean }) => void) => {
+    onTool: (cb: (e: { sessionId: string; name: string; label: string; status: "start" | "end"; ok?: boolean; output?: string }) => void) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const handler = (_: any, e: { sessionId: string; name: string; label: string; status: "start" | "end"; ok?: boolean }) => cb(e);
       ipcRenderer.on("pi-agent:tool", handler);
@@ -300,6 +300,30 @@ const api = {
       const handler = (_: any, e: { sessionId: string; error: string }) => cb(e);
       ipcRenderer.on("pi-agent:error", handler);
       return () => ipcRenderer.off("pi-agent:error", handler);
+    },
+    onToolsReady: (cb: (e: { sessionId: string }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { sessionId: string }) => cb(e);
+      ipcRenderer.on("pi-agent:tools-ready", handler);
+      return () => ipcRenderer.off("pi-agent:tools-ready", handler);
+    },
+    onStep: (cb: (e: { sessionId: string }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { sessionId: string }) => cb(e);
+      ipcRenderer.on("pi-agent:step", handler);
+      return () => ipcRenderer.off("pi-agent:step", handler);
+    },
+    onUsage: (cb: (e: { sessionId: string; promptTokens: number; completionTokens: number }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { sessionId: string; promptTokens: number; completionTokens: number }) => cb(e);
+      ipcRenderer.on("pi-agent:usage", handler);
+      return () => ipcRenderer.off("pi-agent:usage", handler);
+    },
+    onSubagent: (cb: (e: { parentSessionId: string; childSessionId: string; status: "start" | "done"; result?: string }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { parentSessionId: string; childSessionId: string; status: "start" | "done"; result?: string }) => cb(e);
+      ipcRenderer.on("pi-agent:subagent", handler);
+      return () => ipcRenderer.off("pi-agent:subagent", handler);
     },
   },
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -298,7 +298,11 @@ export default function Home() {
            {activeView === "graph"     && <KnowledgeGraphView />}
            {activeView === "insights"  && <InsightsView />}
            {activeView === "settings"  && <SettingsView />}
-           {activeView === "agent"    && <AgentView />}
+           {/* AgentView stays mounted to preserve terminal sessions and pi agent state.
+               CSS-hidden when inactive so xterm + PiAgentPane refs survive view switches. */}
+           <div className={activeView === "agent" ? "contents" : "hidden"}>
+             <AgentView />
+           </div>
           </div>
         </div>
 

--- a/src/components/agent/AgentTerminalPane.tsx
+++ b/src/components/agent/AgentTerminalPane.tsx
@@ -16,12 +16,13 @@ import "@xterm/xterm/css/xterm.css";
 
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { X, Terminal as TerminalIcon, CircleDot, Plus } from "lucide-react";
+import { X, Terminal as TerminalIcon, MessageSquare, CircleDot, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCairnStore } from "@/store";
 import { Tooltip } from "@/components/ui/tooltip";
 import { SpawnAgentModal } from "./SpawnAgentModal";
 import { TerminalManager } from "./TerminalManager";
+import { PiAgentPane } from "./PiAgentPane";
 import type { TerminalSession } from "@/store/slices/terminal-sessions";
 
 // ── Single terminal session mount ─────────────────────────────────────────────
@@ -254,15 +255,28 @@ export function AgentTerminalPane() {
         </Tooltip>
       </div>
 
-      {/* Terminal mounts — each session always mounted, CSS-hidden when inactive */}
+      {/* Session content — branches on sessionType */}
       <div className="flex-1 min-h-0 flex flex-col overflow-hidden bg-[var(--background)]">
-        {terminalSessions.map((session) => (
-          <SessionMount
-            key={session.sessionId}
-            session={session}
-            isActive={session.sessionId === activeSessionId}
-          />
-        ))}
+        {terminalSessions.map((session) => {
+          const isActive = session.sessionId === activeSessionId;
+          if (session.sessionType === "pi") {
+            return (
+              <div
+                key={session.sessionId}
+                className={cn("flex-1 min-h-0 overflow-hidden", !isActive && "hidden")}
+              >
+                <PiAgentPane session={session} isActive={isActive} />
+              </div>
+            );
+          }
+          return (
+            <SessionMount
+              key={session.sessionId}
+              session={session}
+              isActive={isActive}
+            />
+          );
+        })}
       </div>
     </div>
     <SpawnAgentModal open={spawnOpen} onClose={() => setSpawnOpen(false)} />
@@ -292,16 +306,26 @@ function TerminalTab({ session, isActive, onActivate, onClose }: TerminalTabProp
           : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
       )}
     >
-      {/* Status dot */}
-      <CircleDot
-        size={8}
-        className={cn(
-          "flex-shrink-0",
-          session.status === "running"
-            ? "text-[var(--success,#22c55e)]"
-            : "text-[var(--text-tertiary)]"
-        )}
-      />
+      {/* Session type icon / status dot */}
+      {session.sessionType === "pi" ? (
+        <MessageSquare
+          size={8}
+          className={cn(
+            "flex-shrink-0",
+            session.status === "running" ? "text-[var(--accent)]" : "text-[var(--text-tertiary)]"
+          )}
+        />
+      ) : (
+        <CircleDot
+          size={8}
+          className={cn(
+            "flex-shrink-0",
+            session.status === "running"
+              ? "text-[var(--success,#22c55e)]"
+              : "text-[var(--text-tertiary)]"
+          )}
+        />
+      )}
 
       {/* Label */}
       <span className="max-w-[120px] truncate">{session.taskTitle}</span>

--- a/src/components/agent/ContextRing.tsx
+++ b/src/components/agent/ContextRing.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React from "react";
+import { Tooltip } from "@/components/ui/tooltip";
+
+interface ContextRingProps {
+  promptTokens: number;
+  contextLimit: number;
+  /** Ring diameter in px. Default 16. */
+  size?: number;
+  /** Stroke width in px. Default 2. */
+  stroke?: number;
+}
+
+export function ContextRing({ promptTokens, contextLimit, size = 16, stroke = 2 }: ContextRingProps) {
+  const pct  = Math.min(promptTokens / contextLimit, 1);
+  const r    = (size - stroke) / 2;
+  const circ = 2 * Math.PI * r;
+  const dash = pct * circ;
+
+  const colour =
+    pct > 0.85 ? "var(--danger)" :
+    pct > 0.65 ? "var(--warning, #f59e0b)" :
+    "var(--accent)";
+
+  const pctLabel = `${Math.round(pct * 100)}%`;
+
+  return (
+    <Tooltip
+      content={`Context: ${promptTokens.toLocaleString()} / ${contextLimit.toLocaleString()} tokens (${pctLabel})`}
+      side="bottom"
+    >
+      <div className="cursor-default select-none flex-shrink-0">
+        <svg width={size} height={size} className="-rotate-90">
+          <circle
+            cx={size / 2} cy={size / 2} r={r}
+            fill="none"
+            stroke="var(--border)"
+            strokeWidth={stroke}
+          />
+          <circle
+            cx={size / 2} cy={size / 2} r={r}
+            fill="none"
+            stroke={colour}
+            strokeWidth={stroke}
+            strokeDasharray={`${dash} ${circ}`}
+            strokeLinecap="round"
+            style={{ transition: "stroke-dasharray 0.4s ease, stroke 0.4s ease" }}
+          />
+        </svg>
+      </div>
+    </Tooltip>
+  );
+}

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -50,8 +50,12 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
   const [input, setInput]         = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const textareaRef    = useRef<HTMLTextAreaElement>(null);
+  const messagesEndRef  = useRef<HTMLDivElement>(null);
+  const textareaRef     = useRef<HTMLTextAreaElement>(null);
+  // Always-current reference to sendPrompt — lets the initialPrompt effect
+  // call it after mount without capturing a stale closure.
+  const sendPromptRef   = useRef<(text: string) => void>(() => {});
+  const firedInitial    = useRef(false);
 
   // Scroll to bottom on new messages
   useEffect(() => {
@@ -63,12 +67,30 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
     if (isActive) textareaRef.current?.focus();
   }, [isActive]);
 
+  // Fire initialPrompt once when the pane first mounts (set by SpawnAgentModal).
+  // Uses a ref so we always call the current sendPrompt (not a stale closure).
+  // NOTE: No cleanup/clearTimeout — React StrictMode double-invokes effects and
+  // the cleanup would cancel the timer before it fires. The firedInitial ref
+  // ensures we only queue this once even across StrictMode remounts.
+  useEffect(() => {
+    if (firedInitial.current) return;
+    if (!session.initialPrompt) return;
+    firedInitial.current = true;
+    console.log("[PiAgentPane] firing initialPrompt:", session.initialPrompt.slice(0, 80));
+    // Defer 100ms so IPC listeners registered in the effect below are fully live.
+    setTimeout(() => sendPromptRef.current(session.initialPrompt!), 100);
+  // run once on mount only
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Subscribe to IPC events for this session
   useEffect(() => {
     const electron = window.electron;
     if (!electron) return;
 
     const { sessionId } = session;
+
+    console.log("[PiAgentPane] subscribing to IPC events for session", sessionId);
 
     const unsubToken = electron.piAgent.onToken((e) => {
       if (e.sessionId !== sessionId) return;
@@ -77,6 +99,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
 
     const unsubTool = electron.piAgent.onTool((e) => {
       if (e.sessionId !== sessionId) return;
+      console.log("[PiAgentPane] tool event", e);
       if (e.status === "end") {
         addPiToolCall(sessionId, { name: e.name, label: e.label, ok: e.ok ?? true });
       }
@@ -84,12 +107,14 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
 
     const unsubDone = electron.piAgent.onDone((e) => {
       if (e.sessionId !== sessionId) return;
+      console.log("[PiAgentPane] done event", e);
       finalisePiMessage(sessionId);
       setIsLoading(false);
     });
 
     const unsubError = electron.piAgent.onError((e) => {
       if (e.sessionId !== sessionId) return;
+      console.log("[PiAgentPane] error event", e);
       finalisePiMessage(sessionId);
       addPiMessage(sessionId, {
         id:        id(),
@@ -111,6 +136,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
 
   const sendPrompt = useCallback((text: string) => {
     const trimmed = text.trim();
+    console.log("[PiAgentPane] sendPrompt called", { trimmedLen: trimmed.length, isLoading, cwd: session.cwd });
     if (!trimmed || isLoading || !session.cwd) return;
 
     setInput("");
@@ -133,7 +159,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       timestamp:   new Date().toISOString(),
     });
 
-    window.electron?.piAgent.prompt({
+    const promptPayload = {
       sessionId:   session.sessionId,
       prompt:      trimmed,
       projectId:   session.projectId,
@@ -145,8 +171,13 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
         model:   aiConfig.model   || undefined,
         apiKey:  aiConfig.apiKey  || undefined,
       },
-    });
+    };
+    console.log("[PiAgentPane] sending prompt", { ...promptPayload, config: { ...promptPayload.config, apiKey: promptPayload.config.apiKey ? "***" : undefined } });
+    window.electron?.piAgent.prompt(promptPayload);
   }, [isLoading, session, aiConfig, activeWorkspaceId, addPiMessage]);
+
+  // Keep ref current so the initialPrompt effect always calls the latest version
+  sendPromptRef.current = sendPrompt;
 
   function handleStop() {
     window.electron?.piAgent.abort(session.sessionId);

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -9,14 +9,52 @@
  */
 
 import { useEffect, useRef, useState, useCallback } from "react";
-import { Send, Square, RotateCcw, Trash2 } from "lucide-react";
+import { Send, Square, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { id } from "@/lib/utils";
 import { PiMessageBubble } from "./PiMessageBubble";
+import { ContextRing } from "./ContextRing";
 import { Tooltip } from "@/components/ui/tooltip";
 import type { TerminalSession } from "@/store/slices/terminal-sessions";
+
+// ── Cairn tool ref extraction ─────────────────────────────────────────────────
+
+const NOTE_WRITE_TOOLS = new Set([
+  "create_note", "ensure_note", "update_note", "patch_note", "append_to_note",
+]);
+const TASK_WRITE_TOOLS = new Set([
+  "create_task", "update_task", "update_task_status",
+]);
+// Read-only tools — output is never useful to show; suppress it entirely
+const READ_ONLY_TOOLS = new Set([
+  "read", "grep", "find", "ls",
+  "get_active_context", "get_project_context_pack",
+  "list_notes", "get_note", "search_notes",
+  "list_tasks", "get_task", "search_tasks", "list_ready_tasks",
+  "get_idea_flow",
+]);
+
+function extractCairnRef(
+  toolName: string,
+  output: string | undefined,
+): { type: "note" | "task"; id: string; title: string } | undefined {
+  if (!output) return undefined;
+  const isNote = NOTE_WRITE_TOOLS.has(toolName);
+  const isTask = TASK_WRITE_TOOLS.has(toolName);
+  if (!isNote && !isTask) return undefined;
+  try {
+    const parsed = JSON.parse(output);
+    const refId    = parsed?.id;
+    const refTitle = parsed?.title ?? parsed?.name ?? "(untitled)";
+    if (!refId) return undefined;
+    return { type: isNote ? "note" : "task", id: refId, title: refTitle };
+  } catch {
+    return undefined;
+  }
+}
+
 
 interface PiAgentPaneProps {
   session: TerminalSession;
@@ -30,18 +68,36 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
     finalisePiMessage,
     addPiToolCall,
     clearPiMessages,
+    ensurePiStreamingMessage,
+    updatePiUsage,
+    updatePiSubagentUsage,
+    addPiSubagent,
+    appendPiSubagentToken,
+    finalisePiSubagentMessage,
+    addPiSubagentToolCall,
+    completePiSubagent,
+    stepPiSubagent,
     aiConfig,
     projects,
     activeWorkspaceId,
   } = useCairnStore(useShallow((s) => ({
-    addPiMessage:      s.addPiMessage,
-    appendPiToken:     s.appendPiToken,
-    finalisePiMessage: s.finalisePiMessage,
-    addPiToolCall:     s.addPiToolCall,
-    clearPiMessages:   s.clearPiMessages,
-    aiConfig:          s.aiConfig,
-    projects:          s.projects,
-    activeWorkspaceId: s.activeWorkspaceId,
+    addPiMessage:              s.addPiMessage,
+    appendPiToken:             s.appendPiToken,
+    finalisePiMessage:         s.finalisePiMessage,
+    addPiToolCall:             s.addPiToolCall,
+    clearPiMessages:           s.clearPiMessages,
+    ensurePiStreamingMessage:  s.ensurePiStreamingMessage,
+    updatePiUsage:             s.updatePiUsage,
+    updatePiSubagentUsage:     s.updatePiSubagentUsage,
+    addPiSubagent:             s.addPiSubagent,
+    appendPiSubagentToken:     s.appendPiSubagentToken,
+    finalisePiSubagentMessage: s.finalisePiSubagentMessage,
+    addPiSubagentToolCall:     s.addPiSubagentToolCall,
+    completePiSubagent:        s.completePiSubagent,
+    stepPiSubagent:            s.stepPiSubagent,
+    aiConfig:                  s.aiConfig,
+    projects:                  s.projects,
+    activeWorkspaceId:         s.activeWorkspaceId,
   })));
 
   const messages    = session.piMessages ?? [];
@@ -97,12 +153,43 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       appendPiToken(sessionId, e.delta);
     });
 
+    const unsubUsage = electron.piAgent.onUsage((e) => {
+      if (e.sessionId === sessionId) {
+        // Parent step — update the parent ring
+        updatePiUsage(sessionId, e.promptTokens, e.completionTokens);
+      } else if (e.sessionId.startsWith(`${sessionId}:sub:`)) {
+        // Subagent step — update usage on the subagent inline block, not the parent ring
+        updatePiSubagentUsage(sessionId, e.sessionId, e.promptTokens, e.completionTokens);
+      }
+    });
+
+    const unsubToolsReady = electron.piAgent.onToolsReady((e) => {
+      if (e.sessionId === sessionId) {
+        ensurePiStreamingMessage(sessionId);
+      } else if (e.sessionId.startsWith(`${sessionId}:sub:`)) {
+        // subagent — handled via subagent store (no-op here, subagent messages auto-create)
+      }
+    });
+
     const unsubTool = electron.piAgent.onTool((e) => {
       if (e.sessionId !== sessionId) return;
-      console.log("[PiAgentPane] tool event", e);
       if (e.status === "end") {
-        addPiToolCall(sessionId, { name: e.name, label: e.label, ok: e.ok ?? true });
+        addPiToolCall(sessionId, {
+          name:     e.name,
+          label:    e.label,
+          ok:       e.ok ?? true,
+          // Suppress output for read-only tools — no point expanding raw JSON
+          output:   READ_ONLY_TOOLS.has(e.name) ? undefined : e.output,
+          cairnRef: extractCairnRef(e.name, e.output),
+        });
       }
+    });
+
+    const unsubStep = electron.piAgent.onStep((e) => {
+      if (e.sessionId !== sessionId) return;
+      // Finalise the previous turn's assistant message so the next turn's
+      // tokens appear in a separate bubble.
+      finalisePiMessage(sessionId);
     });
 
     const unsubDone = electron.piAgent.onDone((e) => {
@@ -125,11 +212,51 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       setIsLoading(false);
     });
 
+    // ── Subagent events (child session IDs routed back to parent) ──────────
+    const unsubSubagent = electron.piAgent.onSubagent((e) => {
+      if (e.parentSessionId !== sessionId) return;
+      if (e.status === "start") {
+        addPiSubagent(sessionId, e.childSessionId);
+      } else {
+        completePiSubagent(sessionId, e.childSessionId, e.result ?? "");
+      }
+    });
+
+    const unsubSubToken = electron.piAgent.onToken((e) => {
+      if (!e.sessionId.startsWith(`${sessionId}:sub:`)) return;
+      appendPiSubagentToken(sessionId, e.sessionId, e.delta);
+    });
+
+    const unsubSubTool = electron.piAgent.onTool((e) => {
+      if (!e.sessionId.startsWith(`${sessionId}:sub:`)) return;
+      if (e.status === "end") {
+        addPiSubagentToolCall(sessionId, e.sessionId, {
+          name:     e.name,
+          label:    e.label,
+          ok:       e.ok ?? true,
+          output:   READ_ONLY_TOOLS.has(e.name) ? undefined : e.output,
+          cairnRef: extractCairnRef(e.name, e.output),
+        });
+      }
+    });
+
+    const unsubSubStep = electron.piAgent.onStep((e) => {
+      if (!e.sessionId.startsWith(`${sessionId}:sub:`)) return;
+      stepPiSubagent(sessionId, e.sessionId);
+    });
+
     return () => {
       unsubToken();
+      unsubUsage();
+      unsubToolsReady();
       unsubTool();
+      unsubStep();
       unsubDone();
       unsubError();
+      unsubSubagent();
+      unsubSubToken();
+      unsubSubTool();
+      unsubSubStep();
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session.sessionId]);
@@ -199,6 +326,12 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
         <span className="text-[0.714rem] text-[var(--text-tertiary)] truncate flex-1">
           {session.taskTitle !== "Ad-hoc session" ? session.taskTitle : project?.name ?? "Cairn Agent"}
         </span>
+        {session.lastUsage && (
+          <ContextRing
+            promptTokens={session.lastUsage.promptTokens}
+            contextLimit={aiConfig.contextLimit ?? 128000}
+          />
+        )}
         <Tooltip content="Clear conversation" side="left">
           <button
             onClick={handleClear}

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -136,7 +136,6 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
     if (firedInitial.current) return;
     if (!session.initialPrompt) return;
     firedInitial.current = true;
-    console.log("[PiAgentPane] firing initialPrompt:", session.initialPrompt.slice(0, 80));
     // Defer 100ms so IPC listeners registered in the effect below are fully live.
     setTimeout(() => sendPromptRef.current(session.initialPrompt!), 100);
   // run once on mount only
@@ -149,8 +148,6 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
     if (!electron) return;
 
     const { sessionId } = session;
-
-    console.log("[PiAgentPane] subscribing to IPC events for session", sessionId);
 
     const unsubToken = electron.piAgent.onToken((e) => {
       if (e.sessionId !== sessionId) return;
@@ -206,14 +203,12 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
 
     const unsubDone = electron.piAgent.onDone((e) => {
       if (e.sessionId !== sessionId) return;
-      console.log("[PiAgentPane] done event", e);
       finalisePiMessage(sessionId);
       setIsLoading(false);
     });
 
     const unsubError = electron.piAgent.onError((e) => {
       if (e.sessionId !== sessionId) return;
-      console.log("[PiAgentPane] error event", e);
       finalisePiMessage(sessionId);
       addPiMessage(sessionId, {
         id:        id(),
@@ -284,7 +279,6 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
 
   const sendPrompt = useCallback((text: string) => {
     const trimmed = text.trim();
-    console.log("[PiAgentPane] sendPrompt called", { trimmedLen: trimmed.length, isLoading, cwd: session.cwd });
     if (!trimmed || isLoading || !session.cwd) return;
 
     setInput("");
@@ -320,7 +314,6 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
         apiKey:  aiConfig.apiKey  || undefined,
       },
     };
-    console.log("[PiAgentPane] sending prompt", { ...promptPayload, config: { ...promptPayload.config, apiKey: promptPayload.config.apiKey ? "***" : undefined } });
     window.electron?.piAgent.prompt(promptPayload);
   }, [isLoading, session, aiConfig, activeWorkspaceId, addPiMessage]);
 

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -71,6 +71,8 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
     ensurePiStreamingMessage,
     updatePiUsage,
     updatePiSubagentUsage,
+    updatePiToolCall,
+    updatePiSubagentToolCall,
     addPiSubagent,
     appendPiSubagentToken,
     finalisePiSubagentMessage,
@@ -89,6 +91,8 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
     ensurePiStreamingMessage:  s.ensurePiStreamingMessage,
     updatePiUsage:             s.updatePiUsage,
     updatePiSubagentUsage:     s.updatePiSubagentUsage,
+    updatePiToolCall:          s.updatePiToolCall,
+    updatePiSubagentToolCall:  s.updatePiSubagentToolCall,
     addPiSubagent:             s.addPiSubagent,
     appendPiSubagentToken:     s.appendPiSubagentToken,
     finalisePiSubagentMessage: s.finalisePiSubagentMessage,
@@ -171,14 +175,22 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       }
     });
 
+    // callId map: tool name → callId assigned at onToolStart so we can update it on onToolEnd
+    const activeCallIds = new Map<string, string>();
+
     const unsubTool = electron.piAgent.onTool((e) => {
       if (e.sessionId !== sessionId) return;
-      if (e.status === "end") {
-        addPiToolCall(sessionId, {
-          name:     e.name,
+      if (e.status === "start") {
+        const callId = `${e.name}:${Date.now()}`;
+        activeCallIds.set(e.name, callId);
+        addPiToolCall(sessionId, { callId, name: e.name, label: e.label, running: true, ok: true });
+      } else {
+        const callId = activeCallIds.get(e.name) ?? `${e.name}:unknown`;
+        activeCallIds.delete(e.name);
+        updatePiToolCall(sessionId, callId, {
           label:    e.label,
+          running:  false,
           ok:       e.ok ?? true,
-          // Suppress output for read-only tools — no point expanding raw JSON
           output:   READ_ONLY_TOOLS.has(e.name) ? undefined : e.output,
           cairnRef: extractCairnRef(e.name, e.output),
         });
@@ -227,12 +239,21 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       appendPiSubagentToken(sessionId, e.sessionId, e.delta);
     });
 
+    const activeSubCallIds = new Map<string, string>(); // `${childSessionId}:${name}` → callId
+
     const unsubSubTool = electron.piAgent.onTool((e) => {
       if (!e.sessionId.startsWith(`${sessionId}:sub:`)) return;
-      if (e.status === "end") {
-        addPiSubagentToolCall(sessionId, e.sessionId, {
-          name:     e.name,
+      const key = `${e.sessionId}:${e.name}`;
+      if (e.status === "start") {
+        const callId = `${e.name}:${Date.now()}`;
+        activeSubCallIds.set(key, callId);
+        addPiSubagentToolCall(sessionId, e.sessionId, { callId, name: e.name, label: e.label, running: true, ok: true });
+      } else {
+        const callId = activeSubCallIds.get(key) ?? `${e.name}:unknown`;
+        activeSubCallIds.delete(key);
+        updatePiSubagentToolCall(sessionId, e.sessionId, callId, {
           label:    e.label,
+          running:  false,
           ok:       e.ok ?? true,
           output:   READ_ONLY_TOOLS.has(e.name) ? undefined : e.output,
           cairnRef: extractCairnRef(e.name, e.output),

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+/**
+ * PiAgentPane — chat UI for Cairn native agent sessions.
+ *
+ * Rendered inside AgentTerminalPane when session.sessionType === "pi".
+ * Subscribes to pi-agent:* IPC events and updates Zustand store.
+ * Multi-turn: each new message continues the same session's history.
+ */
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { Send, Square, RotateCcw, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useCairnStore } from "@/store";
+import { useShallow } from "zustand/react/shallow";
+import { id } from "@/lib/utils";
+import { PiMessageBubble } from "./PiMessageBubble";
+import { Tooltip } from "@/components/ui/tooltip";
+import type { TerminalSession } from "@/store/slices/terminal-sessions";
+
+interface PiAgentPaneProps {
+  session: TerminalSession;
+  isActive: boolean;
+}
+
+export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
+  const {
+    addPiMessage,
+    appendPiToken,
+    finalisePiMessage,
+    addPiToolCall,
+    clearPiMessages,
+    aiConfig,
+    projects,
+    activeWorkspaceId,
+  } = useCairnStore(useShallow((s) => ({
+    addPiMessage:      s.addPiMessage,
+    appendPiToken:     s.appendPiToken,
+    finalisePiMessage: s.finalisePiMessage,
+    addPiToolCall:     s.addPiToolCall,
+    clearPiMessages:   s.clearPiMessages,
+    aiConfig:          s.aiConfig,
+    projects:          s.projects,
+    activeWorkspaceId: s.activeWorkspaceId,
+  })));
+
+  const messages    = session.piMessages ?? [];
+  const project     = projects.find((p) => p.id === session.projectId);
+
+  const [input, setInput]         = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const textareaRef    = useRef<HTMLTextAreaElement>(null);
+
+  // Scroll to bottom on new messages
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length, messages[messages.length - 1]?.content?.length]);
+
+  // Focus input when pane becomes active
+  useEffect(() => {
+    if (isActive) textareaRef.current?.focus();
+  }, [isActive]);
+
+  // Subscribe to IPC events for this session
+  useEffect(() => {
+    const electron = window.electron;
+    if (!electron) return;
+
+    const { sessionId } = session;
+
+    const unsubToken = electron.piAgent.onToken((e) => {
+      if (e.sessionId !== sessionId) return;
+      appendPiToken(sessionId, e.delta);
+    });
+
+    const unsubTool = electron.piAgent.onTool((e) => {
+      if (e.sessionId !== sessionId) return;
+      if (e.status === "end") {
+        addPiToolCall(sessionId, { name: e.name, label: e.label, ok: e.ok ?? true });
+      }
+    });
+
+    const unsubDone = electron.piAgent.onDone((e) => {
+      if (e.sessionId !== sessionId) return;
+      finalisePiMessage(sessionId);
+      setIsLoading(false);
+    });
+
+    const unsubError = electron.piAgent.onError((e) => {
+      if (e.sessionId !== sessionId) return;
+      finalisePiMessage(sessionId);
+      addPiMessage(sessionId, {
+        id:        id(),
+        role:      "error",
+        content:   e.error,
+        timestamp: new Date().toISOString(),
+      });
+      setIsLoading(false);
+    });
+
+    return () => {
+      unsubToken();
+      unsubTool();
+      unsubDone();
+      unsubError();
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session.sessionId]);
+
+  const sendPrompt = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed || isLoading || !session.cwd) return;
+
+    setInput("");
+    setIsLoading(true);
+
+    // Add user message to store
+    addPiMessage(session.sessionId, {
+      id:        id(),
+      role:      "user",
+      content:   trimmed,
+      timestamp: new Date().toISOString(),
+    });
+
+    // Create placeholder streaming assistant message
+    addPiMessage(session.sessionId, {
+      id:          id(),
+      role:        "assistant",
+      content:     "",
+      isStreaming: true,
+      timestamp:   new Date().toISOString(),
+    });
+
+    window.electron?.piAgent.prompt({
+      sessionId:   session.sessionId,
+      prompt:      trimmed,
+      projectId:   session.projectId,
+      workspaceId: activeWorkspaceId ?? undefined,
+      cwd:         session.cwd,
+      taskTitle:   session.taskTitle !== "Ad-hoc session" ? session.taskTitle : undefined,
+      config: {
+        baseUrl: aiConfig.baseUrl || undefined,
+        model:   aiConfig.model   || undefined,
+        apiKey:  aiConfig.apiKey  || undefined,
+      },
+    });
+  }, [isLoading, session, aiConfig, activeWorkspaceId, addPiMessage]);
+
+  function handleStop() {
+    window.electron?.piAgent.abort(session.sessionId);
+    finalisePiMessage(session.sessionId);
+    setIsLoading(false);
+  }
+
+  function handleClear() {
+    if (isLoading) handleStop();
+    clearPiMessages(session.sessionId);
+    window.electron?.piAgent.clear(session.sessionId);
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-[var(--background)]">
+
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-1.5 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0">
+        <span className="text-[0.714rem] text-[var(--text-tertiary)] truncate flex-1">
+          {session.taskTitle !== "Ad-hoc session" ? session.taskTitle : project?.name ?? "Cairn Agent"}
+        </span>
+        <Tooltip content="Clear conversation" side="left">
+          <button
+            onClick={handleClear}
+            className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors"
+          >
+            <Trash2 size={12} />
+          </button>
+        </Tooltip>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-3 py-3 space-y-3">
+        {messages.length === 0 && (
+          <div className="flex flex-col items-center justify-center h-full gap-2 text-center">
+            <p className="text-[0.786rem] font-medium text-[var(--text-secondary)]">Cairn Agent</p>
+            <p className="text-[0.714rem] text-[var(--text-tertiary)] max-w-48">
+              Ask me to read, edit, or run code — or manage your project board.
+            </p>
+          </div>
+        )}
+        {messages.map((msg) => (
+          <PiMessageBubble key={msg.id} message={msg} />
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input */}
+      <div className="border-t border-[var(--border)] p-2 flex-shrink-0">
+        <div className="relative">
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                sendPrompt(input);
+              }
+            }}
+            placeholder="Ask the agent…"
+            rows={2}
+            disabled={isLoading}
+            className={cn(
+              "w-full resize-none rounded-lg border border-[var(--border)] bg-[var(--surface-2)]",
+              "px-2.5 py-2 pr-8 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)]",
+              "focus:outline-none focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent-dim)]",
+              "transition-colors leading-relaxed disabled:opacity-60",
+            )}
+          />
+          {isLoading ? (
+            <Tooltip content="Stop" side="left">
+              <button
+                onClick={handleStop}
+                className="absolute right-2 bottom-2 p-1 rounded text-[var(--danger)] hover:bg-[var(--danger)]/10 transition-colors"
+              >
+                <Square size={12} />
+              </button>
+            </Tooltip>
+          ) : (
+            <Tooltip content="Send (Enter)" side="left">
+              <button
+                onClick={() => sendPrompt(input)}
+                disabled={!input.trim()}
+                className="absolute right-2 bottom-2 p-1 rounded text-[var(--accent)] hover:bg-[var(--accent-dim)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <Send size={12} />
+              </button>
+            </Tooltip>
+          )}
+        </div>
+        <p className="text-[0.643rem] text-[var(--text-tertiary)] mt-1 text-center">
+          {isLoading ? "Working… click ◼ to stop" : "Shift+Enter for new line · Enter to send"}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/agent/PiMessageBubble.tsx
+++ b/src/components/agent/PiMessageBubble.tsx
@@ -1,10 +1,258 @@
 "use client";
 
-import React from "react";
-import { Bot, User, CheckCircle, Loader2, AlertCircle } from "lucide-react";
+import React, { useState } from "react";
+import { Bot, User, CheckCircle, Loader2, AlertCircle, ChevronDown, ChevronRight, GitBranch, FileText, SquareCheck } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { MarkdownContent } from "@/components/chat/chat-panel/MarkdownContent";
-import type { PiAgentMessage } from "@/store/slices/terminal-sessions";
+import { CairnEvents } from "@/lib/events";
+import { useCairnStore } from "@/store";
+import { ContextRing } from "./ContextRing";
+import type { PiAgentMessage, PiSubagentMessage } from "@/store/slices/terminal-sessions";
+
+// ── Cairn item reference chip ─────────────────────────────────────────────────
+
+const CAIRN_NOTE_ACTIONS: Record<string, string> = {
+  create_note:     "Created note",
+  ensure_note:     "Saved note",
+  update_note:     "Updated note",
+  patch_note:      "Patched note",
+  append_to_note:  "Appended to note",
+};
+const CAIRN_TASK_ACTIONS: Record<string, string> = {
+  create_task:        "Created task",
+  update_task:        "Updated task",
+  update_task_status: "Moved task",
+};
+
+function CairnRefChip({ tc }: {
+  tc: { name: string; ok: boolean; cairnRef: { type: "note" | "task"; id: string; title: string } };
+}) {
+  const setView = useCairnStore((s) => s.setView);
+  const isNote = tc.cairnRef.type === "note";
+  const actionLabel = isNote
+    ? (CAIRN_NOTE_ACTIONS[tc.name] ?? "Updated note")
+    : (CAIRN_TASK_ACTIONS[tc.name] ?? "Updated task");
+
+  function handleClick() {
+    if (isNote) {
+      setView("notes");
+      // Defer so NotesView has one render cycle to mount its cairn:select-note listener
+      setTimeout(() => window.dispatchEvent(CairnEvents.selectNote(tc.cairnRef.id)), 50);
+    } else {
+      setView("board");
+      // Defer so KanbanBoard has one render cycle to mount its cairn:open-card listener
+      setTimeout(() => window.dispatchEvent(CairnEvents.openCard(tc.cairnRef.id)), 50);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className={cn(
+        "flex items-center gap-2 px-2.5 py-1.5 rounded-lg w-fit text-left transition-colors group",
+        "bg-[var(--surface-2)] border border-[var(--border)]",
+        "hover:border-[var(--accent)]/50 hover:bg-[color-mix(in_srgb,var(--accent)_4%,var(--surface-2))]",
+        !tc.ok && "border-[var(--danger)]/30 opacity-60 pointer-events-none",
+      )}
+    >
+      {/* Type icon */}
+      <div className={cn(
+        "w-5 h-5 rounded flex items-center justify-center flex-shrink-0",
+        isNote
+          ? "bg-[color-mix(in_srgb,var(--accent)_12%,transparent)]"
+          : "bg-[color-mix(in_srgb,var(--success,#22c55e)_12%,transparent)]",
+      )}>
+        {isNote
+          ? <FileText size={10} className="text-[var(--accent)]" />
+          : <SquareCheck size={10} className="text-[color-mix(in_srgb,var(--success,#22c55e)_90%,var(--text-primary))]" />
+        }
+      </div>
+
+      {/* Text */}
+      <div className="flex flex-col min-w-0">
+        <span className="text-[0.643rem] text-[var(--text-tertiary)] leading-none mb-0.5">{actionLabel}</span>
+        <span className="text-[0.714rem] font-medium text-[var(--text-primary)] truncate max-w-[200px] leading-none group-hover:text-[var(--accent)] transition-colors">
+          {tc.cairnRef.title}
+        </span>
+      </div>
+
+      {/* Status dot */}
+      <CheckCircle size={9} className={cn("shrink-0 ml-auto", tc.ok ? "text-[var(--accent)]" : "text-[var(--danger)]")} />
+    </button>
+  );
+}
+
+// ── Tool output expansion ─────────────────────────────────────────────────────
+
+function parseDiff(output: string): { type: "add" | "remove" | "context"; text: string }[] | null {
+  const lines = output.split("\n");
+  // Heuristic: looks like a diff if it starts with --- or +++ or has @@ lines
+  const isDiff = lines.some((l) => l.startsWith("---") || l.startsWith("+++") || l.startsWith("@@"));
+  if (!isDiff) return null;
+  return lines.map((text) => {
+    if (text.startsWith("+") && !text.startsWith("+++")) return { type: "add" as const, text };
+    if (text.startsWith("-") && !text.startsWith("---")) return { type: "remove" as const, text };
+    return { type: "context" as const, text };
+  });
+}
+
+function ToolOutputPanel({ name, output }: { name: string; output: string }) {
+  const diff = (name === "edit") ? parseDiff(output) : null;
+
+  if (diff) {
+    return (
+      <div className="mt-1 rounded-md border border-[var(--border)] overflow-hidden text-[0.643rem] font-mono">
+        {diff.map((line, i) => (
+          <div
+            key={i}
+            className={cn(
+              "px-2 py-px leading-5 whitespace-pre-wrap break-all",
+              line.type === "add"    && "bg-[color-mix(in_srgb,var(--success,#22c55e)_10%,transparent)] text-[color-mix(in_srgb,var(--success,#22c55e)_90%,var(--text-primary))]",
+              line.type === "remove" && "bg-[color-mix(in_srgb,var(--danger)_10%,transparent)] text-[color-mix(in_srgb,var(--danger)_80%,var(--text-primary))]",
+              line.type === "context" && "text-[var(--text-tertiary)]",
+            )}
+          >
+            {line.text || "\u00a0"}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <pre className="mt-1 rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 py-1.5 text-[0.643rem] font-mono text-[var(--text-secondary)] overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap break-all leading-5">
+      {output || "(no output)"}
+    </pre>
+  );
+}
+
+function ToolChip({ tc, index }: { tc: { name: string; label: string; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }; index: number }) {
+  const [expanded, setExpanded] = useState(false);
+
+  // Cairn write tools get a dedicated linked bubble instead of raw JSON expansion
+  if (tc.cairnRef && tc.ok) {
+    return <CairnRefChip tc={{ name: tc.name, ok: tc.ok, cairnRef: tc.cairnRef }} />;
+  }
+
+  const hasOutput = !!tc.output;
+
+  return (
+    <div>
+      <button
+        onClick={() => hasOutput && setExpanded((v) => !v)}
+        className={cn(
+          "flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-[var(--surface-2)] border border-[var(--border)] w-fit text-left",
+          hasOutput && "hover:border-[var(--accent)]/40 cursor-pointer transition-colors",
+          !hasOutput && "cursor-default",
+        )}
+      >
+        <CheckCircle size={9} className={cn("shrink-0", tc.ok ? "text-[var(--accent)]" : "text-[var(--danger)]")} />
+        <span className="text-[0.714rem] text-[var(--text-secondary)]">{tc.label}</span>
+        {hasOutput && (
+          expanded
+            ? <ChevronDown size={9} className="text-[var(--text-tertiary)] shrink-0 ml-0.5" />
+            : <ChevronRight size={9} className="text-[var(--text-tertiary)] shrink-0 ml-0.5" />
+        )}
+      </button>
+      {expanded && tc.output && (
+        <ToolOutputPanel name={tc.name} output={tc.output} />
+      )}
+    </div>
+  );
+}
+
+// ── Subagent inline block ─────────────────────────────────────────────────────
+
+function SubagentBlock({ sub }: { sub: PiSubagentMessage }) {
+  const [expanded, setExpanded] = useState(false);
+  const contextLimit = useCairnStore((s) => s.aiConfig.contextLimit ?? 128000);
+
+  return (
+    <div className="mt-1 rounded-lg border border-[var(--border)] bg-[var(--surface)] overflow-hidden">
+      {/* Header */}
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center gap-1.5 px-2.5 py-1.5 hover:bg-[var(--surface-2)] transition-colors text-left"
+      >
+        {sub.running
+          ? <Loader2 size={9} className="text-[var(--accent)] animate-spin shrink-0" />
+          : <GitBranch size={9} className="text-[var(--accent)] shrink-0" />
+        }
+        <span className="text-[0.714rem] font-medium text-[var(--text-secondary)] flex-1">
+          {sub.running ? "Sub-agent working…" : "Sub-agent"}
+        </span>
+        {sub.lastUsage && (
+          <ContextRing
+            promptTokens={sub.lastUsage.promptTokens}
+            contextLimit={contextLimit}
+            size={12}
+            stroke={1.5}
+          />
+        )}
+        {expanded
+          ? <ChevronDown size={9} className="text-[var(--text-tertiary)] shrink-0" />
+          : <ChevronRight size={9} className="text-[var(--text-tertiary)] shrink-0" />
+        }
+      </button>
+
+      {/* Expanded trace */}
+      {expanded && (
+        <div className="border-t border-[var(--border)] px-2.5 py-2 space-y-2 max-h-96 overflow-y-auto">
+          {sub.messages.length === 0 && (
+            <p className="text-[0.643rem] text-[var(--text-tertiary)]">Waiting…</p>
+          )}
+          {sub.messages.map((msg) => (
+            <SubagentMessageRow key={msg.id} msg={msg} />
+          ))}
+          {!sub.running && sub.result && (
+            <div className="mt-1 pt-1 border-t border-[var(--border)]">
+              <p className="text-[0.643rem] text-[var(--text-tertiary)] mb-0.5">Result returned to parent:</p>
+              <p className="text-[0.714rem] text-[var(--text-secondary)] whitespace-pre-wrap">{sub.result}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SubagentMessageRow({ msg }: { msg: PiAgentMessage }) {
+  const hasTools = (msg.toolCalls?.length ?? 0) > 0;
+  const hasContent = msg.content.length > 0;
+
+  return (
+    <div className="flex gap-1.5 items-start">
+      <div className="w-4 h-4 rounded-full bg-[var(--accent-dim)] border border-[var(--accent)]/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+        <Bot size={8} className="text-[var(--accent)]" />
+      </div>
+      <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+        {hasTools && (
+          <div className="flex flex-col gap-0.5">
+            {msg.toolCalls!.map((tc, i) => (
+              <ToolChip key={i} tc={tc} index={i} />
+            ))}
+          </div>
+        )}
+        {!hasContent && msg.isStreaming && !hasTools && (
+          <div className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-[var(--surface-2)] border border-[var(--border)] w-fit">
+            <Loader2 size={8} className="text-[var(--accent)] animate-spin shrink-0" />
+            <span className="text-[0.643rem] text-[var(--text-tertiary)]">Thinking…</span>
+          </div>
+        )}
+        {hasContent && (
+          <div className="px-2 py-1 rounded-lg text-[0.643rem] leading-relaxed bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-secondary)]">
+            <MarkdownContent content={msg.content} />
+            {msg.isStreaming && (
+              <span className="inline-block w-0.5 h-2.5 bg-[var(--accent)] animate-pulse ml-0.5 align-middle" />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Main bubble ───────────────────────────────────────────────────────────────
 
 interface PiMessageBubbleProps {
   message: PiAgentMessage;
@@ -14,6 +262,7 @@ export function PiMessageBubble({ message }: PiMessageBubbleProps) {
   const isUser  = message.role === "user";
   const isError = message.role === "error";
 
+  // USER bubble — right-aligned, accent background, User icon
   if (isUser) {
     return (
       <div className="flex gap-2 items-start justify-end">
@@ -29,6 +278,7 @@ export function PiMessageBubble({ message }: PiMessageBubbleProps) {
     );
   }
 
+  // ERROR bubble — left-aligned, danger colours, AlertCircle icon
   if (isError) {
     return (
       <div className="flex gap-2 items-start">
@@ -44,9 +294,10 @@ export function PiMessageBubble({ message }: PiMessageBubbleProps) {
     );
   }
 
-  // Assistant message
-  const hasContent = message.content.length > 0;
-  const hasTools   = (message.toolCalls?.length ?? 0) > 0;
+  // ASSISTANT bubble — left-aligned, Bot icon, surface-2 background
+  const hasContent  = message.content.length > 0;
+  const hasTools    = (message.toolCalls?.length ?? 0) > 0;
+  const hasSubagents = (message.subagents?.length ?? 0) > 0;
 
   return (
     <div className="flex gap-2 items-start">
@@ -55,30 +306,29 @@ export function PiMessageBubble({ message }: PiMessageBubbleProps) {
       </div>
       <div className="flex-1 min-w-0 flex flex-col gap-1">
 
-        {/* Tool call chips */}
+        {/* Tool call chips — expandable */}
         {hasTools && (
           <div className="flex flex-col gap-0.5">
             {message.toolCalls!.map((tc, i) => (
-              <div
-                key={i}
-                className="flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-[var(--surface-2)] border border-[var(--border)] w-fit"
-              >
-                <CheckCircle size={9} className={cn("shrink-0", tc.ok ? "text-[var(--accent)]" : "text-[var(--danger)]")} />
-                <span className="text-[0.714rem] text-[var(--text-secondary)]">{tc.label}</span>
-              </div>
+              <ToolChip key={i} tc={tc} index={i} />
             ))}
           </div>
         )}
 
-        {/* Streaming "thinking" indicator when no content yet */}
-        {!hasContent && message.isStreaming && !hasTools && (
+        {/* Subagent inline blocks */}
+        {hasSubagents && message.subagents!.map((sub) => (
+          <SubagentBlock key={sub.childSessionId} sub={sub} />
+        ))}
+
+        {/* "Thinking…" spinner — only when streaming with no content or tools yet */}
+        {!hasContent && message.isStreaming && !hasTools && !hasSubagents && (
           <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-[var(--surface-2)] border border-[var(--border)] w-fit">
             <Loader2 size={9} className="text-[var(--accent)] animate-spin shrink-0" />
             <span className="text-[0.714rem] text-[var(--text-tertiary)]">Thinking…</span>
           </div>
         )}
 
-        {/* Message content */}
+        {/* Markdown content with animated cursor when streaming */}
         {hasContent && (
           <div className={cn(
             "px-3 py-2 rounded-xl rounded-tl-sm text-xs leading-relaxed",

--- a/src/components/agent/PiMessageBubble.tsx
+++ b/src/components/agent/PiMessageBubble.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import React from "react";
+import { Bot, User, CheckCircle, Loader2, AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { MarkdownContent } from "@/components/chat/chat-panel/MarkdownContent";
+import type { PiAgentMessage } from "@/store/slices/terminal-sessions";
+
+interface PiMessageBubbleProps {
+  message: PiAgentMessage;
+}
+
+export function PiMessageBubble({ message }: PiMessageBubbleProps) {
+  const isUser  = message.role === "user";
+  const isError = message.role === "error";
+
+  if (isUser) {
+    return (
+      <div className="flex gap-2 items-start justify-end">
+        <div className="flex-1 min-w-0 flex flex-col items-end gap-1">
+          <div className="px-3 py-2 rounded-xl rounded-tr-sm text-xs leading-relaxed bg-[var(--accent)] text-white max-w-[85%]">
+            <p className="whitespace-pre-wrap break-words">{message.content}</p>
+          </div>
+        </div>
+        <div className="w-5 h-5 rounded-full bg-[var(--surface-3)] border border-[var(--border)] flex items-center justify-center flex-shrink-0 mt-0.5">
+          <User size={10} className="text-[var(--text-tertiary)]" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex gap-2 items-start">
+        <div className="w-5 h-5 rounded-full bg-[color-mix(in_srgb,var(--danger)_15%,transparent)] border border-[var(--danger)]/30 flex items-center justify-center flex-shrink-0 mt-0.5">
+          <AlertCircle size={10} className="text-[var(--danger)]" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="px-3 py-2 rounded-xl rounded-tl-sm text-xs leading-relaxed bg-[color-mix(in_srgb,var(--danger)_8%,transparent)] border border-[var(--danger)]/20 text-[var(--danger)]">
+            {message.content}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Assistant message
+  const hasContent = message.content.length > 0;
+  const hasTools   = (message.toolCalls?.length ?? 0) > 0;
+
+  return (
+    <div className="flex gap-2 items-start">
+      <div className="w-5 h-5 rounded-full bg-[var(--accent-dim)] border border-[var(--accent)]/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+        <Bot size={10} className="text-[var(--accent)]" />
+      </div>
+      <div className="flex-1 min-w-0 flex flex-col gap-1">
+
+        {/* Tool call chips */}
+        {hasTools && (
+          <div className="flex flex-col gap-0.5">
+            {message.toolCalls!.map((tc, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-[var(--surface-2)] border border-[var(--border)] w-fit"
+              >
+                <CheckCircle size={9} className={cn("shrink-0", tc.ok ? "text-[var(--accent)]" : "text-[var(--danger)]")} />
+                <span className="text-[0.714rem] text-[var(--text-secondary)]">{tc.label}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Streaming "thinking" indicator when no content yet */}
+        {!hasContent && message.isStreaming && !hasTools && (
+          <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-[var(--surface-2)] border border-[var(--border)] w-fit">
+            <Loader2 size={9} className="text-[var(--accent)] animate-spin shrink-0" />
+            <span className="text-[0.714rem] text-[var(--text-tertiary)]">Thinking…</span>
+          </div>
+        )}
+
+        {/* Message content */}
+        {hasContent && (
+          <div className={cn(
+            "px-3 py-2 rounded-xl rounded-tl-sm text-xs leading-relaxed",
+            "bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-secondary)]",
+          )}>
+            <MarkdownContent content={message.content} />
+            {message.isStreaming && (
+              <span className="inline-block w-0.5 h-3 bg-[var(--accent)] animate-pulse ml-0.5 align-middle" />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/agent/PiMessageBubble.tsx
+++ b/src/components/agent/PiMessageBubble.tsx
@@ -126,8 +126,18 @@ function ToolOutputPanel({ name, output }: { name: string; output: string }) {
   );
 }
 
-function ToolChip({ tc, index }: { tc: { name: string; label: string; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }; index: number }) {
+function ToolChip({ tc, index }: { tc: { callId?: string; name: string; label: string; running?: boolean; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }; index: number }) {
   const [expanded, setExpanded] = useState(false);
+
+  // While running — show a spinner chip, not expandable
+  if (tc.running) {
+    return (
+      <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-[var(--surface-2)] border border-[var(--border)] w-fit">
+        <Loader2 size={9} className="text-[var(--accent)] animate-spin shrink-0" />
+        <span className="text-[0.714rem] text-[var(--text-secondary)]">{tc.label}</span>
+      </div>
+    );
+  }
 
   // Cairn write tools get a dedicated linked bubble instead of raw JSON expansion
   if (tc.cairnRef && tc.ok) {

--- a/src/components/agent/SpawnAgentModal.tsx
+++ b/src/components/agent/SpawnAgentModal.tsx
@@ -7,17 +7,19 @@
  * the task label is hidden, the prompt starts empty, and the session is
  * labelled "Ad-hoc session".
  *
- * Pre-fills from task title + description when a card is provided.
- * On confirm: spawns PTY, adds session to store, navigates to Agent view.
+ * Session types:
+ *   "pi"  — Cairn native agent (structured chat, no PTY)
+ *   "pty" — External PTY agent (xterm.js terminal)
  */
 
 import { useState, useEffect } from "react";
-import { Terminal, AlertTriangle } from "lucide-react";
+import { Terminal, MessageSquare, AlertTriangle } from "lucide-react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogClose } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { id } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import type { TaskCard } from "@/types";
 
 interface SpawnAgentModalProps {
@@ -27,15 +29,29 @@ interface SpawnAgentModalProps {
 }
 
 export function SpawnAgentModal({ card, open, onClose }: SpawnAgentModalProps) {
-  const { agents, fetchAgents, activeProjectId, projects, addTerminalSession, setActiveSession, setView, updateProject } = useCairnStore(useShallow((s) => ({ agents: s.agents, fetchAgents: s.fetchAgents, activeProjectId: s.activeProjectId, projects: s.projects, addTerminalSession: s.addTerminalSession, setActiveSession: s.setActiveSession, setView: s.setView, updateProject: s.updateProject })));
+  const {
+    agents, fetchAgents, activeProjectId, projects,
+    addTerminalSession, setActiveSession, setView, updateProject, aiConfig,
+  } = useCairnStore(useShallow((s) => ({
+    agents:               s.agents,
+    fetchAgents:          s.fetchAgents,
+    activeProjectId:      s.activeProjectId,
+    projects:             s.projects,
+    addTerminalSession:   s.addTerminalSession,
+    setActiveSession:     s.setActiveSession,
+    setView:              s.setView,
+    updateProject:        s.updateProject,
+    aiConfig:             s.aiConfig,
+  })));
 
-  const project = projects.find((p) => p.id === activeProjectId) ?? null;
+  const project      = projects.find((p) => p.id === activeProjectId) ?? null;
   const codeDirectory = project?.codeDirectory ?? null;
 
+  const [sessionType, setSessionType]   = useState<"pi" | "pty">("pi");
   const [selectedAgentId, setSelectedAgentId] = useState<string>("");
-  const [prompt, setPrompt] = useState("");
-  const [spawning, setSpawning] = useState(false);
-  const [spawnError, setSpawnError] = useState<string | null>(null);
+  const [prompt, setPrompt]             = useState("");
+  const [spawning, setSpawning]         = useState(false);
+  const [spawnError, setSpawnError]     = useState<string | null>(null);
 
   // Fetch agents on open
   useEffect(() => {
@@ -56,40 +72,88 @@ export function SpawnAgentModal({ card, open, onClose }: SpawnAgentModalProps) {
     setSpawnError(null);
   }, [open, agents, card]);
 
-  const canSpawn = agents.length > 0 && !!codeDirectory && !!selectedAgentId && !!window.electron;
+  const canSpawnPty = agents.length > 0 && !!codeDirectory && !!selectedAgentId && !!window.electron;
+  const canSpawnPi  = !!codeDirectory && !!window.electron;
+  const canSpawn    = sessionType === "pi" ? canSpawnPi : canSpawnPty;
+
   const selectedAgent = agents.find((a) => a.id === selectedAgentId);
 
   async function handleSpawn() {
-    if (!canSpawn || !selectedAgent || !codeDirectory || !project) return;
+    if (!canSpawn || !codeDirectory || !project) return;
     setSpawning(true);
     setSpawnError(null);
 
-    const taskId = card?.id ?? id();
-    const taskTitle = card?.title ?? "Ad-hoc session";
+    const sessionId  = id();
+    const taskId     = card?.id ?? id();
+    const taskTitle  = card?.title ?? "Ad-hoc session";
 
     try {
-      const { sessionId } = await window.electron!.agent.spawn({
-        agentId: selectedAgent.id,
-        projectId: project.id,
-        cwd: codeDirectory,
-        prompt,
-        taskId,
-        taskTitle,
-      });
-      addTerminalSession({
-        sessionId,
-        taskId,
-        taskTitle,
-        agentId: selectedAgent.id,
-        agentName: selectedAgent.name,
-        projectId: project.id,
-        status: "running",
-        exitCode: null,
-        spawnedAt: new Date().toISOString(),
-      });
-      setActiveSession(sessionId);
-      setView("agent");
-      onClose();
+      if (sessionType === "pi") {
+        // Cairn native agent — no PTY, just create the session and send initial prompt
+        addTerminalSession({
+          sessionId,
+          taskId,
+          taskTitle,
+          agentId:     "cairn-agent",
+          agentName:   "Cairn Agent",
+          projectId:   project.id,
+          cwd:         codeDirectory,
+          status:      "running",
+          exitCode:    null,
+          spawnedAt:   new Date().toISOString(),
+          sessionType: "pi",
+          piMessages:  [],
+        });
+
+        // Send initial prompt if provided
+        if (prompt.trim()) {
+          window.electron!.piAgent.prompt({
+            sessionId,
+            prompt: prompt.trim(),
+            projectId: project.id,
+            workspaceId: project.workspaceId ?? undefined,
+            cwd: codeDirectory,
+            taskTitle: card?.title,
+            config: {
+              baseUrl: aiConfig.baseUrl || undefined,
+              model:   aiConfig.model   || undefined,
+              apiKey:  aiConfig.apiKey  || undefined,
+            },
+          });
+        }
+
+        setActiveSession(sessionId);
+        setView("agent");
+        onClose();
+
+      } else {
+        // External PTY agent
+        if (!selectedAgent) return;
+        const { sessionId: ptySessionId } = await window.electron!.agent.spawn({
+          agentId:   selectedAgent.id,
+          projectId: project.id,
+          cwd:       codeDirectory,
+          prompt,
+          taskId,
+          taskTitle,
+        });
+        addTerminalSession({
+          sessionId:   ptySessionId,
+          taskId,
+          taskTitle,
+          agentId:     selectedAgent.id,
+          agentName:   selectedAgent.name,
+          projectId:   project.id,
+          cwd:         codeDirectory,
+          status:      "running",
+          exitCode:    null,
+          spawnedAt:   new Date().toISOString(),
+          sessionType: "pty",
+        });
+        setActiveSession(ptySessionId);
+        setView("agent");
+        onClose();
+      }
     } catch (e) {
       setSpawnError(String(e));
     } finally {
@@ -102,12 +166,53 @@ export function SpawnAgentModal({ card, open, onClose }: SpawnAgentModalProps) {
       <DialogContent size="md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Terminal size={15} />
+            {sessionType === "pi"
+              ? <MessageSquare size={15} />
+              : <Terminal size={15} />}
             {card ? "Spawn Agent" : "New Session"}
           </DialogTitle>
         </DialogHeader>
 
         <div className="px-5 py-4 space-y-4">
+
+          {/* Session type toggle */}
+          <div>
+            <p className="text-[0.714rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] mb-1.5">
+              Agent type
+            </p>
+            <div className="flex rounded-lg border border-[var(--border)] overflow-hidden text-xs">
+              <button
+                onClick={() => setSessionType("pi")}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-1.5 py-1.5 transition-colors",
+                  sessionType === "pi"
+                    ? "bg-[var(--accent)] text-white"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+                )}
+              >
+                <MessageSquare size={12} />
+                Cairn Agent
+              </button>
+              <button
+                onClick={() => setSessionType("pty")}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-1.5 py-1.5 transition-colors border-l border-[var(--border)]",
+                  sessionType === "pty"
+                    ? "bg-[var(--accent)] text-white"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+                )}
+              >
+                <Terminal size={12} />
+                External Agent
+              </button>
+            </div>
+            {sessionType === "pi" && (
+              <p className="text-[0.714rem] text-[var(--text-tertiary)] mt-1">
+                Uses {aiConfig.model || "gpt-4o"} · reads/writes code + Cairn board
+              </p>
+            )}
+          </div>
+
           {/* Task label — only shown when launched from a card */}
           {card && (
             <div>
@@ -116,21 +221,8 @@ export function SpawnAgentModal({ card, open, onClose }: SpawnAgentModalProps) {
             </div>
           )}
 
-          {/* No agents warning */}
-          {agents.length === 0 && (
-            <div className="flex items-start gap-2 rounded-lg p-3 bg-[color-mix(in_srgb,var(--warning,#f59e0b)_10%,transparent)] text-[var(--warning,#f59e0b)]" role="alert">
-              <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
-              <div className="text-xs">
-                No coding agents configured.{" "}
-                <button onClick={() => { onClose(); setView("settings"); }} className="underline">
-                  Configure in Settings
-                </button>
-              </div>
-            </div>
-          )}
-
           {/* No code directory warning */}
-          {agents.length > 0 && !codeDirectory && (
+          {!codeDirectory && (
             <div className="flex items-start gap-2 rounded-lg p-3 bg-[color-mix(in_srgb,var(--warning,#f59e0b)_10%,transparent)] text-[var(--warning,#f59e0b)]" role="alert">
               <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
               <div className="text-xs">
@@ -149,35 +241,50 @@ export function SpawnAgentModal({ card, open, onClose }: SpawnAgentModalProps) {
             </div>
           )}
 
-          {/* Agent selector */}
-          {agents.length > 0 && (
-            <div>
-              <label className="text-[0.714rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] block mb-1">
-                Agent
-              </label>
-              <select
-                value={selectedAgentId}
-                onChange={(e) => setSelectedAgentId(e.target.value)}
-                className="w-full rounded-md border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] text-sm px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-[var(--accent)]"
-              >
-                {agents.map((a) => (
-                  <option key={a.id} value={a.id}>{a.name}{a.isDefault ? " (default)" : ""}</option>
-                ))}
-              </select>
-            </div>
+          {/* PTY-specific: agent selector */}
+          {sessionType === "pty" && (
+            <>
+              {agents.length === 0 ? (
+                <div className="flex items-start gap-2 rounded-lg p-3 bg-[color-mix(in_srgb,var(--warning,#f59e0b)_10%,transparent)] text-[var(--warning,#f59e0b)]" role="alert">
+                  <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+                  <div className="text-xs">
+                    No coding agents configured.{" "}
+                    <button onClick={() => { onClose(); setView("settings"); }} className="underline">
+                      Configure in Settings
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div>
+                  <label className="text-[0.714rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] block mb-1">
+                    Agent binary
+                  </label>
+                  <select
+                    value={selectedAgentId}
+                    onChange={(e) => setSelectedAgentId(e.target.value)}
+                    className="w-full rounded-md border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] text-sm px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-[var(--accent)]"
+                  >
+                    {agents.map((a) => (
+                      <option key={a.id} value={a.id}>{a.name}{a.isDefault ? " (default)" : ""}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+            </>
           )}
 
           {/* Prompt textarea */}
           <div>
             <label className="text-[0.714rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] block mb-1">
-              Prompt
+              {sessionType === "pi" ? "Initial prompt (optional)" : "Prompt"}
             </label>
             <textarea
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
-              rows={6}
+              onKeyDown={(e) => { if (e.key === "Enter" && e.metaKey) handleSpawn(); }}
+              rows={5}
               className="w-full rounded-md border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] text-sm px-3 py-2 font-mono resize-y focus:outline-none focus:ring-1 focus:ring-[var(--accent)]"
-              placeholder="Describe the task for the agent…"
+              placeholder={sessionType === "pi" ? "Describe what you want the agent to do…" : "Describe the task for the agent…"}
             />
           </div>
 
@@ -198,8 +305,8 @@ export function SpawnAgentModal({ card, open, onClose }: SpawnAgentModalProps) {
               onClick={handleSpawn}
               disabled={!canSpawn || spawning}
             >
-              <Terminal size={13} />
-              {spawning ? "Spawning…" : card ? "Spawn" : "Start"}
+              {sessionType === "pi" ? <MessageSquare size={13} /> : <Terminal size={13} />}
+              {spawning ? "Starting…" : card ? "Spawn" : "Start"}
             </Button>
           </div>
         </div>

--- a/src/components/agent/SpawnAgentModal.tsx
+++ b/src/components/agent/SpawnAgentModal.tsx
@@ -94,33 +94,18 @@ export function SpawnAgentModal({ card, open, onClose }: SpawnAgentModalProps) {
           sessionId,
           taskId,
           taskTitle,
-          agentId:     "cairn-agent",
-          agentName:   "Cairn Agent",
-          projectId:   project.id,
-          cwd:         codeDirectory,
-          status:      "running",
-          exitCode:    null,
-          spawnedAt:   new Date().toISOString(),
-          sessionType: "pi",
-          piMessages:  [],
+          agentId:       "cairn-agent",
+          agentName:     "Cairn Agent",
+          projectId:     project.id,
+          cwd:           codeDirectory,
+          status:        "running",
+          exitCode:      null,
+          spawnedAt:     new Date().toISOString(),
+          sessionType:   "pi",
+          piMessages:    [],
+          // Store the prompt — PiAgentPane will fire it on first mount
+          initialPrompt: prompt.trim() || undefined,
         });
-
-        // Send initial prompt if provided
-        if (prompt.trim()) {
-          window.electron!.piAgent.prompt({
-            sessionId,
-            prompt: prompt.trim(),
-            projectId: project.id,
-            workspaceId: project.workspaceId ?? undefined,
-            cwd: codeDirectory,
-            taskTitle: card?.title,
-            config: {
-              baseUrl: aiConfig.baseUrl || undefined,
-              model:   aiConfig.model   || undefined,
-              apiKey:  aiConfig.apiKey  || undefined,
-            },
-          });
-        }
 
         setActiveSession(sessionId);
         setView("agent");

--- a/src/components/chat/chat-panel/ChatMessageBubble.tsx
+++ b/src/components/chat/chat-panel/ChatMessageBubble.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { Bot, User, FileText, Kanban, FolderOpen, Search, Copy, Check, RotateCcw } from "lucide-react";
+import { Bot, User, FileText, Kanban, FolderOpen, Search, Copy, Check, RotateCcw, CheckCircle } from "lucide-react";
 import { cn, formatRelative } from "@/lib/utils";
 import { MarkdownContent } from "./MarkdownContent";
 import type { ChatMessage, LinkedContextReference } from "@/types";
@@ -29,6 +29,16 @@ export function ChatMessageBubble({ message, onRetry }: ChatMessageBubbleProps) 
         {isUser ? <User size={11} className="text-[var(--text-tertiary)]" /> : <Bot size={11} className="text-[var(--accent)]" />}
       </div>
       <div className={cn("flex-1 min-w-0 space-y-1.5", isUser && "items-end flex flex-col")}>
+        {!isUser && message.toolCalls && message.toolCalls.length > 0 && (
+          <div className="flex flex-col gap-1 mb-1">
+            {message.toolCalls.map((tc, i) => (
+              <div key={i} className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] w-fit">
+                <CheckCircle size={10} className="text-[var(--accent)] shrink-0" />
+                <span className="text-[0.786rem] text-[var(--text-secondary)]">{tc.label}</span>
+              </div>
+            ))}
+          </div>
+        )}
         <div className={cn("px-3 py-2.5 rounded-xl text-xs leading-relaxed max-w-full",
           isUser ? "bg-[var(--accent)] text-white rounded-tr-sm" : "bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-secondary)] rounded-tl-sm")}>
           <MarkdownContent content={message.content} />

--- a/src/components/chat/chat-panel/ToolCallIndicator.tsx
+++ b/src/components/chat/chat-panel/ToolCallIndicator.tsx
@@ -19,7 +19,11 @@ export function ToolCallIndicator({ toolCalls, streamingContent }: ToolCallIndic
       <div className="flex flex-col gap-1 min-w-0 flex-1">
         {toolCalls.map((tc, i) => (
           <div key={i} className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] w-fit">
-            <CheckCircle size={10} className="text-[var(--accent)] shrink-0" />
+            {tc.status === "running" ? (
+              <Loader2 size={10} className="text-[var(--accent)] animate-spin shrink-0" />
+            ) : (
+              <CheckCircle size={10} className="text-[var(--accent)] shrink-0" />
+            )}
             <span className="text-[0.786rem] text-[var(--text-secondary)]">{tc.label}</span>
           </div>
         ))}

--- a/src/components/settings/AISettings.tsx
+++ b/src/components/settings/AISettings.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from "react";
 import {
-  CheckCircle, RefreshCw, Key, Globe, Cpu, Wifi, WifiOff, Eye, EyeOff, Footprints,
+  CheckCircle, RefreshCw, Key, Globe, Cpu, Wifi, WifiOff, Eye, EyeOff, Footprints, Layers,
 } from "lucide-react";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useCairnStore } from "@/store";
@@ -25,7 +25,7 @@ export function AISettings() {
   const [modelsFetched, setModelsFetched] = useState(false);
 
   // Always read directly from the store — no local shadow copy
-  const { baseUrl, model, apiKey, maxSteps, aiEnabled } = aiConfig;
+  const { baseUrl, model, apiKey, maxSteps, contextLimit, aiEnabled } = aiConfig;
   const isLocal =
     baseUrl.includes("localhost") ||
     baseUrl.includes("127.0.0.1") ||
@@ -273,6 +273,46 @@ export function AISettings() {
                   )}
                 >
                   {n}
+                </button>
+              ))}
+            </div>
+          </div>
+        </SettingsRow>
+
+        {/* Context window */}
+        <SettingsRow
+          label="Context window"
+          description="Token limit of your model. Used to display the context usage ring in the agent pane."
+        >
+          <div className="flex flex-col gap-1.5 items-end">
+            <div className="relative">
+              <Layers size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
+              <input
+                type="number"
+                min={1000}
+                max={2000000}
+                step={1000}
+                value={contextLimit ?? 128000}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value, 10);
+                  if (!isNaN(v) && v >= 1000) update({ contextLimit: v });
+                }}
+                className="pl-7 pr-3 py-1.5 text-xs w-28 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent-dim)]"
+              />
+            </div>
+            <div className="flex gap-1.5">
+              {[8000, 32000, 128000, 200000].map((n) => (
+                <button
+                  key={n}
+                  onClick={() => update({ contextLimit: n })}
+                  className={cn(
+                    "px-2 py-1 text-[0.714rem] rounded border transition-colors",
+                    (contextLimit ?? 128000) === n
+                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
+                      : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
+                  )}
+                >
+                  {n >= 1000 ? `${n / 1000}k` : n}
                 </button>
               ))}
             </div>

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -9,6 +9,11 @@
  *
  * The component calls `sendStream()` to fire a request and reads back
  * the state updates as tokens/tool calls arrive.
+ *
+ * Tool calls are tracked with a per-call status ("running" | "done") so the
+ * indicator can show a spinner on the active tool and a check on completed
+ * ones. When the turn finishes, the full tool call list is persisted onto the
+ * assistant ChatMessage so it remains visible in thread history.
  */
 
 import { useState, useEffect, useRef } from "react";
@@ -17,6 +22,8 @@ import { useCairnStore } from "@/store";
 export interface ChatToolCall {
   tool: string;
   label: string;
+  /** "running" = currently executing; "done" = completed this turn */
+  status: "running" | "done";
 }
 
 export interface PendingQuestion {
@@ -59,8 +66,12 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
   const [streamingContent, setStreamingContent] = useState("");
   const [pendingQuestions, setPendingQuestions] = useState<PendingQuestion[] | null>(null);
 
-  // Keep a stable ref so the onDone handler always reads the latest threadId
-  const threadIdRef = useRef<string | null>(null);
+  const threadIdRef  = useRef<string | null>(null);
+  // Accumulates tool calls for the current turn so they can be persisted on done.
+  // A ref (not state) so the onDone closure always reads the latest value without
+  // needing to be in the dependency array.
+  const toolCallsRef = useRef<ChatToolCall[]>([]);
+
   useEffect(() => { threadIdRef.current = threadId; }, [threadId]);
 
   useEffect(() => {
@@ -69,11 +80,18 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
 
     const unsubTool = electron.chat.onToolCall((e) => {
       if (e.tool === "ask_questions") {
-        // Intercept: surface as an inline form rather than a chip
         const qs = (e.args.questions as PendingQuestion[] | undefined) ?? [];
         setPendingQuestions(qs);
       } else {
-        setToolCalls((prev) => [...prev, { tool: e.tool, label: e.label }]);
+        // Mark the previously-running tool as done, add the new one as running.
+        setToolCalls((prev) => {
+          const updated = prev.map((tc) =>
+            tc.status === "running" ? { ...tc, status: "done" as const } : tc
+          );
+          const next = [...updated, { tool: e.tool, label: e.label, status: "running" as const }];
+          toolCallsRef.current = next;
+          return next;
+        });
       }
     });
 
@@ -83,13 +101,18 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
 
     const unsubDone = electron.chat.onDone((e) => {
       const tid = threadIdRef.current;
+      // Mark any still-running tool as done before persisting.
+      const finalToolCalls = toolCallsRef.current.map((tc) =>
+        tc.status === "running" ? { ...tc, status: "done" as const } : tc
+      );
       if (tid) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        addMessage(tid, "assistant", e.content, e.contextRefs as any);
+        addMessage(tid, "assistant", e.content, e.contextRefs as any, finalToolCalls);
       }
       setStreamingContent("");
       setIsLoading(false);
       setToolCalls([]);
+      toolCallsRef.current = [];
       // Do NOT clear pendingQuestions here — the form must stay visible until
       // the user submits their answers. It is cleared in sendStream() instead.
     });
@@ -106,6 +129,7 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
   function sendStream(req: ChatStreamRequest) {
     setIsLoading(true);
     setToolCalls([]);
+    toolCallsRef.current = [];
     setPendingQuestions(null);
     window.electron?.chat.stream(req);
   }
@@ -114,6 +138,7 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
     window.electron?.chat.abort();
     setIsLoading(false);
     setToolCalls([]);
+    toolCallsRef.current = [];
     setStreamingContent("");
     // Keep pendingQuestions — user may still want to answer after stopping
   }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -69,11 +69,12 @@ export const PRIORITY_CSS_COLORS: Record<Priority | string, string> = {
 
 /** Default AI/LLM config values. */
 export const DEFAULT_AI_CONFIG: AIConfig = {
-  baseUrl:   "https://api.openai.com",
-  model:     "gpt-4o-mini",
-  apiKey:    "",
-  maxSteps:  20,
-  aiEnabled: true,
+  baseUrl:      "https://api.openai.com",
+  model:        "gpt-4o-mini",
+  apiKey:       "",
+  maxSteps:     20,
+  contextLimit: 128000,
+  aiEnabled:    true,
 };
 
 // ── localStorage keys ─────────────────────────────────────────────────────────

--- a/src/store/slices/chat.ts
+++ b/src/store/slices/chat.ts
@@ -4,7 +4,7 @@
 
 import type { StateCreator } from "zustand";
 import type { CairnStore } from "../index";
-import type { ChatThread, ChatMessage, PendingAction, ID } from "@/types";
+import type { ChatThread, ChatMessage, ChatToolCallRecord, PendingAction, ID } from "@/types";
 import { id, now } from "@/lib/utils";
 import { ipc } from "../ipc";
 
@@ -19,7 +19,8 @@ export interface ChatSlice {
     threadId: ID,
     role: ChatMessage["role"],
     content: string,
-    contextRefs?: ChatMessage["contextRefs"]
+    contextRefs?: ChatMessage["contextRefs"],
+    toolCalls?: ChatToolCallRecord[]
   ) => ChatMessage;
   confirmAction: (action: PendingAction) => void;
   deleteThread: (threadId: ID) => void;
@@ -58,13 +59,14 @@ export const createChatSlice: StateCreator<CairnStore, [], [], ChatSlice> = (
     return thread;
   },
 
-  addMessage(threadId, role, content, contextRefs) {
+  addMessage(threadId, role, content, contextRefs, toolCalls) {
     const msg: ChatMessage = {
       id: id(),
       threadId,
       role,
       content,
       contextRefs,
+      toolCalls: toolCalls && toolCalls.length > 0 ? toolCalls : undefined,
       createdAt: now(),
     };
     set((s) => ({

--- a/src/store/slices/terminal-sessions.ts
+++ b/src/store/slices/terminal-sessions.ts
@@ -31,8 +31,12 @@ export interface PiAgentMessage {
   content: string;
   /** Tool calls that occurred before or during this assistant message */
   toolCalls?: {
+    /** Unique key to allow in-place updates (tool name + start timestamp) */
+    callId: string;
     name: string;
     label: string;
+    /** true while the tool is executing, false once done */
+    running: boolean;
     ok: boolean;
     output?: string;
     /** Parsed reference for Cairn write tools — renders a linked bubble instead of raw output */
@@ -86,7 +90,9 @@ export interface TerminalSessionsSlice {
   /** Ensure a streaming assistant message exists — creates one if the last message is not streaming */
   ensurePiStreamingMessage: (sessionId: string) => void;
   /** Append a tool call record to the last assistant message */
-  addPiToolCall: (sessionId: string, toolCall: { name: string; label: string; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void;
+  addPiToolCall: (sessionId: string, toolCall: { callId: string; name: string; label: string; running: boolean; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void;
+  /** Update an existing tool call chip in-place (start → done) */
+  updatePiToolCall: (sessionId: string, callId: string, patch: { label?: string; running: boolean; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void;
   /** Clear message history for a pi session */
   clearPiMessages: (sessionId: string) => void;
   /** Update token usage for a session after a step completes */
@@ -98,7 +104,9 @@ export interface TerminalSessionsSlice {
   /** Finalise the last streaming message in a subagent */
   finalisePiSubagentMessage: (sessionId: string, childSessionId: string) => void;
   /** Add a tool call to a subagent's last streaming message */
-  addPiSubagentToolCall: (sessionId: string, childSessionId: string, toolCall: { name: string; label: string; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void;
+  addPiSubagentToolCall: (sessionId: string, childSessionId: string, toolCall: { callId: string; name: string; label: string; running: boolean; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void;
+  /** Update an existing tool call chip on a subagent message in-place */
+  updatePiSubagentToolCall: (sessionId: string, childSessionId: string, callId: string, patch: { label?: string; running: boolean; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void;
   /** Mark a subagent as done and store its result */
   completePiSubagent: (sessionId: string, childSessionId: string, result: string) => void;
   /** Update token usage on an inline subagent block */
@@ -241,7 +249,7 @@ export const createTerminalSessionsSlice: StateCreator<CairnStore, [], [], Termi
     }));
   },
 
-  addPiToolCall(sessionId, toolCall: { name: string; label: string; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) {
+  addPiToolCall(sessionId, toolCall: { callId: string; name: string; label: string; running: boolean; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) {
     set((s) => ({
       terminalSessions: s.terminalSessions.map((t) => {
         if (t.sessionId !== sessionId) return t;
@@ -260,6 +268,25 @@ export const createTerminalSessionsSlice: StateCreator<CairnStore, [], [], Termi
           };
         }
         return t;
+      }),
+    }));
+  },
+
+  updatePiToolCall(sessionId, callId, patch) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        return {
+          ...t,
+          piMessages: (t.piMessages ?? []).map((msg) => {
+            if (!msg.toolCalls) return msg;
+            const idx = msg.toolCalls.findIndex((tc) => tc.callId === callId);
+            if (idx === -1) return msg;
+            const updated = [...msg.toolCalls];
+            updated[idx] = { ...updated[idx], ...patch };
+            return { ...msg, toolCalls: updated };
+          }),
+        };
       }),
     }));
   },
@@ -381,6 +408,35 @@ export const createTerminalSessionsSlice: StateCreator<CairnStore, [], [], Termi
                 ...subMsgs.slice(0, -1),
                 { ...last, toolCalls: [...(last.toolCalls ?? []), toolCall] },
               ],
+            };
+            return { ...msg, subagents: newSubagents };
+          }),
+        };
+      }),
+    }));
+  },
+
+  updatePiSubagentToolCall(sessionId, childSessionId, callId, patch) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        return {
+          ...t,
+          piMessages: (t.piMessages ?? []).map((msg) => {
+            const subIdx = (msg.subagents ?? []).findIndex((sa) => sa.childSessionId === childSessionId);
+            if (subIdx === -1) return msg;
+            const sub = msg.subagents![subIdx];
+            const newSubagents = [...msg.subagents!];
+            newSubagents[subIdx] = {
+              ...sub,
+              messages: sub.messages.map((m) => {
+                if (!m.toolCalls) return m;
+                const idx = m.toolCalls.findIndex((tc) => tc.callId === callId);
+                if (idx === -1) return m;
+                const updated = [...m.toolCalls];
+                updated[idx] = { ...updated[idx], ...patch };
+                return { ...m, toolCalls: updated };
+              }),
             };
             return { ...msg, subagents: newSubagents };
           }),

--- a/src/store/slices/terminal-sessions.ts
+++ b/src/store/slices/terminal-sessions.ts
@@ -37,6 +37,8 @@ export interface TerminalSession {
   sessionType: "pty" | "pi";
   /** Message history for pi sessions — not used by pty sessions */
   piMessages?: PiAgentMessage[];
+  /** Prompt to send automatically when PiAgentPane first mounts */
+  initialPrompt?: string;
 }
 
 export interface TerminalSessionsSlice {

--- a/src/store/slices/terminal-sessions.ts
+++ b/src/store/slices/terminal-sessions.ts
@@ -12,6 +12,16 @@ import type { CairnStore } from "../index";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+export interface PiAgentMessage {
+  id: string;
+  role: "user" | "assistant" | "error";
+  content: string;
+  /** Tool calls that occurred before or during this assistant message */
+  toolCalls?: { name: string; label: string; ok: boolean }[];
+  isStreaming?: boolean;
+  timestamp: string;
+}
+
 export interface TerminalSession {
   sessionId: string;
   taskId: string;
@@ -19,9 +29,14 @@ export interface TerminalSession {
   agentId: string;
   agentName: string;
   projectId: string;
+  cwd?: string;
   status: "running" | "exited";
   exitCode: number | null;
   spawnedAt: string; // ISO string (JSON-safe)
+  /** "pty" = external PTY agent (xterm); "pi" = Cairn native agent (chat UI) */
+  sessionType: "pty" | "pi";
+  /** Message history for pi sessions — not used by pty sessions */
+  piMessages?: PiAgentMessage[];
 }
 
 export interface TerminalSessionsSlice {
@@ -36,6 +51,16 @@ export interface TerminalSessionsSlice {
   removeTerminalSession: (sessionId: string) => void;
   setActiveSession: (sessionId: string | null) => void;
   markSessionExited: (sessionId: string, exitCode: number) => void;
+  /** Add a message to a pi session's message list */
+  addPiMessage: (sessionId: string, msg: PiAgentMessage) => void;
+  /** Append a token delta to the last streaming assistant message */
+  appendPiToken: (sessionId: string, delta: string) => void;
+  /** Finalise the streaming assistant message (isStreaming → false) */
+  finalisePiMessage: (sessionId: string) => void;
+  /** Append a tool call record to the last assistant message */
+  addPiToolCall: (sessionId: string, toolCall: { name: string; label: string; ok: boolean }) => void;
+  /** Clear message history for a pi session */
+  clearPiMessages: (sessionId: string) => void;
   /** Open a file tab (no-op if already open) and make it active. */
   openEditorFile: (path: string) => void;
   /** Close a file tab; activates the nearest remaining tab. */
@@ -81,6 +106,95 @@ export const createTerminalSessionsSlice: StateCreator<CairnStore, [], [], Termi
     set((s) => ({
       terminalSessions: s.terminalSessions.map((t) =>
         t.sessionId === sessionId ? { ...t, status: "exited", exitCode } : t
+      ),
+    }));
+  },
+
+  addPiMessage(sessionId, msg) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) =>
+        t.sessionId === sessionId
+          ? { ...t, piMessages: [...(t.piMessages ?? []), msg] }
+          : t
+      ),
+    }));
+  },
+
+  appendPiToken(sessionId, delta) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        const msgs = t.piMessages ?? [];
+        const last = msgs[msgs.length - 1];
+        if (last?.isStreaming) {
+          return {
+            ...t,
+            piMessages: [
+              ...msgs.slice(0, -1),
+              { ...last, content: last.content + delta },
+            ],
+          };
+        }
+        // No streaming message yet — create one
+        return {
+          ...t,
+          piMessages: [
+            ...msgs,
+            {
+              id: `stream-${Date.now()}`,
+              role: "assistant" as const,
+              content: delta,
+              isStreaming: true,
+              timestamp: new Date().toISOString(),
+            },
+          ],
+        };
+      }),
+    }));
+  },
+
+  finalisePiMessage(sessionId) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        const msgs = t.piMessages ?? [];
+        const last = msgs[msgs.length - 1];
+        if (!last?.isStreaming) return t;
+        return {
+          ...t,
+          piMessages: [...msgs.slice(0, -1), { ...last, isStreaming: false }],
+        };
+      }),
+    }));
+  },
+
+  addPiToolCall(sessionId, toolCall) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        const msgs = t.piMessages ?? [];
+        const last = msgs[msgs.length - 1];
+        if (last?.isStreaming) {
+          return {
+            ...t,
+            piMessages: [
+              ...msgs.slice(0, -1),
+              {
+                ...last,
+                toolCalls: [...(last.toolCalls ?? []), toolCall],
+              },
+            ],
+          };
+        }
+        return t;
+      }),
+    }));
+  },
+
+  clearPiMessages(sessionId) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) =>
+        t.sessionId === sessionId ? { ...t, piMessages: [] } : t
       ),
     }));
   },

--- a/src/store/slices/terminal-sessions.ts
+++ b/src/store/slices/terminal-sessions.ts
@@ -12,12 +12,34 @@ import type { CairnStore } from "../index";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+export interface PiSubagentMessage {
+  /** Unique child session ID */
+  childSessionId: string;
+  /** Messages streamed by the subagent */
+  messages: PiAgentMessage[];
+  /** Whether the subagent is still running */
+  running: boolean;
+  /** Final result returned to the parent */
+  result?: string;
+  /** Latest token usage from the subagent's LLM steps */
+  lastUsage?: { promptTokens: number; completionTokens: number };
+}
+
 export interface PiAgentMessage {
   id: string;
   role: "user" | "assistant" | "error";
   content: string;
   /** Tool calls that occurred before or during this assistant message */
-  toolCalls?: { name: string; label: string; ok: boolean }[];
+  toolCalls?: {
+    name: string;
+    label: string;
+    ok: boolean;
+    output?: string;
+    /** Parsed reference for Cairn write tools — renders a linked bubble instead of raw output */
+    cairnRef?: { type: "note" | "task"; id: string; title: string };
+  }[];
+  /** Subagents spawned during this message */
+  subagents?: PiSubagentMessage[];
   isStreaming?: boolean;
   timestamp: string;
 }
@@ -39,6 +61,8 @@ export interface TerminalSession {
   piMessages?: PiAgentMessage[];
   /** Prompt to send automatically when PiAgentPane first mounts */
   initialPrompt?: string;
+  /** Latest token usage from the LLM — updated after each step */
+  lastUsage?: { promptTokens: number; completionTokens: number };
 }
 
 export interface TerminalSessionsSlice {
@@ -59,10 +83,28 @@ export interface TerminalSessionsSlice {
   appendPiToken: (sessionId: string, delta: string) => void;
   /** Finalise the streaming assistant message (isStreaming → false) */
   finalisePiMessage: (sessionId: string) => void;
+  /** Ensure a streaming assistant message exists — creates one if the last message is not streaming */
+  ensurePiStreamingMessage: (sessionId: string) => void;
   /** Append a tool call record to the last assistant message */
-  addPiToolCall: (sessionId: string, toolCall: { name: string; label: string; ok: boolean }) => void;
+  addPiToolCall: (sessionId: string, toolCall: { name: string; label: string; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void;
   /** Clear message history for a pi session */
   clearPiMessages: (sessionId: string) => void;
+  /** Update token usage for a session after a step completes */
+  updatePiUsage: (sessionId: string, promptTokens: number, completionTokens: number) => void;
+  /** Register a new subagent on the last streaming assistant message */
+  addPiSubagent: (sessionId: string, childSessionId: string) => void;
+  /** Append a token to a subagent's last streaming message */
+  appendPiSubagentToken: (sessionId: string, childSessionId: string, delta: string) => void;
+  /** Finalise the last streaming message in a subagent */
+  finalisePiSubagentMessage: (sessionId: string, childSessionId: string) => void;
+  /** Add a tool call to a subagent's last streaming message */
+  addPiSubagentToolCall: (sessionId: string, childSessionId: string, toolCall: { name: string; label: string; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void;
+  /** Mark a subagent as done and store its result */
+  completePiSubagent: (sessionId: string, childSessionId: string, result: string) => void;
+  /** Update token usage on an inline subagent block */
+  updatePiSubagentUsage: (sessionId: string, childSessionId: string, promptTokens: number, completionTokens: number) => void;
+  /** Start a new step in a subagent (finalise current message) */
+  stepPiSubagent: (sessionId: string, childSessionId: string) => void;
   /** Open a file tab (no-op if already open) and make it active. */
   openEditorFile: (path: string) => void;
   /** Close a file tab; activates the nearest remaining tab. */
@@ -162,6 +204,11 @@ export const createTerminalSessionsSlice: StateCreator<CairnStore, [], [], Termi
         const msgs = t.piMessages ?? [];
         const last = msgs[msgs.length - 1];
         if (!last?.isStreaming) return t;
+        // Drop empty tool-free messages entirely rather than leaving blank bubbles.
+        // This happens when a loop step does only tool calls with no surrounding text.
+        if (!last.content && !(last.toolCalls?.length) && !(last.subagents?.length)) {
+          return { ...t, piMessages: msgs.slice(0, -1) };
+        }
         return {
           ...t,
           piMessages: [...msgs.slice(0, -1), { ...last, isStreaming: false }],
@@ -170,7 +217,31 @@ export const createTerminalSessionsSlice: StateCreator<CairnStore, [], [], Termi
     }));
   },
 
-  addPiToolCall(sessionId, toolCall) {
+  ensurePiStreamingMessage(sessionId) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        const msgs = t.piMessages ?? [];
+        const last = msgs[msgs.length - 1];
+        if (last?.isStreaming) return t; // already have one
+        return {
+          ...t,
+          piMessages: [
+            ...msgs,
+            {
+              id: `stream-${Date.now()}`,
+              role: "assistant" as const,
+              content: "",
+              isStreaming: true,
+              timestamp: new Date().toISOString(),
+            },
+          ],
+        };
+      }),
+    }));
+  },
+
+  addPiToolCall(sessionId, toolCall: { name: string; label: string; ok: boolean; output?: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) {
     set((s) => ({
       terminalSessions: s.terminalSessions.map((t) => {
         if (t.sessionId !== sessionId) return t;
@@ -198,6 +269,184 @@ export const createTerminalSessionsSlice: StateCreator<CairnStore, [], [], Termi
       terminalSessions: s.terminalSessions.map((t) =>
         t.sessionId === sessionId ? { ...t, piMessages: [] } : t
       ),
+    }));
+  },
+
+  updatePiUsage(sessionId, promptTokens, completionTokens) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) =>
+        t.sessionId === sessionId
+          ? { ...t, lastUsage: { promptTokens, completionTokens } }
+          : t
+      ),
+    }));
+  },
+
+  // ── Subagent helpers ──────────────────────────────────────────────────────
+
+  addPiSubagent(sessionId, childSessionId) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        const msgs = t.piMessages ?? [];
+        const last = msgs[msgs.length - 1];
+        if (!last?.isStreaming) return t;
+        const newSubagent: PiSubagentMessage = { childSessionId, messages: [], running: true };
+        return {
+          ...t,
+          piMessages: [
+            ...msgs.slice(0, -1),
+            { ...last, subagents: [...(last.subagents ?? []), newSubagent] },
+          ],
+        };
+      }),
+    }));
+  },
+
+  appendPiSubagentToken(sessionId, childSessionId, delta) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        return {
+          ...t,
+          piMessages: (t.piMessages ?? []).map((msg) => {
+            const subIdx = (msg.subagents ?? []).findIndex((sa) => sa.childSessionId === childSessionId);
+            if (subIdx === -1) return msg;
+            const sub = msg.subagents![subIdx];
+            const subMsgs = sub.messages;
+            const lastSub = subMsgs[subMsgs.length - 1];
+            let newSubMsgs: PiAgentMessage[];
+            if (lastSub?.isStreaming) {
+              newSubMsgs = [...subMsgs.slice(0, -1), { ...lastSub, content: lastSub.content + delta }];
+            } else {
+              newSubMsgs = [...subMsgs, {
+                id: `sub-stream-${Date.now()}`,
+                role: "assistant" as const,
+                content: delta,
+                isStreaming: true,
+                timestamp: new Date().toISOString(),
+              }];
+            }
+            const newSubagents = [...msg.subagents!];
+            newSubagents[subIdx] = { ...sub, messages: newSubMsgs };
+            return { ...msg, subagents: newSubagents };
+          }),
+        };
+      }),
+    }));
+  },
+
+  finalisePiSubagentMessage(sessionId, childSessionId) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        return {
+          ...t,
+          piMessages: (t.piMessages ?? []).map((msg) => {
+            const subIdx = (msg.subagents ?? []).findIndex((sa) => sa.childSessionId === childSessionId);
+            if (subIdx === -1) return msg;
+            const sub = msg.subagents![subIdx];
+            const subMsgs = sub.messages;
+            const last = subMsgs[subMsgs.length - 1];
+            if (!last?.isStreaming) return msg;
+            const newSubagents = [...msg.subagents!];
+            newSubagents[subIdx] = {
+              ...sub,
+              messages: [...subMsgs.slice(0, -1), { ...last, isStreaming: false }],
+            };
+            return { ...msg, subagents: newSubagents };
+          }),
+        };
+      }),
+    }));
+  },
+
+  addPiSubagentToolCall(sessionId, childSessionId, toolCall) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        return {
+          ...t,
+          piMessages: (t.piMessages ?? []).map((msg) => {
+            const subIdx = (msg.subagents ?? []).findIndex((sa) => sa.childSessionId === childSessionId);
+            if (subIdx === -1) return msg;
+            const sub = msg.subagents![subIdx];
+            const subMsgs = sub.messages;
+            const last = subMsgs[subMsgs.length - 1];
+            if (!last?.isStreaming) return msg;
+            const newSubagents = [...msg.subagents!];
+            newSubagents[subIdx] = {
+              ...sub,
+              messages: [
+                ...subMsgs.slice(0, -1),
+                { ...last, toolCalls: [...(last.toolCalls ?? []), toolCall] },
+              ],
+            };
+            return { ...msg, subagents: newSubagents };
+          }),
+        };
+      }),
+    }));
+  },
+
+  completePiSubagent(sessionId, childSessionId, result) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        return {
+          ...t,
+          piMessages: (t.piMessages ?? []).map((msg) => {
+            const subIdx = (msg.subagents ?? []).findIndex((sa) => sa.childSessionId === childSessionId);
+            if (subIdx === -1) return msg;
+            const newSubagents = [...msg.subagents!];
+            newSubagents[subIdx] = { ...newSubagents[subIdx], running: false, result };
+            return { ...msg, subagents: newSubagents };
+          }),
+        };
+      }),
+    }));
+  },
+
+  updatePiSubagentUsage(sessionId, childSessionId, promptTokens, completionTokens) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        return {
+          ...t,
+          piMessages: (t.piMessages ?? []).map((msg) => {
+            const subIdx = (msg.subagents ?? []).findIndex((sa) => sa.childSessionId === childSessionId);
+            if (subIdx === -1) return msg;
+            const newSubagents = [...msg.subagents!];
+            newSubagents[subIdx] = { ...newSubagents[subIdx], lastUsage: { promptTokens, completionTokens } };
+            return { ...msg, subagents: newSubagents };
+          }),
+        };
+      }),
+    }));
+  },
+
+  stepPiSubagent(sessionId, childSessionId) {
+    set((s) => ({
+      terminalSessions: s.terminalSessions.map((t) => {
+        if (t.sessionId !== sessionId) return t;
+        return {
+          ...t,
+          piMessages: (t.piMessages ?? []).map((msg) => {
+            const subIdx = (msg.subagents ?? []).findIndex((sa) => sa.childSessionId === childSessionId);
+            if (subIdx === -1) return msg;
+            const sub = msg.subagents![subIdx];
+            const subMsgs = sub.messages;
+            const last = subMsgs[subMsgs.length - 1];
+            if (!last?.isStreaming) return msg;
+            const newSubagents = [...msg.subagents!];
+            newSubagents[subIdx] = {
+              ...sub,
+              messages: [...subMsgs.slice(0, -1), { ...last, isStreaming: false }],
+            };
+            return { ...msg, subagents: newSubagents };
+          }),
+        };
+      }),
     }));
   },
 

--- a/src/store/slices/ui.ts
+++ b/src/store/slices/ui.ts
@@ -29,6 +29,8 @@ export interface AIConfig {
   apiKey: string;
   /** Maximum tool-call rounds per chat message. Lower = fewer API calls = lower cost. */
   maxSteps: number;
+  /** Context window size in tokens. Used to render the context usage ring. */
+  contextLimit: number;
   /** When false, all in-app AI features are hidden/disabled. Defaults to true. */
   aiEnabled: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -137,6 +137,11 @@ export interface LinkedContextReference {
   snippet?: string;
 }
 
+export interface ChatToolCallRecord {
+  tool: string;
+  label: string;
+}
+
 export interface ChatMessage {
   id: ID;
   threadId: ID;
@@ -144,6 +149,8 @@ export interface ChatMessage {
   content: string;
   /** Entities cited in or used to produce this message */
   contextRefs?: LinkedContextReference[];
+  /** Tool calls made during this assistant turn — persisted so they remain visible after streaming ends */
+  toolCalls?: ChatToolCallRecord[];
   /** If this message triggered a write action */
   pendingAction?: PendingAction;
   createdAt: string;


### PR DESCRIPTION
## What does this PR do?

Adds the Cairn native coding agent (v1.2.0) — a stateful multi-turn tool-call loop running directly inside the app with no external CLI binary required. The agent reads and writes code via 7 ported file-system tools, keeps the board and notes up to date as it works (mandatory workflow enforced in the system prompt), supports subagents for deep sub-tasks, and displays a context usage ring in the chat header. Also includes a suite of bug fixes covering initial prompt delivery, tool chip visibility, duplicate notes, and tab-switch state preservation.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [x] Docs / changelog

## Screenshots / recording

<!-- Agent pane with tool chips, context ring, subagent block, and CairnRefChip links -->

## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes (452/452)
- [x] `npm run test:e2e` passes (11/11)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

- `AgentView` is now always mounted (CSS-hidden when inactive) to preserve `PiAgentPane` IPC subscriptions and `firedInitial` ref across view switches — this was the root cause of the duplicate initial prompt bug.
- `ensure_note` was not previously exposed to the agent (`CAIRN_TOOL_NAMES`) despite existing in the schema and executor — added.
- The `spawn_subagent` tool runs a nested `runAgentLoop` in the same main process with a child session ID (`parentId:sub:hex`). Subagent usage updates its own context ring independently; parent ring only updates from parent steps.
- Coding tools (`read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`) are ported from [pi](https://github.com/earendil-works/pi) — same semantics, adapted for Cairn's Electron main process, no npm dependency.