### PR TITLE
v1.7.3 - Chat and Agent Fixes

### DIFF
--- a/changelogs/v1.7.3.md
+++ b/changelogs/v1.7.3.md
@@ -1,0 +1,15 @@
+## What's new
+
+### Features
+- **Slash Commands & Autocomplete**: Added a slash command autocomplete menu (`/`) in the chat input panel (supporting commands like `/compact`, `/code-review`, `/spawn-subagent`, and `/test` for agent and general AI chats).
+- **Chat Compaction**: Integrated chat compaction history parsing to summarize chat history when it grows too large, optimizing context token usage.
+- **Context Usage Tracker**: Display a live-updating context token usage indicator (`ContextRing`) in the general AI Assistant panel header.
+- **Git Bash Auto-Detection**: Integrated detection and support for native Git Bash executable on Windows environments to prevent WSL-only execution path issues.
+- **Single Instance Lock**: Restrict Cairn desktop app to a single instance, automatically focusing the active window when another instance is run.
+- **UX Tab Closing**: Added support for closing open files (in Agent view editor) and terminal tabs with a middle-click (button 1 on mouse).
+
+### Fixes
+- **Code Directory Persistence**: Fixed the folder dialog picker on the Project Overview screen to immediately persist the chosen directory path via `updateProject`.
+
+### Changes
+- Updated the `ChatThread` data model, Zustand store slice, and main-process IPC handlers to support tracking and persisting token usage, rendering system messages, and clearing message history on demand.

--- a/electron/ipc/chat.ts
+++ b/electron/ipc/chat.ts
@@ -135,6 +135,33 @@ async function runToolLoop(
 }
 
 export function registerChatHandler(db: Database.Database, workspacePath: string, getWin?: () => BrowserWindow | null): void {
+  // chat:compactThread — generates a summary for a chat thread
+  ipcMain.handle("chat:compactThread", async (_event, req: {
+    messages: Array<{ role: string; content: string }>;
+    config: { provider?: string; baseUrl?: string; model?: string; apiKey?: string };
+  }) => {
+    return handle(async () => {
+      const provider = req.config?.provider ?? "openai";
+      const baseUrl = normaliseBaseUrl(req.config?.baseUrl ?? "https://api.openai.com");
+      const model = req.config?.model ?? "gpt-4o-mini";
+      const apiKey = req.config?.apiKey ?? "";
+      
+      const llmConfig = {
+        baseUrl,
+        model,
+        apiKey,
+        maxSteps: 20,
+        temperature: 0.1,
+      };
+
+      const { generateSummary } = await import("../lib/compaction");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const agentMsgs = req.messages as any[];
+      const summary = await generateSummary(agentMsgs, llmConfig, new AbortController().signal);
+      return { summary };
+    });
+  });
+
   // chat:abort — cancel the in-flight stream for this renderer
   ipcMain.on("chat:abort", (event) => {
     const ctrl = abortControllers.get(event.sender.id);

--- a/electron/ipc/chat.ts
+++ b/electron/ipc/chat.ts
@@ -37,6 +37,7 @@ async function runToolLoop(
   signal?: AbortSignal,
   getWin?: () => BrowserWindow | null,
   provider?: string,
+  onUsage?: (pt: number, ct: number) => void,
 ): Promise<{ exhausted: true; content: string } | { exhausted: false }> {
   const maxSteps    = req.config?.maxSteps    ?? 20;
   const temperature = req.config?.temperature ?? 0.3;
@@ -51,6 +52,9 @@ async function runToolLoop(
         const res = await callLocalLLMChat(messages, TOOLS);
         const choice = res.choices?.[0];
         if (!choice) return { exhausted: true, content: "No response from local Llama on-device model." };
+        if (res.usage && onUsage) {
+          onUsage(res.usage.prompt_tokens ?? 0, res.usage.completion_tokens ?? 0);
+        }
         assistantMsg = choice.message as OpenAIMessage;
 
         // Self-Healing Parser for On-Device XML-style tool calls and tokenizers
@@ -105,6 +109,9 @@ async function runToolLoop(
       const data = await response.json() as any;
       const choice = data.choices?.[0];
       if (!choice) return { exhausted: true, content: "No response from AI endpoint." };
+      if (data.usage && onUsage) {
+        onUsage(data.usage.prompt_tokens ?? 0, data.usage.completion_tokens ?? 0);
+      }
       assistantMsg = choice.message as OpenAIMessage;
     }
 
@@ -141,7 +148,6 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
     config: { provider?: string; baseUrl?: string; model?: string; apiKey?: string };
   }) => {
     return handle(async () => {
-      const provider = req.config?.provider ?? "openai";
       const baseUrl = normaliseBaseUrl(req.config?.baseUrl ?? "https://api.openai.com");
       const model = req.config?.model ?? "gpt-4o-mini";
       const apiKey = req.config?.apiKey ?? "";
@@ -210,17 +216,25 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
       send("chat:tool-call", e);
     };
 
-    const loopResult = await runToolLoop(db, req, workspacePath, baseUrl, model, apiKey, messages, emitToolCall, abortCtrl.signal, getWin, provider);
+    let promptTokens = 0;
+    let completionTokens = 0;
+    const addUsage = (pt: number, ct: number) => {
+      promptTokens += pt;
+      completionTokens += ct;
+      send("chat:usage", { promptTokens, completionTokens });
+    };
+
+    const loopResult = await runToolLoop(db, req, workspacePath, baseUrl, model, apiKey, messages, emitToolCall, abortCtrl.signal, getWin, provider, addUsage);
 
     abortControllers.delete(event.sender.id);
 
     if (abortCtrl.signal.aborted) {
-      send("chat:done", { content: "", contextRefs: [] });
+      send("chat:done", { content: "", contextRefs: [], usage: promptTokens > 0 ? { promptTokens, completionTokens } : undefined });
       return;
     }
 
     if (loopResult.exhausted) {
-      send("chat:done", { content: loopResult.content, contextRefs: [] });
+      send("chat:done", { content: loopResult.content, contextRefs: [], usage: promptTokens > 0 ? { promptTokens, completionTokens } : undefined });
       return;
     }
 
@@ -232,7 +246,7 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
       // Re-request with stream: true for real SSE tokens
       let fullContent = "";
       try {
-        for await (const delta of streamCompletion({ baseUrl, model, apiKey, provider: provider as "openai" | "localllm" }, messages, TOOLS)) {
+        for await (const delta of streamCompletion({ baseUrl, model, apiKey, provider: provider as "openai" | "localllm" }, messages, TOOLS, addUsage)) {
           if (abortCtrl.signal.aborted) break;
           fullContent += delta;
           send("chat:token", { delta });
@@ -241,16 +255,16 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
         // Fallback: just emit the already-received content verbatim
         if (!fullContent) {
           send("chat:token", { delta: lastMsg.content });
-          send("chat:done", { content: lastMsg.content, contextRefs: [] });
+          send("chat:done", { content: lastMsg.content, contextRefs: [], usage: promptTokens > 0 ? { promptTokens, completionTokens } : undefined });
           return;
         }
       }
 
-      send("chat:done", { content: fullContent || (lastMsg.content ?? ""), contextRefs: [] });
+      send("chat:done", { content: fullContent || (lastMsg.content ?? ""), contextRefs: [], usage: promptTokens > 0 ? { promptTokens, completionTokens } : undefined });
       return;
     }
 
     // Unexpected state — shouldn't happen, but be safe
-    send("chat:done", { content: "", contextRefs: [] });
+    send("chat:done", { content: "", contextRefs: [], usage: promptTokens > 0 ? { promptTokens, completionTokens } : undefined });
   });
 }

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -527,6 +527,9 @@ export function registerIpcHandlers(ctx: DbContext): void {
   ipcMain.handle("db:chat:messages", (_e, { threadId }) => handle(() => q.getChatMessages(ctx.db, threadId)));
   ipcMain.handle("db:chat:upsertThread", (_e, args) => handle(() => q.upsertChatThread(ctx.db, args)));
   ipcMain.handle("db:chat:addMessage", (_e, args) => handle(() => q.addChatMessage(ctx.db, args)));
+  ipcMain.handle("db:chat:clearThreadMessages", (_e, { threadId }) => handle(() => {
+    ctx.db.prepare("DELETE FROM chat_messages WHERE thread_id = ?").run(threadId);
+  }));
   ipcMain.handle("db:chat:deleteThread", (_e, { threadId }) => handle(() => q.deleteChatThread(ctx.db, threadId)));
 
   // ── Pi Agent Sessions ─────────────────────────────────────────────────────────────────────────────────

--- a/electron/ipc/pi-agent.ts
+++ b/electron/ipc/pi-agent.ts
@@ -303,8 +303,10 @@ export function registerPiAgentHandler(
     try {
       const result = await compactNow(session, llmConfig);
       if (result) {
+        session.messages = result.messages;
         // Update the transformer's cache so the next runAgentLoop call uses the summary
         session.compactionTransformer = undefined; // reset so it rebuilds with new context
+        q.saveLlmHistory(ctx.db, sessionId, session.messages);
         send("pi-agent:compact-result", { sessionId, messageCount: result.messages.length, summary: result.summary });
       } else {
         send("pi-agent:compact-result", { sessionId, messageCount: 0, summary: "" });

--- a/electron/lib/coding-tools/bash.ts
+++ b/electron/lib/coding-tools/bash.ts
@@ -8,7 +8,9 @@
  *        detached-PID tracking (so in-flight children are killed on app exit).
  */
 
-import { spawn } from "child_process";
+import { spawn, execSync } from "child_process";
+import fs from "fs";
+import path from "path";
 import { DEFAULT_MAX_BYTES } from "../truncation";
 
 // Local byte formatter for streaming truncation hints
@@ -20,6 +22,75 @@ function fmt(bytes: number): string {
 
 const MAX_OUTPUT_BYTES = DEFAULT_MAX_BYTES;
 const DEFAULT_TIMEOUT_MS = 120_000; // 2 minutes
+
+// ── Git Bash detection on Windows ─────────────────────────────────────────────
+// Prevents spawning WSL bash (which is the default "bash" in C:\Windows\System32)
+// and instead uses the native Git Bash shell.
+function getBashExecutable(): string {
+  if (process.platform !== "win32") {
+    return "bash";
+  }
+
+  // 1. Check standard installation paths
+  const standardPaths = [
+    "C:\\Program Files\\Git\\bin\\bash.exe",
+    "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+    "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+  ];
+  if (process.env.USERPROFILE) {
+    standardPaths.push(
+      path.join(process.env.USERPROFILE, "AppData\\Local\\Programs\\Git\\bin\\bash.exe"),
+      path.join(process.env.USERPROFILE, "AppData\\Local\\Programs\\Git\\usr\\bin\\bash.exe")
+    );
+  }
+  if (process.env.LOCALAPPDATA) {
+    standardPaths.push(
+      path.join(process.env.LOCALAPPDATA, "Programs\\Git\\bin\\bash.exe"),
+      path.join(process.env.LOCALAPPDATA, "Programs\\Git\\usr\\bin\\bash.exe")
+    );
+  }
+
+  for (const p of standardPaths) {
+    if (fs.existsSync(p)) {
+      return p;
+    }
+  }
+
+  // 2. Try to locate git.exe via PATH and find bash.exe nearby
+  try {
+    const gitPath = execSync("where git", { encoding: "utf8" }).split("\r\n")[0]?.trim();
+    if (gitPath && fs.existsSync(gitPath)) {
+      // "where git" typically returns "C:\Program Files\Git\cmd\git.exe"
+      const gitDir = path.dirname(gitPath); // e.g. "C:\Program Files\Git\cmd"
+      const candidateBin = path.resolve(gitDir, "..", "bin", "bash.exe");
+      if (fs.existsSync(candidateBin)) {
+        return candidateBin;
+      }
+      const candidateUsrBin = path.resolve(gitDir, "..", "usr", "bin", "bash.exe");
+      if (fs.existsSync(candidateUsrBin)) {
+        return candidateUsrBin;
+      }
+    }
+  } catch {
+    // Ignore error if 'where' fails
+  }
+
+  // 3. Search PATH for bash.exe (excluding WSL / System32)
+  const pathDirs = (process.env.PATH || "").split(path.delimiter);
+  for (const dir of pathDirs) {
+    const lowerDir = dir.toLowerCase();
+    if (lowerDir.includes("system32") || lowerDir.includes("syswow64") || lowerDir.includes("windows")) {
+      continue;
+    }
+    const fullPath = path.join(dir, "bash.exe");
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+
+  // Fallback to default "bash"
+  return "bash";
+}
 
 // ── Detached child PID tracking ───────────────────────────────────────────────
 // Tracks PIDs of spawned children so they can be killed on app shutdown.
@@ -81,7 +152,8 @@ export async function bashTool(
     let output = "";
     let truncated = false;
 
-    const child = spawn("bash", ["-c", args.command], {
+    const bashExe = getBashExecutable();
+    const child = spawn(bashExe, ["-c", args.command], {
       cwd,
       // detached: true creates a new process group so process.kill(-pid) reaches
       // all children spawned by the command, not just the direct bash process.

--- a/electron/lib/compaction.ts
+++ b/electron/lib/compaction.ts
@@ -112,7 +112,7 @@ Produce a concise summary of the above conversation for use as context in a futu
 
 Be specific. Cite file paths, function names, and line numbers where they matter. Omit pleasantries and filler.`;
 
-async function generateSummary(
+export async function generateSummary(
   messages: AgentMessage[],
   llmConfig: AgentLLMConfig,
   signal: AbortSignal,

--- a/electron/lib/llm.ts
+++ b/electron/lib/llm.ts
@@ -79,10 +79,14 @@ export async function* streamCompletion(
   config: LLMConfig,
   messages: OpenAIMessage[],
   tools?: object[],
+  onUsage?: (pt: number, ct: number) => void,
 ): AsyncGenerator<string> {
   if (config.provider === "localllm") {
     const { streamLocalLLMChat } = await import("./local-llm");
     for await (const chunk of streamLocalLLMChat(messages)) {
+      if (chunk.usage && onUsage) {
+        onUsage(chunk.usage.prompt_tokens ?? 0, chunk.usage.completion_tokens ?? 0);
+      }
       const delta = chunk.choices?.[0]?.delta?.content ?? "";
       if (delta) yield delta;
     }
@@ -102,6 +106,9 @@ export async function* streamCompletion(
   if (tools && tools.length > 0) {
     body.tools = tools;
     body.tool_choice = "none";
+  }
+  if (onUsage) {
+    body.stream_options = { include_usage: true };
   }
 
   const response = await fetch(`${config.baseUrl}/v1/chat/completions`, {
@@ -127,8 +134,11 @@ export async function* streamCompletion(
       const jsonStr = trimmed.slice(5).trim();
       if (jsonStr === "[DONE]") return;
       try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const delta: string = (JSON.parse(jsonStr) as any).choices?.[0]?.delta?.content ?? "";
+        const obj = JSON.parse(jsonStr);
+        if (obj.usage && onUsage) {
+          onUsage(obj.usage.prompt_tokens ?? 0, obj.usage.completion_tokens ?? 0);
+        }
+        const delta: string = obj.choices?.[0]?.delta?.content ?? "";
         if (delta) yield delta;
       } catch { /* skip malformed lines */ }
     }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -33,6 +33,24 @@ import { stopServerSync } from "./lib/llama-server";
 
 const isDev = !app.isPackaged;
 
+const gotTheLock = app.requestSingleInstanceLock();
+
+if (!gotTheLock) {
+  app.quit();
+} else {
+  app.on("second-instance", () => {
+    // Someone tried to run a second instance, we should focus our window.
+    // However, since app.whenReady() is already running, we might need a reference to the main window.
+    // Given the architecture, we could store a reference to the main window globally or
+    // use a singleton pattern, but here we can try to find the window.
+    const allWindows = BrowserWindow.getAllWindows();
+    if (allWindows.length > 0) {
+      if (allWindows[0].isMinimized()) allWindows[0].restore();
+      allWindows[0].focus();
+    }
+  });
+}
+
 app.setName("Cairn");
 
 // Windows: required for Toast notifications to show with the correct app identity.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -102,6 +102,8 @@ const api = {
     upsertThread:  (args: unknown) => invoke("db:chat:upsertThread", args),
     addMessage:    (args: unknown) => invoke("db:chat:addMessage", args),
     deleteThread:  (threadId: string) => invoke("db:chat:deleteThread", { threadId }),
+    clearThreadMessages: (threadId: string) => invoke("db:chat:clearThreadMessages", { threadId }),
+    compactThread: (req: unknown) => invoke("chat:compactThread", req),
     // ── AI Chat streaming ──────────────────────
     // Fire-and-forget. Listen with onToken / onDone / onToolCall.
     stream: (req: unknown) => ipcRenderer.send("chat:stream", req),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -126,6 +126,12 @@ const api = {
       ipcRenderer.on("chat:tool-call", handler);
       return () => ipcRenderer.off("chat:tool-call", handler);
     },
+    onUsage: (cb: (e: { promptTokens: number; completionTokens: number }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { promptTokens: number; completionTokens: number }) => cb(e);
+      ipcRenderer.on("chat:usage", handler);
+      return () => ipcRenderer.off("chat:usage", handler);
+    },
   },
 
   // ── Knowledge Graph ───────────────────────────

--- a/src/components/agent/AgentEditor.tsx
+++ b/src/components/agent/AgentEditor.tsx
@@ -113,6 +113,12 @@ export function AgentEditor() {
             <div
               key={filePath}
               onClick={() => setActiveEditorFile(filePath)}
+              onAuxClick={(e) => {
+                if (e.button === 1) {
+                  e.preventDefault();
+                  handleClose(e, filePath);
+                }
+              }}
               title={filePath}
               className={cn(
                 "group flex items-center gap-1.5 px-3 py-1.5 text-[0.714rem] cursor-pointer select-none flex-shrink-0 border-r border-[var(--border)] transition-colors",

--- a/src/components/agent/AgentTerminalPane.tsx
+++ b/src/components/agent/AgentTerminalPane.tsx
@@ -634,6 +634,12 @@ function TerminalTab({ session, isActive, onActivate, onClose }: TerminalTabProp
   return (
     <button
       onClick={onActivate}
+      onAuxClick={(e) => {
+        if (e.button === 1) {
+          e.preventDefault();
+          onClose(e);
+        }
+      }}
       role="tab"
       aria-selected={isActive}
       className={cn(

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -61,6 +61,29 @@ function extractCairnRef(
 }
 
 
+const NATIVE_AGENT_SLASH_COMMANDS = [
+  {
+    name: "compact",
+    description: "Summarise and compact conversation history",
+    insertText: "/compact",
+  },
+  {
+    name: "code-review",
+    description: "Review recent git changes for bugs and style",
+    insertText: "Please run a code review of the recent changes. Run git diff and analyze it.",
+  },
+  {
+    name: "spawn-subagent",
+    description: "Spawn a subagent to work on a task",
+    insertText: '/spawn-subagent task: "write tests for..."',
+  },
+  {
+    name: "test",
+    description: "Run project tests and verify correctness",
+    insertText: "Run the project tests and report if they pass.",
+  },
+];
+
 interface PiAgentPaneProps {
   session: TerminalSession;
   isActive: boolean;
@@ -616,6 +639,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
           isLoading={isLoading}
           disabled={isLoading}
           placeholder={session.mode === "plan" ? "Describe what you want to build…" : "Ask the agent…"}
+          commands={NATIVE_AGENT_SLASH_COMMANDS}
         />
         <p className="text-[0.643rem] text-[var(--text-tertiary)] mt-1 text-center">
           {retryInfo

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useState, useMemo } from "react";
 import { Send, Square, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip } from "@/components/ui/tooltip";
+
+export interface SlashCommand {
+  name: string;
+  description: string;
+  insertText: string;
+}
 
 interface ChatInputProps {
   value: string;
@@ -16,6 +22,7 @@ interface ChatInputProps {
   variant?: "default" | "overview";
   showSparkles?: boolean;
   autoFocus?: boolean;
+  commands?: SlashCommand[];
 }
 
 export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
@@ -31,11 +38,39 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
       variant = "default",
       showSparkles = false,
       autoFocus = false,
+      commands = [],
     },
     ref
   ) => {
     const internalRef = useRef<HTMLTextAreaElement>(null);
     const resolvedRef = (ref as React.RefObject<HTMLTextAreaElement>) || internalRef;
+
+    const [showSuggestions, setShowSuggestions] = useState(false);
+    const [activeIndex, setActiveIndex] = useState(0);
+
+    // Filter commands based on input
+    const filteredCommands = useMemo(() => {
+      if (!commands.length || !value.startsWith("/")) return [];
+      const query = value.slice(1).toLowerCase();
+      return commands.filter((cmd) => cmd.name.toLowerCase().includes(query));
+    }, [commands, value]);
+
+    // Show suggestions only when there are matching commands
+    useEffect(() => {
+      if (filteredCommands.length > 0) {
+        setShowSuggestions(true);
+        setActiveIndex((prev) => Math.min(prev, filteredCommands.length - 1));
+      } else {
+        setShowSuggestions(false);
+        setActiveIndex(0);
+      }
+    }, [filteredCommands]);
+
+    const handleSelectCommand = (cmd: SlashCommand) => {
+      onChange(cmd.insertText);
+      setShowSuggestions(false);
+      resolvedRef.current?.focus();
+    };
 
     // Auto-resize height based on contents
     useEffect(() => {
@@ -53,6 +88,29 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
     }, [autoFocus, resolvedRef]);
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (showSuggestions && filteredCommands.length > 0) {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setActiveIndex((prev) => (prev + 1) % filteredCommands.length);
+          return;
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setActiveIndex((prev) => (prev - 1 + filteredCommands.length) % filteredCommands.length);
+          return;
+        }
+        if (e.key === "Enter" || e.key === "Tab") {
+          e.preventDefault();
+          handleSelectCommand(filteredCommands[activeIndex]);
+          return;
+        }
+        if (e.key === "Escape") {
+          e.preventDefault();
+          setShowSuggestions(false);
+          return;
+        }
+      }
+
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         if (!disabled && !isLoading && value.trim()) {
@@ -64,63 +122,102 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
     const isOverview = variant === "overview";
 
     return (
-      <div
-        className={cn(
-          "relative flex items-end gap-2.5 transition-all duration-300",
-          isOverview
-            ? "rounded-2xl border border-[var(--border)] bg-[color-mix(in srgb,var(--surface-2)_85%,transparent)] backdrop-blur-md px-4 py-3 shadow-[0_8px_30px_rgb(0,0,0,0.12)] hover:border-[color-mix(in srgb,var(--accent)_40%,transparent)] focus-within:border-[var(--accent)] focus-within:ring-2 focus-within:ring-[var(--accent-dim)]"
-            : "rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-3 py-2.5 focus-within:border-[var(--accent)] focus-within:ring-2 focus-within:ring-[var(--accent-dim)]"
-        )}
-      >
-        {showSparkles && (
-          <div className="flex-shrink-0 w-8 h-8 rounded-xl bg-[var(--accent-dim)] text-[var(--accent)] flex items-center justify-center animate-pulse self-center">
-            <Sparkles size={14} />
+      <div className="relative w-full">
+        {/* Autocomplete suggestions */}
+        {showSuggestions && filteredCommands.length > 0 && (
+          <div className="absolute bottom-full left-0 right-0 mb-1.5 z-50 bg-[var(--surface)] border border-[var(--border)] rounded-xl shadow-2xl overflow-hidden max-h-56 overflow-y-auto">
+            <div className="px-3 py-1.5 border-b border-[var(--border)] bg-[var(--surface-2)] flex items-center justify-between">
+              <span className="text-[0.643rem] font-semibold uppercase tracking-wider text-[var(--text-tertiary)]">
+                Slash Commands
+              </span>
+              <span className="text-[0.571rem] text-[var(--text-tertiary)]">
+                ↑↓ to navigate · Enter to select
+              </span>
+            </div>
+            <div className="p-1">
+              {filteredCommands.map((cmd, index) => {
+                const isActive = index === activeIndex;
+                return (
+                  <button
+                    key={cmd.name}
+                    type="button"
+                    onClick={() => handleSelectCommand(cmd)}
+                    className={cn(
+                      "w-full text-left px-2.5 py-2 rounded-lg flex flex-col gap-0.5 transition-colors",
+                      isActive
+                        ? "bg-[var(--accent-dim)] text-[var(--accent)]"
+                        : "text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+                    )}
+                  >
+                    <span className="text-xs font-semibold">/{cmd.name}</span>
+                    <span className="text-[0.643rem] text-[var(--text-tertiary)]">
+                      {cmd.description}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         )}
 
-        <textarea
-          ref={resolvedRef}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={placeholder}
-          rows={1}
-          disabled={disabled}
+        <div
           className={cn(
-            "flex-1 bg-transparent text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none py-1.5 leading-relaxed resize-none overflow-y-auto max-h-32 disabled:opacity-60",
-            isOverview ? "text-sm min-h-[36px]" : "text-xs min-h-[32px]"
+            "relative flex items-end gap-2.5 transition-all duration-300",
+            isOverview
+              ? "rounded-2xl border border-[var(--border)] bg-[color-mix(in srgb,var(--surface-2)_85%,transparent)] backdrop-blur-md px-4 py-3 shadow-[0_8px_30px_rgb(0,0,0,0.12)] hover:border-[color-mix(in srgb,var(--accent)_40%,transparent)] focus-within:border-[var(--accent)] focus-within:ring-2 focus-within:ring-[var(--accent-dim)]"
+              : "rounded-lg border border-[var(--border)] bg-[var(--surface-2)] px-3 py-2.5 focus-within:border-[var(--accent)] focus-within:ring-2 focus-within:ring-[var(--accent-dim)]"
           )}
-        />
+        >
+          {showSparkles && (
+            <div className="flex-shrink-0 w-8 h-8 rounded-xl bg-[var(--accent-dim)] text-[var(--accent)] flex items-center justify-center animate-pulse self-center">
+              <Sparkles size={14} />
+            </div>
+          )}
 
-        <div className="flex items-center gap-2 flex-shrink-0 self-center">
-          {isLoading && onStop ? (
-            <Tooltip content="Stop generation" side="left">
-              <button
-                onClick={onStop}
-                type="button"
-                className={cn(
-                  "flex-shrink-0 rounded-lg bg-[var(--danger)] text-white hover:bg-[color-mix(in srgb,var(--danger)_90%,black)] flex items-center justify-center transition-all duration-200 hover:scale-105 active:scale-95 shadow-md shadow-[var(--danger)]/10",
-                  isOverview ? "w-8 h-8 rounded-xl" : "w-7 h-7"
-                )}
-              >
-                <Square size={isOverview ? 11 : 10} fill="currentColor" />
-              </button>
-            </Tooltip>
-          ) : (
-            <Tooltip content="Send (Enter)" side="left">
-              <button
-                onClick={onSubmit}
-                disabled={disabled || !value.trim()}
-                type="button"
-                className={cn(
-                  "flex-shrink-0 rounded-lg bg-[var(--accent)] text-white hover:bg-[color-mix(in srgb,var(--accent)_90%,black)] disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center transition-all duration-200 hover:scale-105 active:scale-95 shadow-md shadow-[var(--accent)]/10",
-                  isOverview ? "w-8 h-8 rounded-xl" : "w-7 h-7"
-                )}
-              >
-                <Send size={isOverview ? 13 : 12} />
-              </button>
-            </Tooltip>
-          )}
+          <textarea
+            ref={resolvedRef}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            rows={1}
+            disabled={disabled}
+            className={cn(
+              "flex-1 bg-transparent text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none py-1.5 leading-relaxed resize-none overflow-y-auto max-h-32 disabled:opacity-60",
+              isOverview ? "text-sm min-h-[36px]" : "text-xs min-h-[32px]"
+            )}
+          />
+
+          <div className="flex items-center gap-2 flex-shrink-0 self-center">
+            {isLoading && onStop ? (
+              <Tooltip content="Stop generation" side="left">
+                <button
+                  onClick={onStop}
+                  type="button"
+                  className={cn(
+                    "flex-shrink-0 rounded-lg bg-[var(--danger)] text-white hover:bg-[color-mix(in srgb,var(--danger)_90%,black)] flex items-center justify-center transition-all duration-200 hover:scale-105 active:scale-95 shadow-md shadow-[var(--danger)]/10",
+                    isOverview ? "w-8 h-8 rounded-xl" : "w-7 h-7"
+                  )}
+                >
+                  <Square size={isOverview ? 11 : 10} fill="currentColor" />
+                </button>
+              </Tooltip>
+            ) : (
+              <Tooltip content="Send (Enter)" side="left">
+                <button
+                  onClick={onSubmit}
+                  disabled={disabled || !value.trim()}
+                  type="button"
+                  className={cn(
+                    "flex-shrink-0 rounded-lg bg-[var(--accent)] text-white hover:bg-[color-mix(in srgb,var(--accent)_90%,black)] disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center transition-all duration-200 hover:scale-105 active:scale-95 shadow-md shadow-[var(--accent)]/10",
+                    isOverview ? "w-8 h-8 rounded-xl" : "w-7 h-7"
+                  )}
+                >
+                  <Send size={isOverview ? 13 : 12} />
+                </button>
+              </Tooltip>
+            )}
+          </div>
         </div>
       </div>
     );

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -15,6 +15,7 @@ import { SuggestedPrompts } from "./chat-panel/SuggestedPrompts";
 import { ToolCallIndicator } from "./chat-panel/ToolCallIndicator";
 import { QuestionForm } from "./chat-panel/QuestionForm";
 import { ChatInput } from "./ChatInput";
+import { ContextRing } from "@/components/agent/ContextRing";
 
 const GRAPH_SYSTEM_PROMPT = `You are a Knowledge Graph assistant embedded in Cairn, a note-taking and project management app.
 
@@ -152,6 +153,11 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
       .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
       .slice(0, 15),
     [chatThreads, activeProjectId],
+  );
+
+  const activeThread = useMemo(
+    () => chatThreads.find((t) => t.id === threadId),
+    [chatThreads, threadId]
   );
 
   // Initialise / switch thread.
@@ -331,7 +337,14 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
         <span className="text-sm font-semibold text-[var(--text-primary)] flex-1">
           {activeView === "graph" ? "Graph Assistant" : "AI Assistant"}
         </span>
-        <span className="text-xs text-[var(--text-tertiary)] truncate max-w-24">{project?.name ?? workspace?.name}</span>
+        <span className="text-xs text-[var(--text-tertiary)] truncate max-w-24 mr-2">{project?.name ?? workspace?.name}</span>
+
+        {activeThread?.lastUsage && (
+          <ContextRing
+            promptTokens={activeThread.lastUsage.promptTokens}
+            contextLimit={aiConfig.contextLimit ?? 128000}
+          />
+        )}
 
         {/* Thread history */}
         {projectThreads.length > 1 && (

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -47,6 +47,24 @@ You help users build meaningful connections between their notes, tasks, and proj
 
 Remember: Suggest connections actively. Call \`suggest_connections\` whenever there is even a potential relationship to explore!`;
 
+const CHAT_SLASH_COMMANDS = [
+  {
+    name: "compact",
+    description: "Summarise and compact conversation history",
+    insertText: "/compact",
+  },
+  {
+    name: "board",
+    description: "Show all task board columns and cards",
+    insertText: "List the current task board columns and cards.",
+  },
+  {
+    name: "review-note",
+    description: "Ask AI to review a note",
+    insertText: 'Please review my note "[note title]" and suggest improvements.',
+  },
+];
+
 interface ChatPanelProps {
   prefill?: { text: string; autoSend?: boolean } | null;
   onPrefillConsumed?: () => void;
@@ -168,6 +186,13 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
   const handleSend = useCallback((text?: string) => {
     const content = text ?? input.trim();
     if (!content || !threadId) return;
+
+    if (content === "/compact") {
+      setInput("");
+      useCairnStore.getState().compactChatThread(threadId);
+      return;
+    }
+
     setInput("");
     addMessage(threadId, "user", content);
 
@@ -437,6 +462,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
           isLoading={isLoading}
           disabled={isLoading}
           placeholder={activeView === "graph" ? "Ask about your knowledge graph…" : "Ask about your project…"}
+          commands={CHAT_SLASH_COMMANDS}
         />
         <div className="flex items-center justify-between mt-1.5 px-0.5">
           <p className="text-[0.714rem] text-[var(--text-tertiary)]">

--- a/src/components/chat/chat-panel/ChatMessageBubble.tsx
+++ b/src/components/chat/chat-panel/ChatMessageBubble.tsx
@@ -15,6 +15,7 @@ interface ChatMessageBubbleProps {
 
 export const ChatMessageBubble = React.memo(function ChatMessageBubble({ message, onRetry }: ChatMessageBubbleProps) {
   const isUser = message.role === "user";
+  const isSystem = message.role === "system";
   const [copied, setCopied] = useState(false);
 
   function handleCopy() {
@@ -22,6 +23,14 @@ export const ChatMessageBubble = React.memo(function ChatMessageBubble({ message
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
+  }
+
+  if (isSystem) {
+    return (
+      <div className="flex justify-center py-0.5">
+        <span className="text-[0.643rem] italic text-[var(--text-tertiary)] px-2">{message.content}</span>
+      </div>
+    );
   }
 
   return (

--- a/src/components/layout/project-overview.tsx
+++ b/src/components/layout/project-overview.tsx
@@ -60,7 +60,10 @@ export function ProjectOverview() {
 
   async function handlePickCodeDir() {
     const result = await window.electron?.agent.pickDirectory() as { data: string | null } | undefined;
-    if (result?.data) setCodeDirInput(result.data);
+    if (result?.data && project) {
+      setCodeDirInput(result.data);
+      updateProject(project.id, { codeDirectory: result.data });
+    }
   }
 
   function handleSaveCodeDir() {

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -63,6 +63,7 @@ export interface UseChatStreamResult {
 
 export function useChatStream(threadId: string | null): UseChatStreamResult {
   const addMessage = useCairnStore((s) => s.addMessage);
+  const setThreadUsage = useCairnStore((s) => s.setThreadUsage);
 
   const [isLoading, setIsLoading]               = useState(false);
   const [toolCalls, setToolCalls]               = useState<ChatToolCall[]>([]);
@@ -107,7 +108,7 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
       setStreamingContent((prev) => prev + e.delta);
     });
 
-    const unsubDone = electron.chat.onDone((e) => {
+    const unsubDone = (electron.chat.onDone as (cb: (e: { content: string; contextRefs: unknown[]; error?: string; usage?: { promptTokens: number; completionTokens: number } }) => void) => () => void)((e) => {
       const tid = threadIdRef.current;
       // Mark any still-running tool as done before persisting.
       const finalToolCalls = toolCallsRef.current.map((tc) =>
@@ -118,6 +119,9 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
         pendingActionsRef.current = [];
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         addMessage(tid, "assistant", e.content, e.contextRefs as any, finalToolCalls, capturedActions);
+        if (e.usage) {
+          setThreadUsage(tid, e.usage);
+        }
       }
       setStreamingContent("");
       setIsLoading(false);
@@ -128,12 +132,20 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
       // the user submits their answers. It is cleared in sendStream() instead.
     });
 
+    const unsubUsage = (electron.chat.onUsage as (cb: (e: { promptTokens: number; completionTokens: number }) => void) => () => void)((e) => {
+      const tid = threadIdRef.current;
+      if (tid) {
+        setThreadUsage(tid, e);
+      }
+    });
+
     return () => {
       unsubTool();
       unsubToken();
       unsubDone();
+      unsubUsage();
     };
-  // addMessage is stable (Zustand), intentionally omitted from deps
+  // addMessage and setThreadUsage are stable (Zustand), intentionally omitted from deps
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -143,6 +155,9 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
     toolCallsRef.current = [];
     pendingActionsRef.current = [];
     setPendingQuestions(null);
+    if (threadId) {
+      setThreadUsage(threadId, undefined);
+    }
     window.electron?.chat.stream(req);
   }
 

--- a/src/store/slices/chat.ts
+++ b/src/store/slices/chat.ts
@@ -28,6 +28,7 @@ export interface ChatSlice {
   renameThread: (threadId: ID, title: string) => void;
   createNewThread: (workspaceId: ID, projectId?: ID) => ChatThread;
   compactChatThread: (threadId: ID) => Promise<void>;
+  setThreadUsage: (threadId: ID, usage: { promptTokens: number; completionTokens: number } | undefined) => void;
 }
 
 // ── Slice creator ─────────────────────────────────────────────────────────────
@@ -189,5 +190,14 @@ export const createChatSlice: StateCreator<CairnStore, [], [], ChatSlice> = (
       }
       await ipcAwait((e) => e.chat.addMessage(summaryMsg));
     }
+  },
+
+  setThreadUsage(threadId, usage) {
+    set((s) => ({
+      chatThreads: s.chatThreads.map((t) =>
+        t.id === threadId ? { ...t, lastUsage: usage } : t
+      ),
+    }));
+    get().persist();
   },
 });

--- a/src/store/slices/chat.ts
+++ b/src/store/slices/chat.ts
@@ -6,7 +6,7 @@ import type { StateCreator } from "zustand";
 import type { CairnStore } from "../index";
 import type { ChatThread, ChatMessage, ChatToolCallRecord, PendingAction, ID } from "@/types";
 import { id, now } from "@/lib/utils";
-import { ipc } from "../ipc";
+import { ipc, ipcAwait, ipcAwaitResult } from "../ipc";
 
 // ── Slice interface ───────────────────────────────────────────────────────────
 
@@ -27,6 +27,7 @@ export interface ChatSlice {
   deleteThread: (threadId: ID) => void;
   renameThread: (threadId: ID, title: string) => void;
   createNewThread: (workspaceId: ID, projectId?: ID) => ChatThread;
+  compactChatThread: (threadId: ID) => Promise<void>;
 }
 
 // ── Slice creator ─────────────────────────────────────────────────────────────
@@ -141,5 +142,52 @@ export const createChatSlice: StateCreator<CairnStore, [], [], ChatSlice> = (
     get().persist();
     ipc((e) => e.chat.upsertThread(thread));
     return thread;
+  },
+
+  async compactChatThread(threadId) {
+    const messages = get().chatMessages.filter((m) => m.threadId === threadId);
+    if (messages.length < 4) return;
+    const history = messages.map((m) => ({ role: m.role, content: m.content }));
+    const aiConfig = get().aiConfig;
+
+    const result = await ipcAwaitResult<{ summary: string }>(async (e) => {
+      const summary = await e.chat.compactThread({
+        messages: history,
+        config: {
+          provider: aiConfig.provider,
+          baseUrl: aiConfig.baseUrl,
+          model: aiConfig.model,
+          apiKey: aiConfig.apiKey,
+        },
+      }) as { summary: string };
+      return { data: summary };
+    });
+
+    if (result && "data" in result && result.data?.summary) {
+      const summary = result.data.summary;
+      const firstUserMsg = messages.find((m) => m.role === "user");
+      const summaryMsg: ChatMessage = {
+        id: id(),
+        threadId,
+        role: "system",
+        content: `[Earlier conversation summarised to fit the context window]\n\n## Session Summary\n\n${summary}\n\n[End of summary — continuing from current state]`,
+        createdAt: now(),
+      };
+
+      set((s) => ({
+        chatMessages: [
+          ...s.chatMessages.filter((m) => m.threadId !== threadId),
+          ...(firstUserMsg ? [firstUserMsg] : []),
+          summaryMsg,
+        ],
+      }));
+      get().persist();
+
+      await ipcAwait((e) => e.chat.clearThreadMessages(threadId));
+      if (firstUserMsg) {
+        await ipcAwait((e) => e.chat.addMessage(firstUserMsg));
+      }
+      await ipcAwait((e) => e.chat.addMessage(summaryMsg));
+    }
   },
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -126,6 +126,7 @@ export interface ChatThread {
   title?: string;
   createdAt: string;
   updatedAt: string;
+  lastUsage?: { promptTokens: number; completionTokens: number };
 }
 
 export type ChatRole = "user" | "assistant" | "system";


### PR DESCRIPTION
## What does this PR do?

This PR implements key features, UX enhancements, and bug fixes on this branch compared to `main`:
1. **Slash Commands & Autocomplete**: Adds a slash command autocomplete menu (`/`) in the chat input panel (supporting commands like `/compact`, `/code-review`, `/spawn-subagent`, and `/test` for agent and general AI chats).
2. **Chat Compaction & Clears**: Integrates chat compaction history parsing to summarize chat history when it grows too large, optimizing context token usage and saving history in the SQLite database.
3. **Context Token Usage Ring**: Displays a live-updating context token usage indicator (`ContextRing`) in the general AI Assistant panel header.
4. **Git Bash Auto-Detection**: Integrates native Git Bash executable detection on Windows environments to prevent WSL-only execution path issues.
5. **Single Instance Lock**: Restricts the Cairn app to a single instance, focusing the active window when another instance is run.
6. **UX Tab Closing**: Adds support for closing open files (in Agent view editor) and terminal tabs with a middle-click (button 1 on mouse).
7. **Code Directory Persistence Fix**: Fixes the folder dialog picker on the Project Overview page to immediately persist the chosen directory path via `updateProject`.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code quality
- [x] Docs / changelog
- [ ] Tests

## Checklist

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

* Note that `lastUsage` has been added as an optional field on the `ChatThread` domain model. Since SQLite queries are explicitly defined with individual columns, this property is ignored by SQLite and stored strictly in Zustand/localStorage.
* The `ContextRing` has been successfully integrated into the general `ChatPanel` header. Live token updates are emitted via the `chat:usage` channel during tool loops and streams, and the final value is persisted on completion.
