### PR TITLE
v1.5.1 - Fix Obsidian Migration

### DIFF
--- a/changelogs/v1.5.1.md
+++ b/changelogs/v1.5.1.md
@@ -1,0 +1,22 @@
+# v1.5.1
+
+## What's new
+
+### Fixes
+
+- **Migration Modal Trigger for Obsidian Vaults** — Fixed an issue where Obsidian vaults containing a folder named `notes` at the root were incorrectly prompted to run the legacy Cairn `drop-notes-dir` workspace migration. The migration check now looks for direct `.md` files inside the root `notes/` directory; if found (indicating Obsidian-style note storage), the migration is safely bypassed automatically.
+
+- **Workspace Syncing for "notes" Folder Projects** — Refactored the directory scanner to dynamically check for direct `.md` files inside a root-level `notes` folder. Instead of skipping the directory unconditionally, the sync scanner now successfully scans it and imports/synchronizes the contents as a project named "notes" under standard folder layouts.
+
+- **ReferenceError Fix in Migration Modal Launch** — Resolved a crash in packaged production builds where triggering workspace migrations threw a `ReferenceError: ctx is not defined`. We refactored `registerAppHandlers` to accept a dynamic `DbContext` parameter and query active windows dynamically using `ctx.getWin()`, ensuring robust event streaming and state management.
+
+- **Target Path Correction for Project Deletion** — Corrected project deletions inside MCP tools to target the standardized root-level project slugs (e.g. `path.join(workspacePath, toSlug(project.name))`) rather than looking inside legacy intermediate `notes/` directories.
+
+### Changes
+
+- `electron/notes-files.ts` — Updated the workspace root sync scanner to dynamically scan `notes` folders containing direct `.md` files rather than skipping them unconditionally.
+- `electron/migrations.ts` — Updated the legacy `v1.5-drop-notes-dir` check logic to return `false` (bypassed) if direct `.md` files exist inside the root-level `notes/` folder.
+- `electron/mcp/tools/projects.ts` — Aligned project folder deletion paths with standardized root-level slugs.
+- `electron/ipc/handlers.ts` & `electron/main.ts` — Refactored `registerAppHandlers` to resolve context scope and active window retrieval issues.
+- `electron/migrations.test.ts` — Created a comprehensive unit test suite covering legacy migration triggers, Obsidian vault detection, and copy-verify-delete operations.
+- `electron/obsidian-compat.test.ts` — Added automated test coverage for project-level synchronization of a root `notes/` directory with direct `.md` files.

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -592,10 +592,9 @@ export function registerIpcHandlers(ctx: DbContext): void {
   * @param updateTrayBadge - callback to update the tray badge count
   */
 export function registerAppHandlers(
-  db: Database.Database,
+  ctx: DbContext,
   userDataPath: string,
   updateTrayBadge: (count: number) => void,
-  win?: BrowserWindow,
   onReinitialise?: (newWorkspacePath: string) => Promise<void>,
   /** Called when the badge is cleared from the renderer — resets poller count too. */
   onBadgeClear?: () => void,
@@ -630,9 +629,12 @@ export function registerAppHandlers(
     // On Windows, update the native title bar overlay to match the new theme.
     // Use --surface values (not backgroundColor) to match TitleBar's bg-[var(--surface)].
     // height:39 not 40 — Windows 1px window border makes 40 clip the border-b below the bar.
-    if (process.platform === "win32" && win && !win.isDestroyed()) {
-      const surface = theme === "light" ? "#ffffff" : "#141414";
-      win.setTitleBarOverlay({ color: surface, symbolColor: "#888888", height: 39 });
+    if (process.platform === "win32") {
+      const activeWin = ctx.getWin();
+      if (activeWin && !activeWin.isDestroyed()) {
+        const surface = theme === "light" ? "#ffffff" : "#141414";
+        activeWin.setTitleBarOverlay({ color: surface, symbolColor: "#888888", height: 39 });
+      }
     }
   }));
 
@@ -680,7 +682,7 @@ export function registerAppHandlers(
   ipcMain.handle("app:reset", () => handle(() => {
     const tables = ["chat_messages", "chat_threads", "mcp_notifications", "task_cards", "board_columns", "notes", "tags", "projects", "workspaces"];
     for (const t of tables) {
-      db.prepare(`DELETE FROM ${t}`).run();
+      ctx.db.prepare(`DELETE FROM ${t}`).run();
     }
     app.relaunch();
     app.quit();
@@ -702,7 +704,7 @@ export function registerAppHandlers(
 
   // ── MCP notification handler ───────────────────────
   ipcMain.handle("mcp:markNotificationsRead", () => handle(() => {
-    markMcpNotificationsRead(db);
+    markMcpNotificationsRead(ctx.db);
     updateTrayBadge(0);
     onBadgeClear?.();
   }));
@@ -710,9 +712,10 @@ export function registerAppHandlers(
   // ── Export note as PDF ─────────────────────────────
   ipcMain.handle("app:exportNotePdf", (_e, { title, html }: { title: string; html: string }) =>
     handle(async () => {
-      if (!win || win.isDestroyed()) throw new Error("No window");
+      const activeWin = ctx.getWin();
+      if (!activeWin || activeWin.isDestroyed()) throw new Error("No window");
 
-      const { canceled, filePath: savePath } = await dialog.showSaveDialog(win, {
+      const { canceled, filePath: savePath } = await dialog.showSaveDialog(activeWin, {
         title: "Export Note as PDF",
         defaultPath: `${title}.pdf`,
         filters: [{ name: "PDF Document", extensions: ["pdf"] }],
@@ -868,8 +871,9 @@ pre, blockquote, table { page-break-inside: avoid; }
     handle(async () => {
       await runMigration(ctx.workspacePath, migrationId, (pct, msg) => {
         // Send progress events to the renderer
-        if (win && !win.isDestroyed()) {
-          win.webContents.send("app:migrationProgress", { migrationId, pct, msg });
+        const activeWin = ctx.getWin();
+        if (activeWin && !activeWin.isDestroyed()) {
+          activeWin.webContents.send("app:migrationProgress", { migrationId, pct, msg });
         }
       });
       return { ok: true };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -263,7 +263,7 @@ app.whenReady().then(async () => {
   win.on("focus", clearBadge);
 
   // Register app:* and mcp:* IPC handlers (now that updateBadge is available)
-  registerAppHandlers(ctx.db, userDataPath, updateBadge, win, reinitialise, clearBadge);
+  registerAppHandlers(ctx, userDataPath, updateBadge, reinitialise, clearBadge);
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/electron/mcp/tools/projects.ts
+++ b/electron/mcp/tools/projects.ts
@@ -5,6 +5,7 @@ import Database from "better-sqlite3";
 import { newId, ts } from "../../db/utils";
 import { DEFAULT_COLUMNS } from "../../db/defaults";
 import { insertNotification, Snapshot } from "../db";
+import { toSlug } from "../../shared/text-utils";
 
 export function upsert_project(db: Database.Database, snap: Snapshot, args: Record<string, any>) {
   if (args.projectId) {
@@ -52,7 +53,7 @@ export function delete_project(db: Database.Database, snap: Snapshot, workspaceP
   const project = snap.projects.find((p) => p.id === args.projectId);
   if (!project) return { error: "Project not found" };
   // Delete notes dir
-  const notesDir = path.join(workspacePath, "notes", project.name.trim().replace(/[/\\:*?"<>|]/g, "").slice(0, 100).trim() || "Untitled");
+  const notesDir = path.join(workspacePath, toSlug(project.name));
   if (fs.existsSync(notesDir)) {
     try { fs.rmSync(notesDir, { recursive: true, force: true }); } catch { /* ignore */ }
   }

--- a/electron/migrations.test.ts
+++ b/electron/migrations.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { checkMigrations, runAllPendingMigrations } from "./migrations";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cairn-migration-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("Cairn Migration System", () => {
+  it("does not require migration if notes/ folder does not exist", () => {
+    const statuses = checkMigrations(tmpDir);
+    const m = statuses.find((s) => s.id === "v1.5-drop-notes-dir");
+    expect(m).toBeDefined();
+    expect(m!.needed).toBe(false);
+  });
+
+  it("requires migration if notes/ folder contains project directories but no direct .md files", () => {
+    const notesDir = path.join(tmpDir, "notes");
+    fs.mkdirSync(path.join(notesDir, "proj-a"), { recursive: true });
+    fs.writeFileSync(path.join(notesDir, "proj-a", "note1.md"), "# Note 1", "utf-8");
+
+    const statuses = checkMigrations(tmpDir);
+    const m = statuses.find((s) => s.id === "v1.5-drop-notes-dir");
+    expect(m!.needed).toBe(true);
+  });
+
+  it("bypasses migration if notes/ folder contains direct .md files (Obsidian style)", () => {
+    const notesDir = path.join(tmpDir, "notes");
+    fs.mkdirSync(notesDir, { recursive: true });
+    fs.writeFileSync(path.join(notesDir, "direct-note.md"), "# Direct Note", "utf-8");
+    // Even if there's a subdirectory
+    fs.mkdirSync(path.join(notesDir, "proj-a"), { recursive: true });
+    fs.writeFileSync(path.join(notesDir, "proj-a", "note1.md"), "# Note 1", "utf-8");
+
+    const statuses = checkMigrations(tmpDir);
+    const m = statuses.find((s) => s.id === "v1.5-drop-notes-dir");
+    expect(m!.needed).toBe(false);
+  });
+
+  it("performs migration copy-verify-delete successfully", async () => {
+    const notesDir = path.join(tmpDir, "notes");
+    fs.mkdirSync(path.join(notesDir, "proj-a"), { recursive: true });
+    fs.writeFileSync(path.join(notesDir, "proj-a", "note1.md"), "# Note 1 Content", "utf-8");
+
+    const statusesBefore = checkMigrations(tmpDir);
+    expect(statusesBefore.find((s) => s.id === "v1.5-drop-notes-dir")!.needed).toBe(true);
+
+    const migratedCount = await runAllPendingMigrations(tmpDir, () => {});
+    expect(migratedCount).toBe(1);
+
+    // Verify notes have moved to root
+    const rootProjDir = path.join(tmpDir, "proj-a");
+    expect(fs.existsSync(rootProjDir)).toBe(true);
+    expect(fs.readFileSync(path.join(rootProjDir, "note1.md"), "utf-8")).toBe("# Note 1 Content");
+
+    // Original notes directory is deleted/gone
+    expect(fs.existsSync(notesDir)).toBe(false);
+
+    // Migration marked complete
+    const statusesAfter = checkMigrations(tmpDir);
+    expect(statusesAfter.find((s) => s.id === "v1.5-drop-notes-dir")!.needed).toBe(false);
+  });
+});

--- a/electron/migrations.ts
+++ b/electron/migrations.ts
@@ -75,9 +75,13 @@ const dropNotesDirMigration: Migration = {
   check(workspacePath: string): boolean {
     const notesDir = path.join(workspacePath, "notes");
     if (!fs.existsSync(notesDir)) return false;
-    // Only needed if notes/ contains at least one directory (project folder)
     try {
       const entries = fs.readdirSync(notesDir);
+      // If there are any .md files directly inside notes/, it's an Obsidian project folder named "notes"
+      const hasDirectMd = entries.some((e) => e.endsWith(".md") && fs.lstatSync(path.join(notesDir, e)).isFile());
+      if (hasDirectMd) return false;
+
+      // Only needed if notes/ contains at least one directory (project folder)
       return entries.some((e) => {
         const fp = path.join(notesDir, e);
         return fs.lstatSync(fp).isDirectory() && !e.startsWith(".");

--- a/electron/notes-files.ts
+++ b/electron/notes-files.ts
@@ -323,13 +323,27 @@ function cleanStaleTmpFiles(dir: string): void {
 
 function syncDir(db: Database.Database, dir: string, workspacePath: string): void {
   // Known non-note directories to skip when scanning from workspace root
-  const SKIP_DIRS = new Set(["assets", "attachments", "notes"]);
+  const SKIP_DIRS = new Set(["assets", "attachments"]);
 
   for (const entry of fs.readdirSync(dir)) {
     // Skip dot-prefixed directories (.obsidian, .trash, .git, etc.)
     if (entry.startsWith(".")) continue;
     // Skip known infrastructure directories
     if (SKIP_DIRS.has(entry) && dir === workspacePath) continue;
+
+    if (entry === "notes" && dir === workspacePath) {
+      // Skip only if it's a legacy notes/ directory (no direct .md files)
+      const notesPath = path.join(workspacePath, "notes");
+      try {
+        const entries = fs.readdirSync(notesPath);
+        const hasDirectMd = entries.some((e) => e.endsWith(".md") && fs.lstatSync(path.join(notesPath, e)).isFile());
+        if (!hasDirectMd) {
+          continue;
+        }
+      } catch {
+        continue;
+      }
+    }
 
     const fp = path.join(dir, entry);
     const stat = fs.lstatSync(fp);

--- a/electron/obsidian-compat.test.ts
+++ b/electron/obsidian-compat.test.ts
@@ -529,4 +529,17 @@ describe("mixed Cairn and Obsidian files", () => {
     expect(finalData.aliases).toEqual(["cf"]);
     expect(finalData.id).toBe("cairn-1");
   });
+
+  it("does not skip root notes/ folder if it has direct .md files, synchronising it as a project called notes", () => {
+    seedProject(db, "notes", "proj-notes", "ws1");
+
+    const notesDir = path.join(tmpDir, "notes");
+    writePlainMdFile(notesDir, "My Note.md", "# My Note\n\nContent.");
+
+    syncNotesFromDisk(db, tmpDir);
+
+    const rows = db.prepare("SELECT title FROM notes WHERE project_id = ?").all("proj-notes") as { title: string }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe("My Note");
+  });
 });


### PR DESCRIPTION
## What does this PR do?

This PR introduces robust Obsidian vault directory compatibility to Cairn, ensuring that vaults containing root-level `notes` directories with direct `.md` files correctly bypass legacy directory migrations and are synchronized as active projects. Additionally, it fixes a context ReferenceError within the startup Migration Modal handlers in packaged production builds and standardizes project folder deletion paths.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code quality
- [x] Docs / changelog
- [x] Tests

## Screenshots / recording

*(No UI visual presentation changes; refactored modal initialization and workspace syncing logic only)*

## Checklist

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts` *(N/A)*
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

- **Migration Detection**: The core change is in `electron/migrations.ts` and `electron/notes-files.ts` where we check if a root-level `notes/` directory contains any direct `.md` files. If it does (Obsidian-style), the migration is bypassed (`needed: false`) and the folder is scanned normaly as a project named `"notes"`.
- **Ipc Handlers Scope Fix**: Refactored `registerAppHandlers` signature in `electron/ipc/handlers.ts` to accept `ctx: DbContext` instead of just a raw `db`, bringing the dynamic `workspacePath` into scope and preventing a startup crash (`ReferenceError: ctx is not defined`) in production.
- **Dynamic Window Selection**: Modified `registerAppHandlers` to retrieve the active window via `ctx.getWin()` rather than utilizing a static, launch-time captured instance.
- **Comprehensive Tests**: Added a full suite of tests in `electron/migrations.test.ts` and `electron/obsidian-compat.test.ts` covering all edge cases (missing notes dir, legacy notes dir, Obsidian-style notes dir with direct files, copy-verify-delete, and note sync). All 416 unit tests are green.
