### PR TITLE
feat: configurable temperature & max steps, smarter agent tools, settings reorganisation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@
 ## Checklist
 
 - [ ] `npm run type-check` passes
+- [ ] `npm run lint` passes
 - [ ] `npm test` passes
 - [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
 - [ ] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)

--- a/changelogs/v1.2.3.md
+++ b/changelogs/v1.2.3.md
@@ -1,0 +1,44 @@
+# v1.2.3
+
+## What's new
+
+### Features
+
+- **Configurable temperature** — LLM sampling temperature is now a first-class setting in AI & Chat (0–1, step 0.05, presets 0.1 / 0.3 / 0.5 / 0.7). Previously hardcoded to 0.3 everywhere. Plan mode always overrides to 0.1 for deterministic codebase analysis regardless of this setting.
+
+- **Temperature wired end-to-end** — the setting is now forwarded through all three AI call paths: Pi agent (`pi-agent:prompt` and `pi-agent:approve-plan`), chat panel, and PRD modal. Previously only the Pi agent partially respected it.
+
+- **Max steps uncapped** — the max steps input now accepts values up to 1000, with an ∞ preset (maps to 1000) for complex multi-file tasks. Presets updated to 10 / 20 / 30 / 50 / ∞. The Pi agent loop now reads this value from settings rather than using the hardcoded constant of 30.
+
+- **Smarter coding agent tool set** — the Pi agent (`CAIRN_TOOL_NAMES`) gains access to seven previously missing tools: `get_neighbors` (N-hop graph traversal), `bulk_update_task_status`, `link_note_to_task`, `create_tag`, `get_idea_flow_rules`, `update_idea_flow_node`, and `layout_idea_flow`. The agent could previously create idea flow nodes and tasks but couldn't link, tag, or arrange them.
+
+- **AI & Chat settings reorganised** — "Enable AI features" is now "Enable inline AI" under a new "Visibility" group that also contains Agent view and AI Chat view toggles. All AI-related visibility is now in one place instead of being split between AI & Chat and General → Views.
+
+### Fixes
+
+- **MCP project selector showing icon name instead of icon** — the project dropdown in the MCP Settings "Project context" panel was rendering `p.icon` as a string inside an HTML `<option>` element (which only supports plain text), causing it to show "Cpu Cairn Project M…" instead of the project name. Fixed by rendering `p.name` only.
+
+- **`maxSteps` setting not applied to Pi agent** — the "Max steps" setting in AI & Chat was correctly forwarded by the chat panel and PRD modal but was silently ignored by the Pi agent, which always used a hardcoded constant of 30. The setting now flows through `PiAgentPromptRequest.config`, `AgentLLMConfig`, and `runAgentLoop`.
+
+- **`temperature` not forwarded by chat panel or PRD modal** — both callers forwarded `maxSteps` but dropped `temperature`. Fixed: `ChatStreamRequest.config`, `ChatRequest.config` (tools.ts), and `electron/ipc/chat.ts` now all carry and apply temperature.
+
+- **`aiEnabled` toggle description was misleading** — the "In-app AI" group description claimed toggling it would hide "chat, text actions, PRD generator, task spawning, and Idea Flow summaries." In practice it only hides inline editor AI buttons — the Agent and AI Chat views are controlled independently via view visibility toggles. Description now accurately reflects what the toggle does.
+
+- **General → Views included Agent and AI Chat rows** — these belong in AI & Chat since they are AI features. Moved to the new Visibility group; General → Views now only lists non-AI views (Board, Idea Flow, Knowledge Graph, Insights) with a note pointing to AI & Chat for the others.
+
+### Changes
+
+- `src/store/slices/ui.ts` — `AIConfig` gains `temperature: number` field
+- `src/lib/constants.ts` — `DEFAULT_AI_CONFIG` gains `temperature: 0.3`
+- `src/components/settings/AISettings.tsx` — "In-app AI" group replaced by "Visibility" group; Agent view and AI Chat view toggles added; temperature `SettingsRow` added (Thermometer icon, presets 0.1/0.3/0.5/0.7); max steps input range raised to 1–1000, presets updated to 10/20/30/50/∞; context window description clarified as display-only
+- `src/components/settings/ViewVisibilitySettings.tsx` — Agent and AI Chat rows removed; description updated to reference AI & Chat settings; unused icon imports removed
+- `src/components/settings/GeneralSettings.tsx` — no change (ViewVisibilitySettings handles its own removal)
+- `src/hooks/useChatStream.ts` — `ChatStreamRequest.config` gains `temperature?: number`
+- `src/components/chat/chat-panel.tsx` — forwards `temperature` in config payload
+- `src/components/notes/notes-view/PrdModal.tsx` — forwards `temperature` in config payload
+- `src/components/agent/PiAgentPane.tsx` — forwards `maxSteps` and `temperature` in both `prompt` and `approvePlan` payloads
+- `electron/lib/tools.ts` — `ChatRequest.config` gains `temperature?: number`
+- `electron/ipc/chat.ts` — reads `req.config?.temperature ?? 0.3`; replaces hardcoded `temperature: 0.3` in fetch body
+- `electron/ipc/pi-agent.ts` — `PiAgentPromptRequest.config` and `PiAgentApprovePlanRequest.config` gain `maxSteps?` and `temperature?`; both `llmConfig` construction sites read them with safe fallbacks
+- `electron/lib/pi-agent-loop.ts` — `AgentLLMConfig` gains `maxSteps` and `temperature`; `MAX_STEPS = 30` constant removed; loop uses `llmConfig.maxSteps`; plan mode forces `temperature = 0.1` regardless of user setting; execute mode uses configured value; error message reports actual configured step count; `CAIRN_TOOL_NAMES` expanded with 7 new tools; stale comment referencing removed tool names updated
+- `src/components/settings/MCPSettings.tsx` — project selector `<option>` renders `p.name` only (was `p.icon + p.name`)

--- a/electron/ipc/chat.ts
+++ b/electron/ipc/chat.ts
@@ -37,7 +37,8 @@ async function runToolLoop(
   signal?: AbortSignal,
   getWin?: () => BrowserWindow | null,
 ): Promise<{ exhausted: true; content: string } | { exhausted: false }> {
-  const maxSteps = req.config?.maxSteps ?? 20;
+  const maxSteps    = req.config?.maxSteps    ?? 20;
+  const temperature = req.config?.temperature ?? 0.3;
   for (let round = 0; round < maxSteps; round++) {
     if (signal?.aborted) return { exhausted: true, content: "" };
     let response: Response;
@@ -47,7 +48,7 @@ async function runToolLoop(
       response = await fetch(`${baseUrl}/v1/chat/completions`, {
         method: "POST",
         headers,
-        body: JSON.stringify({ model, messages, tools: TOOLS, tool_choice: "auto", max_tokens: 4096, temperature: 0.3 }),
+        body: JSON.stringify({ model, messages, tools: TOOLS, tool_choice: "auto", max_tokens: 4096, temperature }),
       });
     } catch {
       return { exhausted: true, content: `Could not reach the AI endpoint at \`${baseUrl}\`. Check your endpoint URL and make sure the server is running.` };

--- a/electron/ipc/pi-agent.ts
+++ b/electron/ipc/pi-agent.ts
@@ -45,6 +45,8 @@ interface PiAgentPromptRequest {
     baseUrl?: string;
     model?: string;
     apiKey?: string;
+    maxSteps?: number;
+    temperature?: number;
   };
 }
 
@@ -59,6 +61,8 @@ interface PiAgentApprovePlanRequest {
     baseUrl?: string;
     model?: string;
     apiKey?: string;
+    maxSteps?: number;
+    temperature?: number;
   };
 }
 
@@ -91,9 +95,11 @@ export function registerPiAgentHandler(
 
     // Resolve LLM config — renderer passes config from its aiConfig store
     const llmConfig: AgentLLMConfig = {
-      baseUrl: normaliseBaseUrl(req.config?.baseUrl || "https://api.openai.com"),
-      model:   req.config?.model   || "gpt-4o",
-      apiKey:  req.config?.apiKey  || "",
+      baseUrl:     normaliseBaseUrl(req.config?.baseUrl || "https://api.openai.com"),
+      model:       req.config?.model       || "gpt-4o",
+      apiKey:      req.config?.apiKey      || "",
+      maxSteps:    req.config?.maxSteps    ?? 20,
+      temperature: req.config?.temperature ?? 0.3,
     };
 
     // Get or create session
@@ -213,9 +219,11 @@ export function registerPiAgentHandler(
     };
 
     const llmConfig: AgentLLMConfig = {
-      baseUrl: normaliseBaseUrl(req.config?.baseUrl || "https://api.openai.com"),
-      model:   req.config?.model   || "gpt-4o",
-      apiKey:  req.config?.apiKey  || "",
+      baseUrl:     normaliseBaseUrl(req.config?.baseUrl || "https://api.openai.com"),
+      model:       req.config?.model       || "gpt-4o",
+      apiKey:      req.config?.apiKey      || "",
+      maxSteps:    req.config?.maxSteps    ?? 20,
+      temperature: req.config?.temperature ?? 0.3,
     };
 
     let session = sessions.get(sessionId);

--- a/electron/lib/pi-agent-loop.test.ts
+++ b/electron/lib/pi-agent-loop.test.ts
@@ -181,7 +181,7 @@ describe("runAgentLoop — SSE streaming", () => {
 
     await runAgentLoop(
       session, "You are a test assistant.", "/tmp",
-      { baseUrl: server.url, model: "test", apiKey: "test" },
+      { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
       db, chatReq, "/tmp", callbacks,
     );
 
@@ -210,7 +210,7 @@ describe("runAgentLoop — SSE streaming", () => {
 
     await runAgentLoop(
       session, "You are a test assistant.", "/tmp",
-      { baseUrl: server.url, model: "test", apiKey: "test" },
+      { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
       db, chatReq, "/tmp", callbacks,
     );
 
@@ -243,7 +243,7 @@ describe("runAgentLoop — SSE streaming", () => {
 
     await runAgentLoop(
       session, "You are a test assistant.", "/tmp",
-      { baseUrl: server.url, model: "test", apiKey: "test" },
+      { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
       db, chatReq, "/tmp", callbacks,
     );
 
@@ -272,7 +272,7 @@ describe("runAgentLoop — SSE streaming", () => {
 
     await runAgentLoop(
       session, "You are a test assistant.", "/tmp",
-      { baseUrl: server.url, model: "test", apiKey: "test" },
+      { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
       db, chatReq, "/tmp", callbacks,
     );
 
@@ -321,7 +321,7 @@ describe("runAgentLoop — SSE streaming", () => {
 
     await runAgentLoop(
       session, "You are a test assistant.", "/tmp",
-      { baseUrl: server.url, model: "test", apiKey: "test" },
+      { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
       db, chatReq, "/tmp", callbacks,
     );
 
@@ -350,7 +350,7 @@ describe("runAgentLoop — SSE streaming", () => {
 
     await runAgentLoop(
       session, "You are a test assistant.", "/tmp",
-      { baseUrl: server.url, model: "test", apiKey: "test" },
+      { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
       db, chatReq, "/tmp", callbacks,
     );
 
@@ -370,7 +370,7 @@ describe("runAgentLoop — SSE streaming", () => {
 
     await runAgentLoop(
       session, "You are a test assistant.", "/tmp",
-      { baseUrl: server.url, model: "test", apiKey: "test" },
+      { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
       db, chatReq, "/tmp", callbacks,
     );
 
@@ -418,7 +418,7 @@ describe("runAgentLoop — SSE streaming", () => {
 
     await runAgentLoop(
       session, "You are a test assistant.", "/tmp",
-      { baseUrl: server.url, model: "test", apiKey: "test" },
+      { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
       db, chatReq, "/tmp", callbacks,
     );
 
@@ -462,7 +462,7 @@ describe.skipIf(!liveBaseUrl)("runAgentLoop — live endpoint", () => {
       session,
       "You are a test assistant. Follow instructions exactly.",
       "/tmp",
-      { baseUrl: liveBaseUrl!, model: liveModel, apiKey: liveApiKey },
+      { baseUrl: liveBaseUrl!, model: liveModel, apiKey: liveApiKey, maxSteps: 10, temperature: 0.3 },
       db, chatReq, "/tmp", callbacks,
     );
 
@@ -480,7 +480,7 @@ describe.skipIf(!liveBaseUrl)("runAgentLoop — live endpoint", () => {
       session,
       "You are a test assistant with access to coding tools. When asked to list files, always use the ls tool.",
       "/tmp",
-      { baseUrl: liveBaseUrl!, model: liveModel, apiKey: liveApiKey },
+      { baseUrl: liveBaseUrl!, model: liveModel, apiKey: liveApiKey, maxSteps: 10, temperature: 0.3 },
       db, chatReq, "/tmp", callbacks,
     );
 

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -35,6 +35,10 @@ export interface AgentLLMConfig {
   baseUrl: string;
   model: string;
   apiKey: string;
+  /** Maximum tool-call iterations per turn. Defaults to 20. */
+  maxSteps: number;
+  /** Sampling temperature. Plan mode overrides this to 0.1 for determinism. */
+  temperature: number;
 }
 
 // ── Message types ─────────────────────────────────────────────────────────────
@@ -107,26 +111,38 @@ const CODING_TOOL_DEFS = [
 ];
 
 // Cairn data tool names exposed to the coding agent.
-// Redundant tools (create_note, update_note, update_task_status, list_notes,
-// list_tasks, get_cairn_context) are excluded — see AGENT_EXCLUDED_TOOLS in
-// tool-schemas.ts. ensure_note / patch_note / search_* cover all use cases.
+// get_cairn_context is excluded (see AGENT_EXCLUDED_TOOLS) — agents use
+// get_project_context_pack instead. Delete tools are intentionally omitted
+// to prevent autonomous destructive actions.
 const CAIRN_TOOL_NAMES = new Set([
+  // ── Context / read ──────────────────────────────────────────────────────────
   "get_active_context",
   "get_project_context_pack",
+  "get_neighbors",
+  // ── Notes ───────────────────────────────────────────────────────────────────
   "get_note",
   "ensure_note",
   "patch_note",
   "append_to_note",
   "search_notes",
+  // ── Tasks ───────────────────────────────────────────────────────────────────
   "get_task",
   "create_task",
   "update_task",
+  "bulk_update_task_status",
   "search_tasks",
   "list_ready_tasks",
+  "link_note_to_task",
+  // ── Tags ────────────────────────────────────────────────────────────────────
+  "create_tag",
+  // ── Idea Flow ───────────────────────────────────────────────────────────────
   "get_idea_flow",
+  "get_idea_flow_rules",
   "create_idea_flow_node",
+  "update_idea_flow_node",
   "create_idea_flow_edge",
-  // Renderer-side only — main process no-ops; renderer renders an inline QuestionForm.
+  "layout_idea_flow",
+  // ── Renderer-side only — main process no-ops; renderer renders an inline QuestionForm.
   "ask_questions",
 ]);
 
@@ -220,8 +236,6 @@ async function executeSingleTool(
 
 // ── Main loop ─────────────────────────────────────────────────────────────────
 
-const MAX_STEPS = 30;
-
 export async function runAgentLoop(
   session: PiAgentSession,
   systemPrompt: string,
@@ -239,7 +253,9 @@ export async function runAgentLoop(
   const { signal } = session.abortCtrl;
   const allTools = getAllToolDefs(mode);
 
-  const { baseUrl, model, apiKey } = llmConfig;
+  const { baseUrl, model, apiKey, maxSteps, temperature: configTemp } = llmConfig;
+  // Plan mode always uses 0.1 for deterministic analysis regardless of user setting
+  const temperature = mode === "plan" ? 0.1 : (configTemp ?? 0.3);
   if (!apiKey && !isLocalEndpoint(baseUrl)) {
     callbacks.onError("No API key configured. Set one in Settings → AI & Chat.");
     return;
@@ -247,7 +263,7 @@ export async function runAgentLoop(
 
   let steps = 0;
 
-  while (steps < MAX_STEPS) {
+  while (steps < maxSteps) {
     if (signal.aborted) { callbacks.onDone(); return; }
     steps++;
     // From step 2 onwards, signal the renderer to finalise the previous
@@ -276,7 +292,7 @@ export async function runAgentLoop(
           tools: allTools,
           tool_choice: "auto",
           max_tokens: 8192,
-          temperature: 0.3,
+          temperature,
           stream: true,
           stream_options: { include_usage: true },
         }),
@@ -461,6 +477,6 @@ export async function runAgentLoop(
 
   // Exceeded max steps
   callbacks.onError(
-    `Reached the maximum of ${MAX_STEPS} steps. Any changes made have been saved. Try a more focused request.`
+    `Reached the maximum of ${maxSteps} steps. Any changes made have been saved. Try a more focused request.`
   );
 }

--- a/electron/lib/tools.ts
+++ b/electron/lib/tools.ts
@@ -85,7 +85,7 @@ export interface ChatRequest {
   projectId?: string;
   workspaceId?: string;
   history?: Array<{ role: "user" | "assistant" | "system"; content: string }>;
-  config?: { baseUrl?: string; model?: string; apiKey?: string; maxSteps?: number };
+  config?: { baseUrl?: string; model?: string; apiKey?: string; maxSteps?: number; temperature?: number };
   systemPrompt?: string;
 }
 

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -398,9 +398,11 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       taskTitle:   session.taskTitle !== "Ad-hoc session" ? session.taskTitle : undefined,
       mode:        session.mode ?? "execute",
       config: {
-        baseUrl: aiConfig.baseUrl || undefined,
-        model:   aiConfig.model   || undefined,
-        apiKey:  aiConfig.apiKey  || undefined,
+        baseUrl:     aiConfig.baseUrl     || undefined,
+        model:       aiConfig.model       || undefined,
+        apiKey:      aiConfig.apiKey      || undefined,
+        maxSteps:    aiConfig.maxSteps    ?? 20,
+        temperature: aiConfig.temperature ?? 0.3,
       },
     };
     window.electron?.piAgent.prompt(promptPayload);
@@ -448,9 +450,11 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       cwd:         session.cwd,
       taskTitle:   session.taskTitle !== "Ad-hoc session" ? session.taskTitle : undefined,
       config: {
-        baseUrl: aiConfig.baseUrl || undefined,
-        model:   aiConfig.model   || undefined,
-        apiKey:  aiConfig.apiKey  || undefined,
+        baseUrl:     aiConfig.baseUrl     || undefined,
+        model:       aiConfig.model       || undefined,
+        apiKey:      aiConfig.apiKey      || undefined,
+        maxSteps:    aiConfig.maxSteps    ?? 20,
+        temperature: aiConfig.temperature ?? 0.3,
       },
     });
   }

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -183,10 +183,11 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
       workspaceId: activeWorkspaceId,
       history: messages.slice(-40).map((m) => ({ role: m.role, content: m.content })),
       config: {
-        baseUrl: aiConfig.baseUrl || undefined,
-        model: aiConfig.model || undefined,
-        apiKey: aiConfig.apiKey || undefined,
-        maxSteps: aiConfig.maxSteps ?? 20,
+        baseUrl:     aiConfig.baseUrl     || undefined,
+        model:       aiConfig.model       || undefined,
+        apiKey:      aiConfig.apiKey      || undefined,
+        maxSteps:    aiConfig.maxSteps    ?? 20,
+        temperature: aiConfig.temperature ?? 0.3,
       },
     });
   }

--- a/src/components/notes/notes-view/PrdModal.tsx
+++ b/src/components/notes/notes-view/PrdModal.tsx
@@ -93,10 +93,11 @@ export function PrdModal({ projectId, workspaceId, onClose }: PrdModalProps) {
       workspaceId,
       history,
       config: {
-        baseUrl:  aiConfig.baseUrl  || "https://api.openai.com",
-        model:    aiConfig.model    || "gpt-4o-mini",
-        apiKey:   aiConfig.apiKey   || "",
-        maxSteps: aiConfig.maxSteps ?? 20,
+        baseUrl:     aiConfig.baseUrl     || "https://api.openai.com",
+        model:       aiConfig.model       || "gpt-4o-mini",
+        apiKey:      aiConfig.apiKey      || "",
+        maxSteps:    aiConfig.maxSteps    ?? 20,
+        temperature: aiConfig.temperature ?? 0.3,
       },
       systemPrompt: buildPrdSystemPrompt(projectId),
     });

--- a/src/components/settings/AISettings.tsx
+++ b/src/components/settings/AISettings.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from "react";
 import {
-  CheckCircle, RefreshCw, Key, Globe, Cpu, Wifi, WifiOff, Eye, EyeOff, Footprints, Layers, Thermometer, Terminal, MessageSquare,
+  CheckCircle, RefreshCw, Key, Globe, Cpu, Wifi, WifiOff, Eye, EyeOff, Footprints, Layers, Thermometer,
 } from "lucide-react";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useCairnStore } from "@/store";

--- a/src/components/settings/AISettings.tsx
+++ b/src/components/settings/AISettings.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from "react";
 import {
-  CheckCircle, RefreshCw, Key, Globe, Cpu, Wifi, WifiOff, Eye, EyeOff, Footprints, Layers,
+  CheckCircle, RefreshCw, Key, Globe, Cpu, Wifi, WifiOff, Eye, EyeOff, Footprints, Layers, Thermometer, Terminal, MessageSquare,
 } from "lucide-react";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useCairnStore } from "@/store";
@@ -10,11 +10,17 @@ import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import { SettingsGroup, SettingsRow, Toggle } from "./shared";
 import { MCPServerSettings } from "./MCPSettings";
+import type { ToggleableView } from "@/store/slices/ui";
 
 type TestState = "idle" | "testing" | "ok" | "error";
 
 export function AISettings() {
-  const { aiConfig, setAIConfig } = useCairnStore(useShallow((s) => ({ aiConfig: s.aiConfig, setAIConfig: s.setAIConfig })));
+  const { aiConfig, setAIConfig, hiddenViews, toggleViewVisibility } = useCairnStore(useShallow((s) => ({
+    aiConfig:             s.aiConfig,
+    setAIConfig:          s.setAIConfig,
+    hiddenViews:          s.hiddenViews,
+    toggleViewVisibility: s.toggleViewVisibility,
+  })));
   const [showKey, setShowKey] = useState(false);
   const [testState, setTestState] = useState<TestState>("idle");
   const [testError, setTestError] = useState("");
@@ -25,7 +31,7 @@ export function AISettings() {
   const [modelsFetched, setModelsFetched] = useState(false);
 
   // Always read directly from the store — no local shadow copy
-  const { baseUrl, model, apiKey, maxSteps, contextLimit, aiEnabled } = aiConfig;
+  const { baseUrl, model, apiKey, maxSteps, temperature, contextLimit, aiEnabled } = aiConfig;
   const isLocal =
     baseUrl.includes("localhost") ||
     baseUrl.includes("127.0.0.1") ||
@@ -78,20 +84,31 @@ export function AISettings() {
 
   return (
     <div className="space-y-8">
-      {/* ── Enable / disable all AI features ── */}
+      {/* ── Visibility ── */}
       <SettingsGroup
-        title="In-app AI"
-        description="Enable or disable all AI-powered features — chat, text actions, PRD generator, task spawning, and Idea Flow summaries."
+        title="Visibility"
+        description="Control which AI features and views are shown."
       >
         <SettingsRow
-          label="Enable AI features"
-          description="When off, all AI buttons and shortcuts are hidden. Formatting tools are unaffected."
+          label="Enable inline AI"
+          description="Shows AI buttons in the editor — text actions, PRD generator, task spawning, and Idea Flow AI summaries. Does not affect the Agent or Chat views."
         >
           <Toggle
             checked={aiEnabled ?? true}
             onChange={(v) => update({ aiEnabled: v })}
           />
         </SettingsRow>
+        {([
+          { view: "agent" as ToggleableView, label: "Agent view", description: "Embedded coding agent in the sidebar" },
+          { view: "chat"  as ToggleableView, label: "AI Chat view", description: "In-app AI chat panel" },
+        ]).map(({ view, label, description }) => {
+          const visible = !hiddenViews.has(view);
+          return (
+            <SettingsRow key={view} label={label} description={description}>
+              <Toggle checked={visible} onChange={() => toggleViewVisibility(view)} />
+            </SettingsRow>
+          );
+        })}
       </SettingsGroup>
 
       {/* ── Endpoint config ── */}
@@ -243,7 +260,7 @@ export function AISettings() {
         {/* Max steps */}
         <SettingsRow
           label="Max steps"
-          description="Tool-call rounds the agent can take per message. Lower values reduce API costs."
+          description="Tool-call rounds the agent can take per message. Use ∞ for complex multi-file tasks — but watch API costs."
         >
           <div className="flex flex-col gap-1.5 items-end">
             <div className="relative">
@@ -251,23 +268,74 @@ export function AISettings() {
               <input
                 type="number"
                 min={1}
-                max={50}
+                max={1000}
                 value={maxSteps ?? 20}
                 onChange={(e) => {
                   const v = parseInt(e.target.value, 10);
-                  if (!isNaN(v) && v >= 1 && v <= 50) update({ maxSteps: v });
+                  if (!isNaN(v) && v >= 1 && v <= 1000) update({ maxSteps: v });
                 }}
                 className="pl-7 pr-3 py-1.5 text-xs w-24 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent-dim)]"
               />
             </div>
             <div className="flex gap-1.5">
-              {[5, 10, 20].map((n) => (
+              {([10, 20, 30, 50] as const).map((n) => (
                 <button
                   key={n}
                   onClick={() => update({ maxSteps: n })}
                   className={cn(
                     "px-2 py-1 text-[0.714rem] rounded border transition-colors",
                     (maxSteps ?? 20) === n
+                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
+                      : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
+                  )}
+                >
+                  {n}
+                </button>
+              ))}
+              <button
+                onClick={() => update({ maxSteps: 1000 })}
+                className={cn(
+                  "px-2 py-1 text-[0.714rem] rounded border transition-colors",
+                  (maxSteps ?? 20) === 1000
+                    ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
+                    : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
+                )}
+              >
+                ∞
+              </button>
+            </div>
+          </div>
+        </SettingsRow>
+
+        {/* Temperature */}
+        <SettingsRow
+          label="Temperature"
+          description="Sampling temperature for the agent (0–1). Lower = more deterministic. Plan mode always uses 0.1 regardless of this setting."
+        >
+          <div className="flex flex-col gap-1.5 items-end">
+            <div className="relative">
+              <Thermometer size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
+              <input
+                type="number"
+                min={0}
+                max={1}
+                step={0.05}
+                value={temperature ?? 0.3}
+                onChange={(e) => {
+                  const v = parseFloat(e.target.value);
+                  if (!isNaN(v) && v >= 0 && v <= 1) update({ temperature: v });
+                }}
+                className="pl-7 pr-3 py-1.5 text-xs w-24 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent-dim)]"
+              />
+            </div>
+            <div className="flex gap-1.5">
+              {[0.1, 0.3, 0.5, 0.7].map((n) => (
+                <button
+                  key={n}
+                  onClick={() => update({ temperature: n })}
+                  className={cn(
+                    "px-2 py-1 text-[0.714rem] rounded border transition-colors",
+                    (temperature ?? 0.3) === n
                       ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
                       : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
                   )}
@@ -282,7 +350,7 @@ export function AISettings() {
         {/* Context window */}
         <SettingsRow
           label="Context window"
-          description="Token limit of your model. Used to display the context usage ring in the agent pane."
+          description="Token limit of your model. Used to display the context usage ring in the coding agent — does not truncate or limit API calls."
         >
           <div className="flex flex-col gap-1.5 items-end">
             <div className="relative">

--- a/src/components/settings/MCPSettings.tsx
+++ b/src/components/settings/MCPSettings.tsx
@@ -244,7 +244,7 @@ export function MCPProjectConfig() {
             .filter((p) => !p.archivedAt)
             .map((p) => (
               <option key={p.id} value={p.id}>
-                {p.icon ? `${p.icon} ` : ""}{p.name}
+                {p.name}
               </option>
             ))}
         </select>

--- a/src/components/settings/ViewVisibilitySettings.tsx
+++ b/src/components/settings/ViewVisibilitySettings.tsx
@@ -5,7 +5,7 @@
  * Overview and Notes are always visible and shown as locked.
  */
 
-import { Kanban, Workflow, Terminal, GitBranch, BarChart2, MessageSquare, Lock } from "lucide-react";
+import { Kanban, Workflow, GitBranch, BarChart2, Lock } from "lucide-react";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import type { ToggleableView } from "@/store/slices/ui";
@@ -43,10 +43,8 @@ interface ViewOption {
 const VIEW_OPTIONS: ViewOption[] = [
   { view: "board",    label: "Board",           description: "Kanban task board",               icon: <Kanban size={13} /> },
   { view: "flow",     label: "Idea Flow",        description: "Visual node graph for ideas",     icon: <Workflow size={13} /> },
-  { view: "agent",    label: "Agent",            description: "Embedded coding agent terminal",  icon: <Terminal size={13} /> },
   { view: "graph",    label: "Knowledge Graph",  description: "Workspace-wide connection graph", icon: <GitBranch size={13} /> },
   { view: "insights", label: "Insights",         description: "Analytics and progress charts",   icon: <BarChart2 size={13} /> },
-  { view: "chat",     label: "AI Chat",          description: "In-app AI chat panel",            icon: <MessageSquare size={13} /> },
 ];
 
 export function ViewVisibilitySettings() {
@@ -55,7 +53,7 @@ export function ViewVisibilitySettings() {
   return (
     <SettingsGroup
       title="Views"
-      description="Choose which views appear in the sidebar. Overview and Notes are always shown."
+      description="Choose which views appear in the sidebar. Overview and Notes are always shown. Agent and AI Chat are managed in AI & Chat settings."
     >
       {/* Always-on rows */}
       {(["Overview", "Notes"] as const).map((label) => (

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -43,6 +43,7 @@ export interface ChatStreamRequest {
     model?: string;
     apiKey?: string;
     maxSteps?: number;
+    temperature?: number;
   };
   systemPrompt?: string;
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -73,6 +73,7 @@ export const DEFAULT_AI_CONFIG: AIConfig = {
   model:        "gpt-4o-mini",
   apiKey:       "",
   maxSteps:     20,
+  temperature:  0.3,
   contextLimit: 128000,
   aiEnabled:    true,
 };

--- a/src/store/slices/ui.ts
+++ b/src/store/slices/ui.ts
@@ -28,6 +28,8 @@ export interface AIConfig {
   apiKey: string;
   /** Maximum tool-call rounds per chat message. Lower = fewer API calls = lower cost. */
   maxSteps: number;
+  /** LLM sampling temperature (0–1). Lower = more deterministic. Applied to the agent loop. */
+  temperature: number;
   /** Context window size in tokens. Used to render the context usage ring. */
   contextLimit: number;
   /** When false, all in-app AI features are hidden/disabled. Defaults to true. */


### PR DESCRIPTION
## What does this PR do?

Wires `temperature` and `maxSteps` through the full AI call stack (Pi agent, chat panel, PRD modal) so both settings are actually respected everywhere. Expands the Pi agent's Cairn tool set with 7 previously missing tools, fixes the MCP project selector showing icon component names instead of project names, and reorganises AI & Chat settings so all AI-related visibility toggles live in one place.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code quality

## Screenshots / recording

<!-- Settings → AI & Chat now shows a Visibility group at the top with Enable inline AI, Agent view, and AI Chat view toggles. Temperature row added below Max steps. -->

## Checklist

- [x] `npm run type-check` passes
- [x] `npm test` passes
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

- `AgentLLMConfig` gained two required fields (`maxSteps`, `temperature`) — the pi-agent-loop tests needed updating to supply them; all 394 tests pass.
- Pi agent plan mode hard-codes `temperature = 0.1` regardless of user setting — this is intentional for deterministic codebase analysis.
- Max steps ∞ preset maps to `1000` in the store — the input accepts 1–1000.
- The 7 new `CAIRN_TOOL_NAMES` additions (e.g. `get_neighbors`, `layout_idea_flow`) do not require any new IPC handlers — they all route through the existing `executeTool` path.