### PR TITLE
feat(agent): Pi agent harness improvements — compaction, retry, parallel tools, diff output, bash cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,7 @@ Cairn has two processes that share the same `cairn.db` (SQLite WAL mode):
 **Cairn native agent** — a stateful multi-turn tool-call loop running entirely in the main process. No external binary required. Session type `"pi"` in the terminal sessions store; rendered by `PiAgentPane` instead of xterm. Key files:
 
 - `electron/ipc/pi-agent.ts` — IPC handler; `sessions Map<sessionId, PiAgentSession>`; registers all `pi-agent:*` channels
-- `electron/lib/pi-agent-loop.ts` — `runAgentLoop()`; SSE stream parsing; tool execution; callbacks (`onToken`, `onToolsReady`, `onToolPending`, `onToolStart`, `onToolEnd`, `onStepStart`, `onUsage`, `onSubagent`, `onDone`, `onError`)
+- `electron/lib/pi-agent-loop.ts` — `runAgentLoop()`; SSE stream parsing; parallel tool execution (`Promise.all`); callbacks (`onToken`, `onToolsReady`, `onToolPending`, `onToolStart`, `onToolEnd`, `onStepStart`, `onUsage`, `onRetry`, `onSubagent`, `onDone`, `onError`); `transformContext` hook; `AgentToolContext` groups all per-session infrastructure
 - `electron/lib/pi-agent-prompt.ts` — system prompt builder; mandatory Cairn workflow injected here
 - `electron/lib/coding-tools/` — 7 ported file-system tools (`read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`) + `spawn_subagent` + `file-mutex.ts`
 
@@ -361,7 +361,8 @@ Shared modules live in `src/components/graph/`: `analyticsUtils.ts`, `analyticsH
 | `electron/ipc/chat.ts` | AI chat loop — `runToolLoop` + IPC handler registration |
 | `electron/ipc/chat-executor.ts` | `executeTool` — all AI tool implementations |
 | `electron/ipc/pi-agent.ts` | Cairn native agent IPC handler — `sessions` Map, all `pi-agent:*` channels |
-| `electron/lib/pi-agent-loop.ts` | `runAgentLoop()` — multi-turn SSE loop, tool execution, all callbacks; `onToolPending` fires during streaming |
+| `electron/lib/pi-agent-loop.ts` | `runAgentLoop()` — multi-turn SSE loop, parallel tool execution, callbacks, retry, `transformContext` hook; `AgentToolContext` groups cwd/db/IPC/session state |
+| `electron/lib/compaction.ts` | `buildCompactionTransformer` — async LLM-based context compaction; fires `pi-agent:compact` events; falls back to sliding-window pruner while summary is in flight |
 | `electron/lib/pi-agent-prompt.ts` | System prompt builder; mandatory Cairn workflow; `spawn_subagent` description |
 | `electron/lib/coding-tools/` | 8 coding tools (`read`, `write`, `edit`, `bash`, `grep`, `find`, `ls`, `spawn_subagent`) + `file-mutex.ts` |
 | `electron/lib/llm.ts` | `LLMConfig`, `callLLM`, `streamCompletion`, `isLocalEndpoint`, `normaliseBaseUrl` |
@@ -569,10 +570,18 @@ renderer                         main process
    │                                  │  if more turns:
    │ ◄── pi-agent:step ───────────────┤    seal message, start next
    │ ◄── pi-agent:usage ──────────────┤    token counts → context ring
+   │ ◄── pi-agent:retry ──────────────┤    (on transient error) countdown badge
+   │ ◄── pi-agent:compact ────────────┤    (when compaction fires) "Compacting…" indicator
    │ ◄── pi-agent:done ───────────────┤  turn complete
 ```
 
 The `pending` status fires during streaming as soon as a tool name is seen in the SSE delta — this is what makes the chip appear immediately rather than waiting for the full response. The `start` event reuses the same `callId` to update the chip's label to the resolved human-readable version once argument parsing is complete.
+
+**Parallel tool execution** — all tool calls in a single assistant turn run concurrently via `Promise.all` in `executeSingleTool`. Results are appended to `session.messages` in source order regardless of completion order. Per-file serialisation is handled transparently by `file-mutex.ts`.
+
+**Automatic retry** — `isRetryable(status, body)` in `pi-agent-loop.ts` detects transient errors (429, 5xx, overloaded/rate-limit body patterns). Up to `AgentLLMConfig.maxRetries` attempts (default 3) with exponential backoff starting at `baseRetryDelayMs` (default 2000 ms). `onRetry` callback fires before each sleep; `pi-agent:retry` is emitted to the renderer.
+
+**Context compaction** — `buildCompactionTransformer` in `electron/lib/compaction.ts` returns a `transformContext` function passed to `runAgentLoop`. When `session.lastPromptTokens` exceeds 80% of `llmConfig.contextWindow`, it fires a background LLM summarisation call (non-streaming, `temperature: 0.1`). The current turn uses a sliding-window fallback; subsequent turns use the cached summary. `onCompactionStart`/`onCompactionEnd` fire `pi-agent:compact` events to the renderer. To change the threshold or number of verbatim turns preserved, edit `COMPACT_THRESHOLD` and `KEEP_RECENT_TURNS` in `compaction.ts`.
 
 **Subagents**
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Cairn is a desktop app (Electron + Next.js) that combines markdown notes with a 
 - **Idea Flow** — Freeform node canvas per project (`⌘4`): ideas, note/task refs, groups, URLs, AI summaries — connected with labelled edges
 - **Live dashboards** — AI-generated interactive HTML dashboards with a live `window.cairn.query()` data bridge; inline "Fix with AI" on runtime errors; editable via built-in CodeMirror overlay
 - **MCP server** — Exposes your workspace to external AI agents (OpenCode, Claude Desktop, etc.) via the Model Context Protocol
-- **Cairn Agent** — Native coding agent (`⌘5`) with board and notes integration: moves tasks, writes session notes, captures discovered work; supports subagents for deep sub-tasks; Plan Mode writes a PRD note before coding; context usage ring; works with any OpenAI-compatible endpoint
+- **Cairn Agent** — Native coding agent (`⌘5`) with board and notes integration: moves tasks, writes session notes, captures discovered work; supports subagents for deep sub-tasks; Plan Mode writes a PRD note before coding; automatic retry on transient API errors; LLM-based context compaction for long sessions; context usage ring; works with any OpenAI-compatible endpoint
 - **Agent workspace** — Three-pane view (`⌘5`) for running external AI coding agents (Claude Code, OpenCode, Aider, or any CLI) connected to project tasks; file tree, multi-file CodeMirror 6 editor, xterm.js terminal, and git diff viewer
 - **Knowledge Graph** — Workspace-wide graph of every note, card, project, and tag; Force-directed and Radial tree layouts; auto-discovered relationships (`⌘6`)
 - **Insights** — Analytics view: Ridgeline joy plot, Beeswarm, Bullet health bars, Sankey pipeline flow, Timeline, Matrix heatmap, Table (`⌘7`)
@@ -136,6 +136,8 @@ The agent can delegate contained sub-tasks to a fresh sub-agent via `spawn_subag
 ### Context usage ring
 
 A small ring in the agent pane header shows how full the model's context window is after each step. Configure the limit for your model in **Settings → AI & Chat → Context window** (presets: 8k / 32k / 128k / 200k).
+
+When usage reaches 80% the agent automatically summarises older context with a background LLM call — the status bar shows `"Compacting context…"` while this is in flight. If a transient API error occurs, the status bar shows a countdown (`"Transient error — retrying (1/3) in 8s…"`) and the agent retries automatically.
 
 ## MCP server
 

--- a/changelogs/v1.3.0.md
+++ b/changelogs/v1.3.0.md
@@ -1,0 +1,37 @@
+# v1.3.0
+
+## What's new
+
+### Features
+
+- **LLM-based context compaction** — long Pi agent sessions no longer hit the context window ceiling. When token usage reaches 80% of the model's context window, the agent automatically summarises the oldest portion of the conversation with a lightweight non-streaming LLM call. The summary is injected as a structured context block; the 6 most recent turns are always preserved verbatim. Compaction runs asynchronously (fire-and-forget) so the current turn is never blocked — a sliding-window fallback is used for that turn if the summary isn't ready yet. A `"Compacting context…"` indicator appears in the Pi agent status bar while the summary call is in flight.
+
+- **Automatic retry with exponential backoff** — transient API errors (429, 500, 502, 503, 504, overloaded/rate-limit body patterns) are now retried automatically instead of failing the session. Up to 3 retries with 2 s / 4 s / 8 s backoff. A countdown badge (`"Transient error — retrying (1/3) in 8s…"`) appears in the status bar and is cleared when the retry succeeds. Abort cancels any in-progress sleep cleanly.
+
+- **Parallel tool execution** — all tool calls in a single assistant turn now run concurrently via `Promise.all`. Tool result messages are appended in original source order regardless of completion order. `onToolEnd` fires as each tool completes. Per-file serialisation is handled transparently by the existing file mutex.
+
+- **Edit tool unified diff** — the `edit` tool now returns a unified diff alongside the success confirmation, so the model and the user can see exactly what changed in each edit operation. The diff is generated inline using an LCS-based algorithm (no new dependencies).
+
+- **Bash process-group cleanup** — bash subprocesses are now spawned with `detached: true` on Unix, and their PIDs are tracked via `trackPid`/`untrackPid`. All tracked processes are killed as a process group (`process.kill(-pid, "SIGKILL")`) on app quit via `before-quit`, preventing zombie shells from surviving after Cairn exits.
+
+- **`transformContext` hook** — `AgentLoopCallbacks` gains an optional `transformContext?: (messages: AgentMessage[]) => AgentMessage[]` hook that runs on the session message history before each LLM call without mutating the stored history. Used internally by both the compaction transformer and the sliding-window pruner.
+
+- **System prompt fix** — the Pi agent system prompt is now passed as the `system:` field in the OpenAI request body rather than prepended as a `user` message, matching the OpenAI API specification.
+
+### Fixes
+
+- **Test suite aligned to refactored signature** — `pi-agent-loop.test.ts` was calling `runAgentLoop` with the old positional parameter signature after the `AgentToolContext` refactor. All 10 call sites updated; 394/394 tests pass.
+
+- **Lint clean** — removed unused `contextWindow` parameter from `slidingWindowFallback` in `compaction.ts`; prefixed unused `getWin` destructuring in `pi-agent-loop.ts` to satisfy the `no-unused-vars` rule.
+
+### Changes
+
+- `electron/lib/pi-agent-loop.ts` — `AgentToolContext` interface introduced (groups `cwd`, `db`, `req`, `workspacePath`, `sessionId`, `send`, `getWin?`); `runAgentLoop` signature reduced from 11 to 6 parameters; `AgentLLMConfig` gains `maxRetries?`, `baseRetryDelayMs?`, `contextWindow?`; `AgentLoopCallbacks` gains `onRetry?`, `transformContext?`; `PiAgentSession` gains `lastPromptTokens?`; sequential tool loop replaced with `Promise.all`; `isRetryable()` and `sleep()` helpers added; sliding-window pruner built in as default fallback when no `transformContext` is provided
+- `electron/lib/compaction.ts` — new file; exports `buildCompactionTransformer`, `COMPACT_THRESHOLD`, `FALLBACK_KEEP_TURNS`, `FALLBACK_THRESHOLD`
+- `electron/lib/coding-tools/bash.ts` — `detached: true` on non-Windows; `trackPid`/`untrackPid`/`killTrackedBashProcesses` added
+- `electron/lib/coding-tools/edit.ts` — `generateUnifiedDiff()` (inline LCS) added; edit tool returns diff in output
+- `electron/ipc/pi-agent.ts` — `buildCompactionTransformer` wired into both `runAgentLoop` calls; `pi-agent:compact` and `pi-agent:retry` IPC events emitted
+- `electron/preload.ts` — `onCompact` bridge added to `piAgent` API
+- `electron/main.ts` — `before-quit` handler calls `killTrackedBashProcesses()`
+- `src/components/agent/PiAgentPane.tsx` — retry countdown UI; `isCompacting` state wired to `onCompact`; `"Compacting context…"` shown in status bar
+- `electron/lib/pi-agent-loop.test.ts` — all `runAgentLoop` call sites updated to new `AgentToolContext` signature; `makeToolCtx` helper added

--- a/electron/ipc/pi-agent.ts
+++ b/electron/ipc/pi-agent.ts
@@ -14,10 +14,12 @@
  *   pi-agent:done      { sessionId }
  *   pi-agent:error     { sessionId, error: string }
  *   pi-agent:retry     { sessionId, attempt: number, maxRetries: number, delayMs: number, error: string }
+ *   pi-agent:compact   { sessionId, status: "start" | "end" }
  */
 
 import { ipcMain } from "electron";
 import { runAgentLoop, type PiAgentSession, type AgentLLMConfig, type AgentToolContext } from "../lib/pi-agent-loop";
+import { buildCompactionTransformer } from "../lib/compaction";
 import { buildPiAgentSystemPrompt } from "../lib/pi-agent-prompt";
 import { normaliseBaseUrl } from "../lib/llm";
 import type { ChatRequest } from "../lib/tools";
@@ -156,6 +158,14 @@ export function registerPiAgentHandler(
       getWin,
     };
 
+    const transformContext = buildCompactionTransformer(
+      session,
+      llmConfig,
+      session.abortCtrl.signal,
+      () => send("pi-agent:compact", { sessionId, status: "start" }),
+      () => send("pi-agent:compact", { sessionId, status: "end" }),
+    );
+
     await runAgentLoop(
       session,
       systemPrompt,
@@ -182,6 +192,7 @@ export function registerPiAgentHandler(
         onStepStart:     () => send("pi-agent:step",  { sessionId }),
         onUsage:         (promptTokens, completionTokens) => send("pi-agent:usage", { sessionId, promptTokens, completionTokens }),
         onRetry:         (attempt, maxRetries, delayMs, error) => send("pi-agent:retry", { sessionId, attempt, maxRetries, delayMs, error }),
+        transformContext,
         onDone: () => {
           try {
             q.saveLlmHistory(ctx.db, sessionId, session.messages);
@@ -287,6 +298,14 @@ export function registerPiAgentHandler(
       getWin,
     };
 
+    const transformContext = buildCompactionTransformer(
+      session,
+      llmConfig,
+      session.abortCtrl.signal,
+      () => send("pi-agent:compact", { sessionId, status: "start" }),
+      () => send("pi-agent:compact", { sessionId, status: "end" }),
+    );
+
     await runAgentLoop(
       session,
       systemPrompt,
@@ -313,6 +332,7 @@ export function registerPiAgentHandler(
         onStepStart:     () => send("pi-agent:step",  { sessionId }),
         onUsage:         (promptTokens, completionTokens) => send("pi-agent:usage", { sessionId, promptTokens, completionTokens }),
         onRetry:         (attempt, maxRetries, delayMs, error) => send("pi-agent:retry", { sessionId, attempt, maxRetries, delayMs, error }),
+        transformContext,
         onDone: () => {
           try {
             q.saveLlmHistory(ctx.db, sessionId, session.messages);

--- a/electron/ipc/pi-agent.ts
+++ b/electron/ipc/pi-agent.ts
@@ -13,10 +13,11 @@
  *   pi-agent:tool      { sessionId, name: string, label: string, status: "start"|"end", ok?: boolean }
  *   pi-agent:done      { sessionId }
  *   pi-agent:error     { sessionId, error: string }
+ *   pi-agent:retry     { sessionId, attempt: number, maxRetries: number, delayMs: number, error: string }
  */
 
 import { ipcMain } from "electron";
-import { runAgentLoop, type PiAgentSession, type AgentLLMConfig } from "../lib/pi-agent-loop";
+import { runAgentLoop, type PiAgentSession, type AgentLLMConfig, type AgentToolContext } from "../lib/pi-agent-loop";
 import { buildPiAgentSystemPrompt } from "../lib/pi-agent-prompt";
 import { normaliseBaseUrl } from "../lib/llm";
 import type { ChatRequest } from "../lib/tools";
@@ -145,14 +146,20 @@ export function registerPiAgentHandler(
       },
     };
 
+    const toolCtx: AgentToolContext = {
+      cwd,
+      db:            ctx.db,
+      req:           chatReq,
+      workspacePath: ctx.workspacePath,
+      sessionId,
+      send,
+      getWin,
+    };
+
     await runAgentLoop(
       session,
       systemPrompt,
-      cwd,
       llmConfig,
-      ctx.db,
-      chatReq,
-      ctx.workspacePath,
       {
         onToken:         (delta) => send("pi-agent:token",      { sessionId, delta }),
         onToolsReady:    ()     => send("pi-agent:tools-ready", { sessionId }),
@@ -174,6 +181,7 @@ export function registerPiAgentHandler(
         },
         onStepStart:     () => send("pi-agent:step",  { sessionId }),
         onUsage:         (promptTokens, completionTokens) => send("pi-agent:usage", { sessionId, promptTokens, completionTokens }),
+        onRetry:         (attempt, maxRetries, delayMs, error) => send("pi-agent:retry", { sessionId, attempt, maxRetries, delayMs, error }),
         onDone: () => {
           try {
             q.saveLlmHistory(ctx.db, sessionId, session.messages);
@@ -197,9 +205,7 @@ export function registerPiAgentHandler(
           try { q.updatePiSession(ctx.db, sessionId, { planNoteId: noteId, updatedAt: ts() }); } catch { /* non-critical */ }
         },
       },
-      getWin,
-      sessionId,
-      send,
+      toolCtx,
       mode,
     );
   });
@@ -271,14 +277,20 @@ export function registerPiAgentHandler(
       config: { baseUrl: llmConfig.baseUrl, model: llmConfig.model, apiKey: llmConfig.apiKey },
     };
 
+    const toolCtx: AgentToolContext = {
+      cwd,
+      db:            ctx.db,
+      req:           chatReq,
+      workspacePath: ctx.workspacePath,
+      sessionId,
+      send,
+      getWin,
+    };
+
     await runAgentLoop(
       session,
       systemPrompt,
-      cwd,
       llmConfig,
-      ctx.db,
-      chatReq,
-      ctx.workspacePath,
       {
         onToken:       (delta) => send("pi-agent:token",      { sessionId, delta }),
         onToolsReady:  ()     => send("pi-agent:tools-ready", { sessionId }),
@@ -300,6 +312,7 @@ export function registerPiAgentHandler(
         },
         onStepStart:     () => send("pi-agent:step",  { sessionId }),
         onUsage:         (promptTokens, completionTokens) => send("pi-agent:usage", { sessionId, promptTokens, completionTokens }),
+        onRetry:         (attempt, maxRetries, delayMs, error) => send("pi-agent:retry", { sessionId, attempt, maxRetries, delayMs, error }),
         onDone: () => {
           try {
             q.saveLlmHistory(ctx.db, sessionId, session.messages);
@@ -323,9 +336,7 @@ export function registerPiAgentHandler(
           try { q.updatePiSession(ctx.db, sessionId, { planNoteId: noteId, updatedAt: ts() }); } catch { /* non-critical */ }
         },
       },
-      getWin,
-      sessionId,
-      send,
+      toolCtx,
       "execute",
     );
   });

--- a/electron/lib/coding-tools/bash.ts
+++ b/electron/lib/coding-tools/bash.ts
@@ -2,14 +2,49 @@
  * bash tool — execute shell commands with streaming output + abort.
  *
  * Ported from pi packages/coding-agent/src/core/tools/bash.ts
- * Keeps: output truncation, abort signal, timeout, streaming onUpdate.
- * Removed: TUI rendering, TypeBox schemas, pluggable Operations.
+ * Keeps: output truncation, abort signal, timeout, streaming onUpdate,
+ *        process-group kill (sends SIGKILL to the entire process tree so
+ *        child processes spawned by the command are also terminated),
+ *        detached-PID tracking (so in-flight children are killed on app exit).
  */
 
 import { spawn } from "child_process";
 
 const MAX_OUTPUT_BYTES = 50_000;
 const DEFAULT_TIMEOUT_MS = 120_000; // 2 minutes
+
+// ── Detached child PID tracking ───────────────────────────────────────────────
+// Tracks PIDs of spawned children so they can be killed on app shutdown.
+
+const trackedPids = new Set<number>();
+
+function trackPid(pid: number): void { trackedPids.add(pid); }
+function untrackPid(pid: number): void { trackedPids.delete(pid); }
+
+/** Kill a process and all its children cross-platform. */
+function killProcessTree(pid: number): void {
+  if (process.platform === "win32") {
+    try {
+      spawn("taskkill", ["/F", "/T", "/PID", String(pid)], { stdio: "ignore", detached: true });
+    } catch { /* ignore */ }
+  } else {
+    // Negative PID kills the entire process group
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      // Fallback: kill just the direct child if process-group kill fails
+      try { process.kill(pid, "SIGKILL"); } catch { /* already dead */ }
+    }
+  }
+}
+
+/** Called during Electron app shutdown to clean up any lingering children. */
+export function killTrackedBashProcesses(): void {
+  for (const pid of trackedPids) killProcessTree(pid);
+  trackedPids.clear();
+}
+
+// ── Tool implementation ───────────────────────────────────────────────────────
 
 export interface BashArgs {
   command: string;
@@ -40,9 +75,14 @@ export async function bashTool(
 
     const child = spawn("bash", ["-c", args.command], {
       cwd,
+      // detached: true creates a new process group so process.kill(-pid) reaches
+      // all children spawned by the command, not just the direct bash process.
+      detached: process.platform !== "win32",
       env: { ...process.env, TERM: "xterm-256color" },
       stdio: ["ignore", "pipe", "pipe"],
     });
+
+    if (child.pid) trackPid(child.pid);
 
     const onData = (chunk: Buffer) => {
       const text = chunk.toString("utf8");
@@ -65,21 +105,26 @@ export async function bashTool(
     child.stdout.on("data", onData);
     child.stderr.on("data", onData);
 
+    const doKill = () => {
+      if (child.pid) killProcessTree(child.pid);
+    };
+
     const timer = setTimeout(() => {
-      child.kill("SIGKILL");
+      doKill();
       reject(new Error(`Command timed out after ${args.timeout ?? DEFAULT_TIMEOUT_MS / 1000} seconds\n\n${output}`));
     }, timeoutMs);
 
     const abortHandler = () => {
       clearTimeout(timer);
-      child.kill("SIGKILL");
+      doKill();
       reject(new Error(`Command aborted\n\n${output}`));
     };
-    signal?.addEventListener("abort", abortHandler);
+    signal?.addEventListener("abort", abortHandler, { once: true });
 
     child.on("close", (code) => {
       clearTimeout(timer);
       signal?.removeEventListener("abort", abortHandler);
+      if (child.pid) untrackPid(child.pid);
       if (signal?.aborted) return; // already rejected above
       if (code !== 0 && code !== null) {
         reject(new Error(`Command exited with code ${code}\n\n${output}`));
@@ -91,6 +136,7 @@ export async function bashTool(
     child.on("error", (err) => {
       clearTimeout(timer);
       signal?.removeEventListener("abort", abortHandler);
+      if (child.pid) untrackPid(child.pid);
       reject(new Error(`Failed to execute command: ${err.message}`));
     });
   });

--- a/electron/lib/coding-tools/edit.ts
+++ b/electron/lib/coding-tools/edit.ts
@@ -3,6 +3,7 @@
  *
  * Ported from pi packages/coding-agent/src/core/tools/edit.ts
  * Keeps: diff-based edit, file mutex, BOM/line-ending normalisation.
+ * Added: unified diff returned in tool output so the model can verify its edits.
  * Removed: TUI rendering, TypeBox schemas, pluggable Operations.
  */
 
@@ -62,6 +63,113 @@ function applyEdits(content: string, edits: EditEntry[]): string {
   return result;
 }
 
+// ── Minimal unified diff ──────────────────────────────────────────────────────
+
+const DIFF_CONTEXT_LINES = 3;
+
+/**
+ * Generate a compact unified diff between two strings.
+ * No external dependencies — uses a simple LCS-based line diff.
+ */
+function generateUnifiedDiff(oldContent: string, newContent: string, filePath: string): string {
+  const oldLines = oldContent.split("\n");
+  const newLines = newContent.split("\n");
+
+  // Build LCS table (Myers-style, but simple DP for correctness)
+  const m = oldLines.length;
+  const n = newLines.length;
+
+  // For large files use a heuristic: only diff changed regions to stay fast
+  // dp[i][j] = length of LCS of oldLines[0..i-1] and newLines[0..j-1]
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = oldLines[i - 1] === newLines[j - 1]
+        ? dp[i - 1][j - 1] + 1
+        : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+
+  // Backtrack to get edit script
+  type Op = { type: "eq" | "del" | "ins"; line: string };
+  const ops: Op[] = [];
+  let i = m, j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      ops.push({ type: "eq", line: oldLines[i - 1] });
+      i--; j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      ops.push({ type: "ins", line: newLines[j - 1] });
+      j--;
+    } else {
+      ops.push({ type: "del", line: oldLines[i - 1] });
+      i--;
+    }
+  }
+  ops.reverse();
+
+  // Group into hunks with context
+  const hunks: string[] = [];
+  let hunkLines: string[] = [];
+  let oldLine = 1, newLine = 1;
+  let hunkOldStart = 1, hunkNewStart = 1;
+  let inHunk = false;
+
+  const flushHunk = () => {
+    if (hunkLines.length > 0) {
+      const oldCount = hunkLines.filter(l => l.startsWith("-") || l.startsWith(" ")).length;
+      const newCount = hunkLines.filter(l => l.startsWith("+") || l.startsWith(" ")).length;
+      hunks.push(`@@ -${hunkOldStart},${oldCount} +${hunkNewStart},${newCount} @@\n${hunkLines.join("\n")}`);
+      hunkLines = [];
+    }
+    inHunk = false;
+  };
+
+  let pendingContext: string[] = [];
+
+  for (const op of ops) {
+    if (op.type === "eq") {
+      if (inHunk) {
+        hunkLines.push(` ${op.line}`);
+        pendingContext.push(` ${op.line}`);
+        if (pendingContext.length > DIFF_CONTEXT_LINES * 2) {
+          // Too much context — flush hunk and start fresh
+          flushHunk();
+          pendingContext = pendingContext.slice(-DIFF_CONTEXT_LINES);
+        }
+      } else {
+        pendingContext.push(` ${op.line}`);
+        if (pendingContext.length > DIFF_CONTEXT_LINES) pendingContext.shift();
+      }
+      oldLine++;
+      newLine++;
+    } else {
+      if (!inHunk) {
+        // Start new hunk — include trailing context from before
+        hunkOldStart = oldLine - pendingContext.length;
+        hunkNewStart = newLine - pendingContext.length;
+        hunkLines = [...pendingContext];
+        pendingContext = [];
+        inHunk = true;
+      }
+      if (op.type === "del") {
+        hunkLines.push(`-${op.line}`);
+        oldLine++;
+      } else {
+        hunkLines.push(`+${op.line}`);
+        newLine++;
+      }
+    }
+  }
+  flushHunk();
+
+  if (hunks.length === 0) return "";
+
+  return `--- a/${filePath}\n+++ b/${filePath}\n${hunks.join("\n")}`;
+}
+
+// ── Tool ──────────────────────────────────────────────────────────────────────
+
 export async function editTool(args: EditArgs, cwd: string): Promise<string> {
   if (!args.edits || args.edits.length === 0) {
     throw new Error("edit: edits array must not be empty");
@@ -88,8 +196,11 @@ export async function editTool(args: EditArgs, cwd: string): Promise<string> {
     const final = (hasBom ? "\uFEFF" : "") + restore(updated, lineEnding);
     fs.writeFileSync(filePath, final, "utf8");
 
+    const diff = generateUnifiedDiff(normalised, updated, args.path);
     const editCount = args.edits.length;
-    return `Applied ${editCount} edit${editCount === 1 ? "" : "s"} to ${args.path}`;
+    const summary = `Applied ${editCount} edit${editCount === 1 ? "" : "s"} to ${args.path}`;
+
+    return diff ? `${summary}\n\n${diff}` : summary;
   });
 }
 
@@ -100,7 +211,8 @@ export const editToolDefinition = {
     description:
       "Make targeted string replacements in a file. Each edit replaces an exact oldText with newText. " +
       "oldText must match exactly — include enough surrounding lines to make it unique. " +
-      "Always read the file first to get the exact content.",
+      "Always read the file first to get the exact content. " +
+      "Returns a unified diff of all changes made.",
     parameters: {
       type: "object",
       properties: {

--- a/electron/lib/coding-tools/subagent.ts
+++ b/electron/lib/coding-tools/subagent.ts
@@ -10,10 +10,7 @@
  */
 
 import { randomBytes } from "crypto";
-import type Database from "better-sqlite3";
-import type { BrowserWindow } from "electron";
-import { runAgentLoop, type PiAgentSession, type AgentLLMConfig } from "../pi-agent-loop";
-import type { ChatRequest } from "../tools";
+import { runAgentLoop, type PiAgentSession, type AgentLLMConfig, type AgentToolContext } from "../pi-agent-loop";
 
 export interface SpawnSubagentArgs {
   prompt: string;
@@ -55,25 +52,26 @@ export const spawnSubagentDefinition = {
 
 export async function spawnSubagentTool(
   args: SpawnSubagentArgs,
-  parentCwd: string,
+  parentToolCtx: AgentToolContext,
   parentLlmConfig: AgentLLMConfig,
-  db: Database.Database,
-  parentReq: ChatRequest,
-  workspacePath: string,
-  parentSessionId: string,
-  send: (channel: string, payload: unknown) => void,
-  getWin?: () => BrowserWindow | null,
 ): Promise<string> {
-  const childSessionId = `${parentSessionId}:sub:${randomBytes(4).toString("hex")}`;
-  const cwd = args.cwd ?? parentCwd;
+  const childSessionId = `${parentToolCtx.sessionId}:sub:${randomBytes(4).toString("hex")}`;
+
+  const childToolCtx: AgentToolContext = {
+    ...parentToolCtx,
+    cwd:       args.cwd ?? parentToolCtx.cwd,
+    sessionId: childSessionId,
+    req:       { ...parentToolCtx.req, threadId: childSessionId },
+  };
+
   const llmConfig: AgentLLMConfig = {
     ...parentLlmConfig,
     model: args.model ?? parentLlmConfig.model,
   };
 
   // Tell the renderer a subagent is starting
-  send("pi-agent:subagent", {
-    parentSessionId,
+  parentToolCtx.send("pi-agent:subagent", {
+    parentSessionId: parentToolCtx.sessionId,
     childSessionId,
     status: "start",
   });
@@ -87,46 +85,43 @@ export async function spawnSubagentTool(
     "You are a focused sub-agent. Complete the given task thoroughly, use tools as needed, " +
     "then respond with a clear, concise final answer. Do not ask clarifying questions.";
 
-  let finalAnswer = "";
   let errorMessage = "";
 
   await runAgentLoop(
     session,
     systemPrompt,
-    cwd,
     llmConfig,
-    db,
-    { ...parentReq, threadId: childSessionId },
-    workspacePath,
     {
-      onToken:       (delta) => send("pi-agent:token",      { sessionId: childSessionId, delta }),
-      onToolsReady:  ()     => send("pi-agent:tools-ready", { sessionId: childSessionId }),
-      onToolPending: (name, callId) => send("pi-agent:tool", { sessionId: childSessionId, name, label: name, callId, status: "pending" }),
-      onToolStart:   (name, label, callId) => send("pi-agent:tool", { sessionId: childSessionId, name, label, callId, status: "start" }),
-      onToolEnd:     (name, label, ok, output, callId) => send("pi-agent:tool", { sessionId: childSessionId, name, label, callId, status: "end", ok, output }),
-      onStepStart:  () => send("pi-agent:step", { sessionId: childSessionId }),
-      onUsage:      (pt, ct) => send("pi-agent:usage", { sessionId: childSessionId, promptTokens: pt, completionTokens: ct }),
-      onDone:       () => { /* handled below */ },
+      onToken:       (delta) => childToolCtx.send("pi-agent:token",      { sessionId: childSessionId, delta }),
+      onToolsReady:  ()     => childToolCtx.send("pi-agent:tools-ready", { sessionId: childSessionId }),
+      onToolPending: (name, callId) => childToolCtx.send("pi-agent:tool", { sessionId: childSessionId, name, label: name, callId, status: "pending" }),
+      onToolStart:   (name, label, callId) => childToolCtx.send("pi-agent:tool", { sessionId: childSessionId, name, label, callId, status: "start" }),
+      onToolEnd:     (name, label, ok, output, callId) => childToolCtx.send("pi-agent:tool", { sessionId: childSessionId, name, label, callId, status: "end", ok, output }),
+      onStepStart:  () => childToolCtx.send("pi-agent:step", { sessionId: childSessionId }),
+      onUsage:      (pt, ct) => childToolCtx.send("pi-agent:usage", { sessionId: childSessionId, promptTokens: pt, completionTokens: ct }),
+      onDone:       () => { /* handled below via session.messages */ },
       onError:      (msg) => { errorMessage = msg; },
     },
-    getWin,
+    childToolCtx,
   );
 
   // Extract the final assistant message from history
   const lastAssistant = [...session.messages]
     .reverse()
     .find((m) => m.role === "assistant");
-  if (lastAssistant && "content" in lastAssistant && lastAssistant.content) {
-    finalAnswer = lastAssistant.content;
-  }
+
+  const finalAnswer =
+    lastAssistant && "content" in lastAssistant && lastAssistant.content
+      ? lastAssistant.content
+      : "";
 
   const result = errorMessage
     ? `Sub-agent error: ${errorMessage}`
     : finalAnswer || "(sub-agent produced no output)";
 
   // Notify renderer the subagent is done
-  send("pi-agent:subagent", {
-    parentSessionId,
+  parentToolCtx.send("pi-agent:subagent", {
+    parentSessionId: parentToolCtx.sessionId,
     childSessionId,
     status: "done",
     result,

--- a/electron/lib/compaction.ts
+++ b/electron/lib/compaction.ts
@@ -1,0 +1,277 @@
+/**
+ * LLM-based context compaction for long Pi-agent sessions.
+ *
+ * When the session's lastPromptTokens exceeds COMPACT_THRESHOLD of the model's
+ * context window, the oldest messages are summarised with a single non-streaming
+ * LLM call. The summary is injected back as a synthetic user message and the
+ * trimmed messages are dropped from the context sent to the model.
+ *
+ * This does NOT mutate session.messages — it only transforms what is sent to
+ * the LLM each turn (via the transformContext hook in AgentLoopCallbacks).
+ * The full conversation history is always preserved in session storage.
+ *
+ * Compaction is skipped when:
+ *   - lastPromptTokens is unknown (first turn)
+ *   - The session is already compact (below threshold)
+ *   - A compaction call is already in flight for this session
+ *   - The compaction API call fails (falls back silently to the pruner)
+ */
+
+import type { AgentLLMConfig, AgentMessage, AgentToolResultMsg, PiAgentSession } from "./pi-agent-loop";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** Start compacting when context reaches this fraction of the window. */
+const COMPACT_THRESHOLD = 0.80;
+
+/** Number of recent turns to preserve verbatim (not summarised). */
+const KEEP_RECENT_TURNS = 6;
+
+/** Max tokens to request for the summary itself. */
+const SUMMARY_MAX_TOKENS = 4096;
+
+/** Character budget per tool result included in the serialised conversation. */
+const TOOL_RESULT_MAX_CHARS = 1500;
+
+// ── Message serialisation ─────────────────────────────────────────────────────
+
+function serializeMessages(messages: AgentMessage[]): string {
+  const parts: string[] = [];
+
+  for (const msg of messages) {
+    if (msg.role === "user") {
+      const text = typeof msg.content === "string" ? msg.content : "";
+      if (text) parts.push(`[User]: ${text}`);
+    } else if (msg.role === "assistant") {
+      if (msg.content) parts.push(`[Assistant]: ${msg.content}`);
+      if (msg.tool_calls?.length) {
+        const calls = msg.tool_calls.map((tc) => {
+          let args = "";
+          try { args = JSON.stringify(JSON.parse(tc.function.arguments), null, 0); } catch { args = tc.function.arguments; }
+          return `${tc.function.name}(${args})`;
+        });
+        parts.push(`[Tool calls]: ${calls.join("; ")}`);
+      }
+    } else if (msg.role === "tool") {
+      const result = msg as AgentToolResultMsg;
+      const text = result.content.length > TOOL_RESULT_MAX_CHARS
+        ? `${result.content.slice(0, TOOL_RESULT_MAX_CHARS)}…`
+        : result.content;
+      parts.push(`[Tool result]: ${text}`);
+    }
+  }
+
+  return parts.join("\n\n");
+}
+
+// ── Split: what to summarise vs what to keep verbatim ────────────────────────
+
+interface Split {
+  toSummarise: AgentMessage[];
+  toKeep: AgentMessage[];
+}
+
+function splitMessages(messages: AgentMessage[]): Split {
+  // Walk backwards, count assistant turns to find the keep boundary
+  let keptTurns = 0;
+  let keepFromIdx = messages.length;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "assistant") {
+      keptTurns++;
+      keepFromIdx = i;
+      if (keptTurns >= KEEP_RECENT_TURNS) break;
+    }
+  }
+
+  return {
+    toSummarise: messages.slice(0, keepFromIdx),
+    toKeep:      messages.slice(keepFromIdx),
+  };
+}
+
+// ── Summarisation LLM call ────────────────────────────────────────────────────
+
+const SUMMARIZATION_SYSTEM_PROMPT =
+  "You are a context summarization assistant. Your task is to read a conversation between a user " +
+  "and an AI coding assistant, then produce a structured summary following the exact format specified. " +
+  "Do NOT continue the conversation. Do NOT respond to any questions in the conversation. " +
+  "ONLY output the structured summary.";
+
+const SUMMARIZATION_USER_PROMPT = (conversationText: string) =>
+  `<conversation>\n${conversationText}\n</conversation>
+
+Produce a concise summary of the above conversation for use as context in a future AI coding session. Include:
+
+1. **Goal** — What the user is trying to accomplish (1-2 sentences).
+2. **Progress** — What has been implemented or discovered so far. Reference specific files and functions where relevant.
+3. **Key decisions** — Any important design choices or constraints identified.
+4. **Modified files** — List every file that was created or changed.
+5. **Current state** — Where things stand right now and what remains to be done.
+6. **Open issues** — Bugs, TODOs, or unresolved questions noted during the session.
+
+Be specific. Cite file paths, function names, and line numbers where they matter. Omit pleasantries and filler.`;
+
+async function generateSummary(
+  messages: AgentMessage[],
+  llmConfig: AgentLLMConfig,
+  signal: AbortSignal,
+): Promise<string> {
+  const conversationText = serializeMessages(messages);
+  if (!conversationText.trim()) return "";
+
+  const { baseUrl, model, apiKey } = llmConfig;
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+  const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers,
+    signal,
+    body: JSON.stringify({
+      model,
+      system: SUMMARIZATION_SYSTEM_PROMPT,
+      messages: [{ role: "user", content: SUMMARIZATION_USER_PROMPT(conversationText) }],
+      max_tokens: SUMMARY_MAX_TOKENS,
+      temperature: 0.1, // deterministic summary
+      stream: false,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Compaction LLM call failed: ${response.status} ${response.statusText}`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const json = await response.json() as any;
+  const content: string = json.choices?.[0]?.message?.content ?? "";
+  if (!content) throw new Error("Compaction returned empty summary");
+  return content;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Build a transformContext function that performs LLM-based compaction when
+ * the session's context usage crosses the threshold, falling back to the
+ * simple sliding-window pruner if the LLM call fails or is not needed.
+ *
+ * The returned function is async-safe: concurrent calls are serialised via
+ * the `compacting` flag so only one summary request is in flight at a time.
+ */
+export function buildCompactionTransformer(
+  session: PiAgentSession,
+  llmConfig: AgentLLMConfig,
+  signal: AbortSignal,
+  onCompactionStart?: () => void,
+  onCompactionEnd?: (summary: string) => void,
+): (messages: AgentMessage[]) => AgentMessage[] {
+  const contextWindow = llmConfig.contextWindow ?? 128_000;
+  let compacting = false;
+  // Cache the last summary so if compaction is still in flight we can use it
+  let cachedSummary: string | null = null;
+
+  return (messages: AgentMessage[]): AgentMessage[] => {
+    const lastPromptTokens = session.lastPromptTokens ?? 0;
+
+    // Below threshold — pass through unchanged
+    if (lastPromptTokens === 0 || lastPromptTokens < contextWindow * COMPACT_THRESHOLD) {
+      return messages;
+    }
+
+    // If we already have a summary from the last compaction, apply it immediately
+    // while the next compaction (if any) runs asynchronously in the background.
+    if (cachedSummary !== null) {
+      const { toKeep } = splitMessages(messages);
+      return buildCompactedContext(cachedSummary, messages[0], toKeep);
+    }
+
+    // Kick off async compaction in the background (fire-and-forget for this turn).
+    // This turn falls back to the sliding-window pruner; the NEXT turn will use
+    // the LLM summary once it arrives.
+    if (!compacting) {
+      compacting = true;
+      onCompactionStart?.();
+
+      const { toSummarise } = splitMessages(messages);
+      generateSummary(toSummarise, llmConfig, signal)
+        .then((summary) => {
+          cachedSummary = summary;
+          onCompactionEnd?.(summary);
+        })
+        .catch((err) => {
+          console.warn("[compaction] summarisation failed, will retry next turn:", err?.message ?? err);
+        })
+        .finally(() => {
+          compacting = false;
+        });
+    }
+
+    // Fallback for this turn: sliding-window trim (safe, no LLM call)
+    return slidingWindowFallback(messages);
+  };
+}
+
+function buildCompactedContext(
+  summary: string,
+  firstMessage: AgentMessage | undefined,
+  recentMessages: AgentMessage[],
+): AgentMessage[] {
+  const summaryMessage: AgentMessage = {
+    role: "user",
+    content:
+      "[Earlier conversation summarised to fit the context window]\n\n" +
+      "## Session Summary\n\n" +
+      summary +
+      "\n\n[End of summary — continuing from current state]",
+  };
+
+  const result: AgentMessage[] = [];
+  // Always keep the very first user message (the original task)
+  if (firstMessage && firstMessage.role === "user") result.push(firstMessage);
+  result.push(summaryMessage);
+  result.push(...recentMessages);
+  return result;
+}
+
+// ── Sliding-window fallback (no LLM) ─────────────────────────────────────────
+
+const FALLBACK_KEEP_TURNS = 8;
+const FALLBACK_THRESHOLD  = 0.80;
+
+function slidingWindowFallback(messages: AgentMessage[]): AgentMessage[] {
+  const keepIds = new Set<string>();
+  let keptTurns = 0;
+  let keepFromIdx = messages.length;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role === "assistant") {
+      keptTurns++;
+      if (msg.tool_calls) for (const tc of msg.tool_calls) keepIds.add(tc.id);
+      keepFromIdx = i;
+      if (keptTurns >= FALLBACK_KEEP_TURNS) break;
+    }
+  }
+
+  const firstUser = messages.find((m) => m.role === "user");
+  const tail = messages.slice(keepFromIdx);
+  const extraToolResults = messages.slice(1, keepFromIdx).filter(
+    (m) => m.role === "tool" && keepIds.has((m as AgentToolResultMsg).tool_call_id),
+  );
+
+  const marker: AgentMessage = {
+    role: "user",
+    content: "[Earlier context trimmed to fit the context window. Full history preserved in session storage.]",
+  };
+
+  const pruned: AgentMessage[] = [];
+  if (firstUser) pruned.push(firstUser);
+  pruned.push(marker);
+  pruned.push(...extraToolResults);
+  pruned.push(...tail);
+  return pruned;
+}
+
+// Re-export threshold for use in pi-agent-loop default pruner
+export { COMPACT_THRESHOLD, FALLBACK_KEEP_TURNS, FALLBACK_THRESHOLD };

--- a/electron/lib/pi-agent-loop.test.ts
+++ b/electron/lib/pi-agent-loop.test.ts
@@ -27,7 +27,7 @@ import BetterSqlite3 from "better-sqlite3";
 import type Database from "better-sqlite3";
 import { applySchema } from "../db/schema";
 import { createWorkspace, createProject, createColumn } from "../db/queries";
-import { runAgentLoop, type PiAgentSession, type AgentLoopCallbacks } from "./pi-agent-loop";
+import { runAgentLoop, type PiAgentSession, type AgentLoopCallbacks, type AgentToolContext } from "./pi-agent-loop";
 import { normaliseBaseUrl } from "./llm";
 import type { ChatRequest } from "./tools";
 
@@ -52,6 +52,17 @@ const chatReq: ChatRequest = {
   projectId: "proj1",
   threadId: "test",
 };
+
+function makeToolCtx(db: Database.Database): AgentToolContext {
+  return {
+    cwd: "/tmp",
+    db,
+    req: chatReq,
+    workspacePath: "/tmp",
+    sessionId: "test",
+    send: () => {},
+  };
+}
 
 /**
  * Build a server that serves a fixed sequence of SSE response bodies.
@@ -180,9 +191,9 @@ describe("runAgentLoop — SSE streaming", () => {
     const { log, callbacks } = makeCallbacks();
 
     await runAgentLoop(
-      session, "You are a test assistant.", "/tmp",
+      session, "You are a test assistant.",
       { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
-      db, chatReq, "/tmp", callbacks,
+      callbacks, makeToolCtx(db),
     );
 
     expect(log).toContain("token:Hello");
@@ -209,9 +220,9 @@ describe("runAgentLoop — SSE streaming", () => {
     const { log, callbacks } = makeCallbacks();
 
     await runAgentLoop(
-      session, "You are a test assistant.", "/tmp",
+      session, "You are a test assistant.",
       { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
-      db, chatReq, "/tmp", callbacks,
+      callbacks, makeToolCtx(db),
     );
 
     const toolsReadyIdx = log.indexOf("tools-ready");
@@ -242,9 +253,9 @@ describe("runAgentLoop — SSE streaming", () => {
     const { log, callbacks } = makeCallbacks();
 
     await runAgentLoop(
-      session, "You are a test assistant.", "/tmp",
+      session, "You are a test assistant.",
       { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
-      db, chatReq, "/tmp", callbacks,
+      callbacks, makeToolCtx(db),
     );
 
     const firstTokenIdx  = log.findIndex((e) => e.startsWith("token:"));
@@ -271,9 +282,9 @@ describe("runAgentLoop — SSE streaming", () => {
     const { log, callbacks } = makeCallbacks();
 
     await runAgentLoop(
-      session, "You are a test assistant.", "/tmp",
+      session, "You are a test assistant.",
       { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
-      db, chatReq, "/tmp", callbacks,
+      callbacks, makeToolCtx(db),
     );
 
     const stepStartIdx      = log.indexOf("step-start");
@@ -320,9 +331,9 @@ describe("runAgentLoop — SSE streaming", () => {
     const { log, callbacks } = makeCallbacks();
 
     await runAgentLoop(
-      session, "You are a test assistant.", "/tmp",
+      session, "You are a test assistant.",
       { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
-      db, chatReq, "/tmp", callbacks,
+      callbacks, makeToolCtx(db),
     );
 
     // Tool should have executed with the full reconstructed args
@@ -349,9 +360,9 @@ describe("runAgentLoop — SSE streaming", () => {
     const { log, callbacks } = makeCallbacks();
 
     await runAgentLoop(
-      session, "You are a test assistant.", "/tmp",
+      session, "You are a test assistant.",
       { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
-      db, chatReq, "/tmp", callbacks,
+      callbacks, makeToolCtx(db),
     );
 
     expect(log).toContain("usage:512:64");
@@ -369,9 +380,9 @@ describe("runAgentLoop — SSE streaming", () => {
     const { log, callbacks } = makeCallbacks();
 
     await runAgentLoop(
-      session, "You are a test assistant.", "/tmp",
+      session, "You are a test assistant.",
       { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
-      db, chatReq, "/tmp", callbacks,
+      callbacks, makeToolCtx(db),
     );
 
     const toolsReadyIdx = log.indexOf("tools-ready");
@@ -417,9 +428,9 @@ describe("runAgentLoop — SSE streaming", () => {
     const { log, callbacks } = makeCallbacks();
 
     await runAgentLoop(
-      session, "You are a test assistant.", "/tmp",
+      session, "You are a test assistant.",
       { baseUrl: server.url, model: "test", apiKey: "test", maxSteps: 10, temperature: 0.3 },
-      db, chatReq, "/tmp", callbacks,
+      callbacks, makeToolCtx(db),
     );
 
     const starts = log.filter((e) => e.startsWith("tool-start:"));
@@ -461,9 +472,8 @@ describe.skipIf(!liveBaseUrl)("runAgentLoop — live endpoint", () => {
     await runAgentLoop(
       session,
       "You are a test assistant. Follow instructions exactly.",
-      "/tmp",
       { baseUrl: liveBaseUrl!, model: liveModel, apiKey: liveApiKey, maxSteps: 10, temperature: 0.3 },
-      db, chatReq, "/tmp", callbacks,
+      callbacks, makeToolCtx(db),
     );
 
     expect(log).toContain("done");
@@ -479,9 +489,8 @@ describe.skipIf(!liveBaseUrl)("runAgentLoop — live endpoint", () => {
     await runAgentLoop(
       session,
       "You are a test assistant with access to coding tools. When asked to list files, always use the ls tool.",
-      "/tmp",
       { baseUrl: liveBaseUrl!, model: liveModel, apiKey: liveApiKey, maxSteps: 10, temperature: 0.3 },
-      db, chatReq, "/tmp", callbacks,
+      callbacks, makeToolCtx(db),
     );
 
     expect(log).toContain("done");

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -1,9 +1,9 @@
 /**
  * Cairn Native Agent Loop
  *
- * A stateful multi-turn tool-call loop. Reuses streamCompletion from llm.ts
- * (OpenAI-compatible). Each session keeps its own message history in the
- * PiAgentSession object managed by the IPC handler.
+ * A stateful multi-turn tool-call loop (OpenAI-compatible streaming).
+ * Each session keeps its own message history in the PiAgentSession object
+ * managed by the IPC handler.
  *
  * Events emitted (via callbacks, forwarded to renderer over IPC):
  *   onToken(delta)              — streaming text chunk
@@ -11,6 +11,7 @@
  *   onToolEnd(name, label, ok)  — tool execution finished
  *   onDone()                    — turn complete, no more tool calls
  *   onError(message)            — unrecoverable error
+ *   onRetry?(attempt, max, delayMs, error) — transient error, retrying
  */
 
 import type Database from "better-sqlite3";
@@ -39,6 +40,15 @@ export interface AgentLLMConfig {
   maxSteps: number;
   /** Sampling temperature. Plan mode overrides this to 0.1 for determinism. */
   temperature: number;
+  /** Maximum automatic retries on transient errors (429/5xx). Defaults to 3. */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff. Doubles each attempt. Defaults to 2000. */
+  baseRetryDelayMs?: number;
+  /**
+   * Model context window size in tokens. Used by the sliding-window pruner to
+   * decide when to trim old messages. Defaults to 128000.
+   */
+  contextWindow?: number;
 }
 
 // ── Message types ─────────────────────────────────────────────────────────────
@@ -56,6 +66,29 @@ interface ToolCallSpec {
   id: string;
   type: "function";
   function: { name: string; arguments: string };
+}
+
+// ── Per-session infrastructure context ───────────────────────────────────────
+
+/**
+ * Stable, per-session infrastructure that every tool needs.
+ * Passed as a single object instead of individual positional parameters.
+ */
+export interface AgentToolContext {
+  /** Working directory for all file-system tool calls. */
+  cwd: string;
+  /** SQLite database handle for Cairn tool execution. */
+  db: Database.Database;
+  /** ChatRequest used to scope Cairn tool calls (threadId, projectId, etc.). */
+  req: ChatRequest;
+  /** Absolute path to the Electron workspace root (for note file writes). */
+  workspacePath: string;
+  /** Session ID — used to scope IPC events and subagent child IDs. */
+  sessionId: string;
+  /** Send an IPC event to the renderer window. */
+  send: (channel: string, payload: unknown) => void;
+  /** Returns the current BrowserWindow (may be null if destroyed). */
+  getWin?: () => BrowserWindow | null;
 }
 
 // ── Tool label helper ─────────────────────────────────────────────────────────
@@ -88,6 +121,17 @@ export interface AgentLoopCallbacks {
   onError:         (message: string) => void;
   /** Fired when the agent writes a note in plan mode — carries the note ID */
   onPlanNoteFound?: (noteId: string) => void;
+  /**
+   * Fired before each automatic retry attempt on a transient error.
+   * The renderer can show a countdown ("Retrying in Xs…") in the status area.
+   */
+  onRetry?: (attempt: number, maxRetries: number, delayMs: number, error: string) => void;
+  /**
+   * Optional transform applied to session.messages before each LLM call.
+   * Does NOT mutate session.messages — only affects what is sent to the model.
+   * Use for context pruning, injection, or summarisation.
+   */
+  transformContext?: (messages: AgentMessage[]) => AgentMessage[];
 }
 
 // ── Session state ─────────────────────────────────────────────────────────────
@@ -95,6 +139,8 @@ export interface AgentLoopCallbacks {
 export interface PiAgentSession {
   messages: AgentMessage[];
   abortCtrl: AbortController;
+  /** Most recent prompt_tokens count from the last onUsage callback. Updated each turn. */
+  lastPromptTokens?: number;
 }
 
 // ── All tool definitions ──────────────────────────────────────────────────────
@@ -173,22 +219,107 @@ function getAllToolDefs(mode: "plan" | "execute" = "execute") {
   return all;
 }
 
+// ── Retry helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Returns true when an HTTP status + body string indicates a transient error
+ * that is worth retrying. Never retries auth/bad-request errors.
+ */
+function isRetryableError(status: number, body: string): boolean {
+  if (status === 400 || status === 401 || status === 403) return false;
+  if (status === 429 || status >= 500) return true;
+  return /overloaded|rate.?limit|service.?unavailable|server.?error|connection.?error|fetch failed|timed?.?out/i.test(body);
+}
+
+/**
+ * Abortable sleep. Rejects with an AbortError if signal fires before the delay.
+ */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) { reject(new DOMException("Aborted", "AbortError")); return; }
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener("abort", () => { clearTimeout(timer); reject(new DOMException("Aborted", "AbortError")); }, { once: true });
+  });
+}
+
+// ── Context pruning ───────────────────────────────────────────────────────────
+
+/**
+ * Default transformContext implementation.
+ *
+ * When the last recorded promptTokens exceeds 80 % of the configured context
+ * window, trims the oldest messages while preserving:
+ *   - The first user message (the original request).
+ *   - The most recent KEEP_TURNS assistant+tool pairs.
+ *   - Any tool-result messages whose tool_call_id is still referenced by a
+ *     kept assistant message (orphan prevention).
+ * A synthetic marker message is injected at the trim boundary so the model
+ * knows context was abbreviated.
+ */
+const KEEP_TURNS = 8;
+const CONTEXT_TRIM_THRESHOLD = 0.80;
+
+function buildSlidingWindowPruner(
+  session: PiAgentSession,
+  contextWindow: number,
+): (messages: AgentMessage[]) => AgentMessage[] {
+  return (messages: AgentMessage[]): AgentMessage[] => {
+    const lastPromptTokens = session.lastPromptTokens ?? 0;
+    if (lastPromptTokens === 0 || lastPromptTokens < contextWindow * CONTEXT_TRIM_THRESHOLD) {
+      return messages;
+    }
+
+    const keepIds = new Set<string>(); // tool_call_ids referenced by kept assistant msgs
+    let keptTurns = 0;
+    let keepFromIdx = messages.length;
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg.role === "assistant") {
+        keptTurns++;
+        if (msg.tool_calls) {
+          for (const tc of msg.tool_calls) keepIds.add(tc.id);
+        }
+        keepFromIdx = i;
+        if (keptTurns >= KEEP_TURNS) break;
+      }
+    }
+
+    const firstUser = messages.find((m) => m.role === "user");
+    const tail = messages.slice(keepFromIdx);
+
+    // Keep any orphaned tool-result messages before the tail whose call_id is still referenced
+    const extraToolResults = messages.slice(1, keepFromIdx).filter(
+      (m) => m.role === "tool" && keepIds.has((m as AgentToolResultMsg).tool_call_id),
+    );
+
+    const marker: AgentUserMessage = {
+      role: "user",
+      content: "[Earlier context trimmed to fit the context window. The full conversation history is preserved in session storage.]",
+    };
+
+    const pruned: AgentMessage[] = [];
+    if (firstUser) pruned.push(firstUser);
+    pruned.push(marker);
+    pruned.push(...extraToolResults);
+    pruned.push(...tail);
+
+    return pruned;
+  };
+}
+
 // ── Execute a single tool call ────────────────────────────────────────────────
 
 async function executeSingleTool(
   name: string,
   args: ToolArgs,
-  cwd: string,
   signal: AbortSignal,
-  db: Database.Database,
-  req: ChatRequest,
-  workspacePath: string,
-  llmConfig: AgentLLMConfig,
   onUpdate: (output: string) => void,
-  sessionId: string,
-  send: (channel: string, payload: unknown) => void,
-  getWin?: () => BrowserWindow | null,
+  toolCtx: AgentToolContext,
+  llmConfig: AgentLLMConfig,
 ): Promise<string> {
+  const { cwd, db, req, workspacePath, sessionId, send, getWin } = toolCtx;
+
   switch (name) {
     case "read":  return readTool(args as Parameters<typeof readTool>[0],  cwd);
     case "write": return writeTool(args as Parameters<typeof writeTool>[0], cwd);
@@ -203,14 +334,8 @@ async function executeSingleTool(
     case "ls":    return lsTool(args as Parameters<typeof lsTool>[0],    cwd);
     case "spawn_subagent": return spawnSubagentTool(
       args as Parameters<typeof spawnSubagentTool>[0],
-      cwd,
+      toolCtx,
       llmConfig,
-      db,
-      req,
-      workspacePath,
-      sessionId,
-      send,
-      getWin,
     );
     default: {
       // Delegate to Cairn chat executor
@@ -239,27 +364,31 @@ async function executeSingleTool(
 export async function runAgentLoop(
   session: PiAgentSession,
   systemPrompt: string,
-  cwd: string,
   llmConfig: AgentLLMConfig,
-  db: Database.Database,
-  req: ChatRequest,
-  workspacePath: string,
   callbacks: AgentLoopCallbacks,
-  getWin?: () => BrowserWindow | null,
-  sessionId?: string,
-  send?: (channel: string, payload: unknown) => void,
+  toolCtx: AgentToolContext,
   mode: "plan" | "execute" = "execute",
 ): Promise<void> {
   const { signal } = session.abortCtrl;
   const allTools = getAllToolDefs(mode);
 
-  const { baseUrl, model, apiKey, maxSteps, temperature: configTemp } = llmConfig;
+  const {
+    baseUrl, model, apiKey, maxSteps, temperature: configTemp,
+    maxRetries    = 3,
+    baseRetryDelayMs = 2000,
+    contextWindow = 128_000,
+  } = llmConfig;
+
   // Plan mode always uses 0.1 for deterministic analysis regardless of user setting
   const temperature = mode === "plan" ? 0.1 : (configTemp ?? 0.3);
   if (!apiKey && !isLocalEndpoint(baseUrl)) {
     callbacks.onError("No API key configured. Set one in Settings → AI & Chat.");
     return;
   }
+
+  // Build the context pruner — closes over session so it sees live lastPromptTokens
+  const pruner = callbacks.transformContext
+    ?? buildSlidingWindowPruner(session, contextWindow);
 
   let steps = 0;
 
@@ -270,41 +399,87 @@ export async function runAgentLoop(
     // assistant message and start a fresh one for this turn's tokens.
     if (steps > 1) callbacks.onStepStart();
 
-    // Build messages array for this request
-    const messages: AgentMessage[] = [
-      { role: "user", content: systemPrompt } as AgentUserMessage,
-      ...session.messages,
-    ];
+    // Build messages array — apply context pruning.
+    // systemPrompt passes as `system:` in the request body (not as a user message).
+    const contextMessages = pruner([...session.messages]);
 
     // ── Stream assistant response ─────────────────────────────────────────
     const headers: Record<string, string> = { "Content-Type": "application/json" };
     if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
 
-    let response: Response;
-    try {
-      response = await fetch(`${baseUrl}/v1/chat/completions`, {
-        method: "POST",
-        headers,
-        signal,
-        body: JSON.stringify({
-          model,
-          messages,
-          tools: allTools,
-          tool_choice: "auto",
-          max_tokens: 8192,
-          temperature,
-          stream: true,
-          stream_options: { include_usage: true },
-        }),
-      });
-    } catch (e) {
+    // Retry loop — wraps the fetch + !response.ok check
+    let response: Response | null = null;
+    let retryAttempt = 0;
+
+    while (true) {
       if (signal.aborted) { callbacks.onDone(); return; }
-      callbacks.onError(`Cannot reach AI endpoint: ${(e as Error).message}`);
-      return;
+
+      let fetchError: string | null = null;
+      try {
+        response = await fetch(`${baseUrl}/v1/chat/completions`, {
+          method: "POST",
+          headers,
+          signal,
+          body: JSON.stringify({
+            model,
+            system: systemPrompt,
+            messages: contextMessages,
+            tools: allTools,
+            tool_choice: "auto",
+            max_tokens: 8192,
+            temperature,
+            stream: true,
+            stream_options: { include_usage: true },
+          }),
+        });
+      } catch (e) {
+        if (signal.aborted) { callbacks.onDone(); return; }
+        fetchError = (e as Error).message;
+      }
+
+      // Determine if we should retry
+      const status = response?.status ?? 0;
+      let bodyText = "";
+      if (response && !response.ok) {
+        bodyText = await response.text().catch(() => response!.statusText);
+      }
+
+      const shouldRetry =
+        fetchError !== null
+          ? /overloaded|rate.?limit|service.?unavailable|server.?error|connection.?error|fetch failed|timed?.?out/i.test(fetchError)
+          : (response && !response.ok && isRetryableError(status, bodyText));
+
+      if (!shouldRetry) break; // success or non-retryable error — exit retry loop
+
+      if (retryAttempt >= maxRetries) {
+        const errMsg = fetchError
+          ? `Cannot reach AI endpoint after ${maxRetries} retries: ${fetchError}`
+          : `AI error (${status}) after ${maxRetries} retries: ${bodyText.slice(0, 300)}`;
+        callbacks.onError(errMsg);
+        return;
+      }
+
+      retryAttempt++;
+      const delayMs = baseRetryDelayMs * 2 ** (retryAttempt - 1);
+      callbacks.onRetry?.(retryAttempt, maxRetries, delayMs, fetchError ?? bodyText.slice(0, 200));
+
+      try {
+        await sleep(delayMs, signal);
+      } catch {
+        callbacks.onDone();
+        return;
+      }
+
+      response = null; // reset for next attempt
     }
 
+    // Non-retryable hard errors
+    if (!response) {
+      callbacks.onError("Cannot reach AI endpoint. Check your network and API settings.");
+      return;
+    }
     if (!response.ok) {
-      const text = await response.text().catch(() => response.statusText);
+      const text = await response.text().catch(() => response!.statusText);
       callbacks.onError(`AI error (${response.status}): ${text.slice(0, 300)}`);
       return;
     }
@@ -329,8 +504,6 @@ export async function runAgentLoop(
         if (!trimmed.startsWith("data:")) continue;
         const jsonStr = trimmed.slice(5).trim();
         if (jsonStr === "[DONE]") {
-          // Mark done and break the inner loop — the outer while condition
-          // catches this on the next iteration so we don't call reader.read() again.
           streamDone = true;
           break;
         }
@@ -339,23 +512,21 @@ export async function runAgentLoop(
           const chunk = JSON.parse(jsonStr) as any;
 
           // Usage chunk — sent as the final SSE chunk when stream_options.include_usage is set.
-          // It has an empty choices array and a top-level usage object.
           if (chunk.usage) {
             const pt = chunk.usage.prompt_tokens ?? 0;
             const ct = chunk.usage.completion_tokens ?? 0;
+            session.lastPromptTokens = pt;
             callbacks.onUsage(pt, ct);
           }
 
           const delta = chunk.choices?.[0]?.delta;
           if (!delta) continue;
 
-          // Text token
           if (delta.content) {
             contentBuffer += delta.content;
             callbacks.onToken(delta.content);
           }
 
-          // Tool call chunks
           if (delta.tool_calls) {
             for (const tc of delta.tool_calls) {
               const idx: number = tc.index ?? 0;
@@ -368,8 +539,7 @@ export async function runAgentLoop(
               if (tc.function?.name) buf.name = tc.function.name;
               if (tc.function?.arguments) buf.args += tc.function.arguments;
 
-              // As soon as we have the tool name, fire pending chip — mirrors pi's
-              // approach of creating the chip during streaming, not post-stream.
+              // Fire pending chip as soon as we see the tool name during streaming
               if (isNew && buf.name) {
                 if (!toolsReadyFired) {
                   callbacks.onToolsReady();
@@ -401,36 +571,32 @@ export async function runAgentLoop(
         function: { name: buf.name, arguments: buf.args },
       }));
 
-    // Persist assistant message with tool_calls
     session.messages.push({
       role: "assistant",
       content: contentBuffer || null,
       tool_calls: toolCalls,
     });
 
-    // ── Ensure renderer has a streaming message (fallback if onToolsReady
-    //    wasn't fired during streaming, e.g. endpoint doesn't stream tool names).
     if (!toolsReadyFired) callbacks.onToolsReady();
 
-    // ── Execute each tool ─────────────────────────────────────────────────
-    for (const [tcIdx, tc] of toolCalls.entries()) {
-      if (signal.aborted) { callbacks.onDone(); return; }
+    // ── Execute tools in parallel ─────────────────────────────────────────
+    // All tools in a turn fire concurrently. Results are appended to
+    // session.messages in original source order regardless of completion order.
+    // onToolEnd fires as each tool finishes (may be out of order for UI updates).
+    // The file mutex in file-mutex.ts serialises concurrent writes to the same path.
+    if (signal.aborted) { callbacks.onDone(); return; }
 
+    type ToolOutcome = { tcIdx: number; tc: ToolCallSpec; ok: boolean; resultContent: string; pendingCallId?: string };
+
+    const toolPromises: Promise<ToolOutcome>[] = toolCalls.map(async (tc, tcIdx): Promise<ToolOutcome> => {
       let args: ToolArgs = {};
       try { args = JSON.parse(tc.function.arguments) as ToolArgs; } catch { args = {}; }
 
-      const label =
-        CODING_LABELS[tc.function.name]?.(args) ??
-        `${tc.function.name}`;
-
-      // Pass the callId assigned during streaming so the renderer updates the
-      // existing pending chip rather than creating a duplicate.
+      const label = CODING_LABELS[tc.function.name]?.(args) ?? tc.function.name;
       const pendingCallId = streamCallIds.get(tcIdx);
       callbacks.onToolStart(tc.function.name, label, pendingCallId);
 
-      // Yield to the event loop so the renderer can process the onToolStart IPC
-      // message and render the running spinner before the (potentially synchronous)
-      // tool execution blocks the main process event loop.
+      // Yield so the renderer processes the onToolStart IPC before execution begins
       await new Promise<void>((r) => setImmediate(r));
 
       let resultContent: string;
@@ -439,16 +605,10 @@ export async function runAgentLoop(
         resultContent = await executeSingleTool(
           tc.function.name,
           args,
-          cwd,
           signal,
-          db,
-          req,
-          workspacePath,
-          llmConfig,
           (output) => callbacks.onToolStart(tc.function.name, `${label}: ${output.slice(-80)}`),
-          sessionId ?? "",
-          send ?? (() => {}),
-          getWin,
+          toolCtx,
+          llmConfig,
         );
       } catch (e) {
         ok = false;
@@ -457,8 +617,7 @@ export async function runAgentLoop(
 
       callbacks.onToolEnd(tc.function.name, label, ok, resultContent, pendingCallId);
 
-      // In plan mode only, notify the renderer when the agent writes the PRD note.
-      // Suppressed in execute mode to avoid overwriting planNoteId after approval.
+      // In plan mode, notify renderer when agent writes the PRD note
       if (mode === "plan" && ok && tc.function.name === "ensure_note") {
         try {
           const parsed = JSON.parse(resultContent) as { id?: string };
@@ -466,6 +625,14 @@ export async function runAgentLoop(
         } catch { /* non-JSON output — ignore */ }
       }
 
+      return { tcIdx, tc, ok, resultContent, pendingCallId };
+    });
+
+    const outcomes = await Promise.all(toolPromises);
+
+    // Append in source order
+    outcomes.sort((a, b) => a.tcIdx - b.tcIdx);
+    for (const { tc, resultContent } of outcomes) {
       session.messages.push({
         role: "tool",
         tool_call_id: tc.id,

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -318,7 +318,7 @@ async function executeSingleTool(
   toolCtx: AgentToolContext,
   llmConfig: AgentLLMConfig,
 ): Promise<string> {
-  const { cwd, db, req, workspacePath, sessionId, send, getWin } = toolCtx;
+  const { cwd, db, req, workspacePath, sessionId, send, getWin: _getWin } = toolCtx;
 
   switch (name) {
     case "read":  return readTool(args as Parameters<typeof readTool>[0],  cwd);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -27,6 +27,7 @@ import { syncNotesFromDisk } from "./notes-files";
 import { markMcpNotificationsRead } from "./db/queries";
 import { setupProtocol, registerAssetProtocol, setAssetWorkspacePath } from "./lib/protocol";
 import { createTray } from "./lib/tray";
+import { killTrackedBashProcesses } from "./lib/coding-tools/bash";
 import { startMcpNotificationPoller } from "./lib/mcp-poller";
 
 const isDev = !app.isPackaged;
@@ -267,6 +268,11 @@ app.whenReady().then(async () => {
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
+});
+
+app.on("before-quit", () => {
+  // Kill any bash child processes that are still running so they don't linger
+  killTrackedBashProcesses();
 });
 
 app.on("window-all-closed", () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -321,6 +321,13 @@ const api = {
       ipcRenderer.on("pi-agent:usage", handler);
       return () => ipcRenderer.off("pi-agent:usage", handler);
     },
+    /** Fired before each automatic retry on a transient error. delayMs is the backoff wait. */
+    onRetry: (cb: (e: { sessionId: string; attempt: number; maxRetries: number; delayMs: number; error: string }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { sessionId: string; attempt: number; maxRetries: number; delayMs: number; error: string }) => cb(e);
+      ipcRenderer.on("pi-agent:retry", handler);
+      return () => ipcRenderer.off("pi-agent:retry", handler);
+    },
     onSubagent: (cb: (e: { parentSessionId: string; childSessionId: string; status: "start" | "done"; result?: string }) => void) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const handler = (_: any, e: { parentSessionId: string; childSessionId: string; status: "start" | "done"; result?: string }) => cb(e);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -328,6 +328,13 @@ const api = {
       ipcRenderer.on("pi-agent:retry", handler);
       return () => ipcRenderer.off("pi-agent:retry", handler);
     },
+    /** Fired when the session starts or finishes an LLM-based compaction pass. */
+    onCompact: (cb: (e: { sessionId: string; status: "start" | "end" }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { sessionId: string; status: "start" | "end" }) => cb(e);
+      ipcRenderer.on("pi-agent:compact", handler);
+      return () => ipcRenderer.off("pi-agent:compact", handler);
+    },
     onSubagent: (cb: (e: { parentSessionId: string; childSessionId: string; status: "start" | "done"; result?: string }) => void) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const handler = (_: any, e: { parentSessionId: string; childSessionId: string; status: "start" | "done"; result?: string }) => cb(e);

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -123,6 +123,8 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
   const [planNoteContent, setPlanNoteContent]     = useState<string | null>(null);
   // Retry state — shown in status bar when the loop is backing off after a transient error
   const [retryInfo, setRetryInfo]                 = useState<{ attempt: number; maxRetries: number; delayMs: number } | null>(null);
+  // Compaction state — shown in status bar while an LLM summary call is in flight
+  const [isCompacting, setIsCompacting]           = useState(false);
 
   const messagesEndRef  = useRef<HTMLDivElement>(null);
   const textareaRef     = useRef<HTMLTextAreaElement>(null);
@@ -236,6 +238,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       finalisePiMessage(sessionId);
       setIsLoading(false);
       setRetryInfo(null);
+      setIsCompacting(false);
       // Persist the full message transcript after the turn completes
       const msgs = useCairnStore.getState().terminalSessions.find((t) => t.sessionId === sessionId)?.piMessages ?? [];
       const saveable = msgs.filter((m) => !m.isStreaming).map((m) => ({
@@ -253,6 +256,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       if (e.sessionId !== sessionId) return;
       finalisePiMessage(sessionId);
       setRetryInfo(null);
+      setIsCompacting(false);
       addPiMessage(sessionId, {
         id:        id(),
         role:      "error",
@@ -356,6 +360,12 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       setTimeout(() => setRetryInfo(null), e.delayMs + 500);
     });
 
+    // Compaction events — show "Compacting…" in status bar while LLM summary is in flight
+    const unsubCompact = electron.piAgent.onCompact((e) => {
+      if (e.sessionId !== sessionId) return;
+      setIsCompacting(e.status === "start");
+    });
+
     return () => {
       unsubToken();
       unsubUsage();
@@ -373,6 +383,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       unsubAskQuestions();
       unsubNoteUpdated();
       unsubRetry();
+      unsubCompact();
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session.sessionId]);
@@ -617,9 +628,11 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
         <p className="text-[0.643rem] text-[var(--text-tertiary)] mt-1 text-center">
           {retryInfo
             ? `Transient error — retrying (${retryInfo.attempt}/${retryInfo.maxRetries}) in ${Math.round(retryInfo.delayMs / 1000)}s…`
-            : isLoading
-              ? "Working… click ◼ to stop"
-              : "Shift+Enter for new line · Enter to send"
+            : isCompacting
+              ? "Compacting context…"
+              : isLoading
+                ? "Working… click ◼ to stop"
+                : "Shift+Enter for new line · Enter to send"
           }
         </p>
       </div>

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -121,6 +121,8 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
   const [pendingQuestions, setPendingQuestions]   = useState<PendingQuestion[] | null>(null);
   // Live PRD note content — updated whenever the agent writes to the plan note
   const [planNoteContent, setPlanNoteContent]     = useState<string | null>(null);
+  // Retry state — shown in status bar when the loop is backing off after a transient error
+  const [retryInfo, setRetryInfo]                 = useState<{ attempt: number; maxRetries: number; delayMs: number } | null>(null);
 
   const messagesEndRef  = useRef<HTMLDivElement>(null);
   const textareaRef     = useRef<HTMLTextAreaElement>(null);
@@ -233,6 +235,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       if (e.sessionId !== sessionId) return;
       finalisePiMessage(sessionId);
       setIsLoading(false);
+      setRetryInfo(null);
       // Persist the full message transcript after the turn completes
       const msgs = useCairnStore.getState().terminalSessions.find((t) => t.sessionId === sessionId)?.piMessages ?? [];
       const saveable = msgs.filter((m) => !m.isStreaming).map((m) => ({
@@ -249,6 +252,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
     const unsubError = electron.piAgent.onError((e) => {
       if (e.sessionId !== sessionId) return;
       finalisePiMessage(sessionId);
+      setRetryInfo(null);
       addPiMessage(sessionId, {
         id:        id(),
         role:      "error",
@@ -344,6 +348,14 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       setPlanNoteContent(e.content);
     });
 
+    // Retry events — show backoff countdown in the status bar
+    const unsubRetry = electron.piAgent.onRetry((e) => {
+      if (e.sessionId !== sessionId) return;
+      setRetryInfo({ attempt: e.attempt, maxRetries: e.maxRetries, delayMs: e.delayMs });
+      // Auto-clear the retry badge once enough time has passed (delayMs + 500ms grace)
+      setTimeout(() => setRetryInfo(null), e.delayMs + 500);
+    });
+
     return () => {
       unsubToken();
       unsubUsage();
@@ -360,6 +372,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       unsubModeChange();
       unsubAskQuestions();
       unsubNoteUpdated();
+      unsubRetry();
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session.sessionId]);
@@ -602,7 +615,12 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
           )}
         </div>
         <p className="text-[0.643rem] text-[var(--text-tertiary)] mt-1 text-center">
-          {isLoading ? "Working… click ◼ to stop" : "Shift+Enter for new line · Enter to send"}
+          {retryInfo
+            ? `Transient error — retrying (${retryInfo.attempt}/${retryInfo.maxRetries}) in ${Math.round(retryInfo.delayMs / 1000)}s…`
+            : isLoading
+              ? "Working… click ◼ to stop"
+              : "Shift+Enter for new line · Enter to send"
+          }
         </p>
       </div>
       </div>


### PR DESCRIPTION
## What does this PR do?

Closes the most impactful gaps between Cairn's Pi agent harness and the Pi monorepo coding agent. Seven targeted improvements land in this PR — each independently mergeable but shipped together as a cohesive reliability and performance upgrade.

## Type of change

- [x] New feature
- [x] Refactor / code quality

## Checklist

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## What changed

**Context compaction** (`electron/lib/compaction.ts` — new file)  
When token usage hits 80% of the context window, the oldest messages are summarised with a non-streaming LLM call. Compaction is async fire-and-forget — the current turn uses a sliding-window fallback; subsequent turns use the cached summary. A `"Compacting context…"` badge appears in the Pi agent status bar while the call is in flight.

**Automatic retry** (`pi-agent-loop.ts`)  
Retryable HTTP errors (429/5xx, overloaded/rate-limit body patterns) trigger up to 3 retries with 2 s / 4 s / 8 s backoff. A countdown badge shows in the status bar. Abort cancels any in-progress sleep.

**Parallel tool execution** (`pi-agent-loop.ts`)  
All tool calls in a single assistant turn now run via `Promise.all`. Results appended in source order. Per-file serialisation handled transparently by the existing file mutex.

**Edit tool diff output** (`coding-tools/edit.ts`)  
The `edit` tool now returns a unified diff alongside the success string. Implemented inline with LCS — no new dependencies.

**Bash process-group cleanup** (`coding-tools/bash.ts`, `main.ts`)  
Bash processes spawn with `detached: true` on Unix. PIDs tracked and killed as a process group on `before-quit`.

**System prompt fix** (`pi-agent-loop.ts`)  
System prompt now sent as the `system:` field in the request body, not prepended as a `user` message.

**`AgentToolContext` refactor** (`pi-agent-loop.ts`)  
`runAgentLoop` reduced from 11 positional parameters to 6 by grouping DB/IPC/path context into `AgentToolContext`. Tests updated accordingly.

## Notes for reviewer

- `npm run test:e2e` not run — no UI flows changed beyond the status bar text additions in `PiAgentPane`.
- Compaction is fire-and-forget by design: the first turn above the threshold always uses the sliding-window fallback. This avoids blocking the agent loop. The LLM summary is applied from the second over-threshold turn onward.
- The `contextWindow` used for the compaction threshold defaults to `128_000` if not set in `AgentLLMConfig`. This can be made configurable via Settings in a follow-up.