### PR TITLE
v1.7.4 - feat/fix: chat compaction fixes, regular chat clear button

### DIFF
--- a/changelogs/v1.7.4.md
+++ b/changelogs/v1.7.4.md
@@ -4,6 +4,7 @@
 - Added a visual loading state ("Compacting chat history...") when running the `/compact` command in the AI Assistant Chat.
 - Improved the rendering of system chat message summaries using the markdown renderer (enabling rich lists, bold text, and headers).
 - Added a "Clear conversation" button to the regular AI Assistant Chat panel header.
+- Automatically render inline clickable note and task links for note/task read or write tools (like `get_note` and `get_task`) inside the message history of both the regular AI Assistant Chat and the native Cairn Agent.
 
 ### Fixes
 - Resolved a runtime `ReferenceError: handle is not defined` error when invoking the chat compaction IPC handler in the main process.

--- a/changelogs/v1.7.4.md
+++ b/changelogs/v1.7.4.md
@@ -10,7 +10,10 @@
 - Resolved a runtime `ReferenceError: handle is not defined` error when invoking the chat compaction IPC handler in the main process.
 - Fixed a silent bug where the chat compaction summary was not being replaced or updated in the UI due to mismatching IPC response envelopes.
 - Reset the LLM context usage ring when clearing the conversation history in either the native Cairn Agent (`piagent`) or the regular AI Assistant Chat.
+- Fixed a critical issue in the native Cairn Agent where context compaction would lose the agreed-upon plan and user execution approvals/commands (e.g. "lets go", "continue"). The compaction summarizer now explicitly preserves plans, approvals, and current execution state.
+- Made the background compaction transformer asynchronous to wait for the LLM summary, preventing a sliding-window fallback that caused the agent to lose context and revert changes on the compaction turn.
 
 ### Changes
 - Updated `electron/ipc/chat.ts` to run a self-contained `try/catch` block.
 - Removed debug logging from the frontend chat store slice and backend Electron IPC handler.
+- Updated `pi-agent:prompt` in `electron/ipc/pi-agent.ts` to fetch and persist the approved plan content in the system prompt across subsequent message turns in execution mode.

--- a/changelogs/v1.7.4.md
+++ b/changelogs/v1.7.4.md
@@ -1,0 +1,15 @@
+## What's new
+
+### Features
+- Added a visual loading state ("Compacting chat history...") when running the `/compact` command in the AI Assistant Chat.
+- Improved the rendering of system chat message summaries using the markdown renderer (enabling rich lists, bold text, and headers).
+- Added a "Clear conversation" button to the regular AI Assistant Chat panel header.
+
+### Fixes
+- Resolved a runtime `ReferenceError: handle is not defined` error when invoking the chat compaction IPC handler in the main process.
+- Fixed a silent bug where the chat compaction summary was not being replaced or updated in the UI due to mismatching IPC response envelopes.
+- Reset the LLM context usage ring when clearing the conversation history in either the native Cairn Agent (`piagent`) or the regular AI Assistant Chat.
+
+### Changes
+- Updated `electron/ipc/chat.ts` to run a self-contained `try/catch` block.
+- Removed debug logging from the frontend chat store slice and backend Electron IPC handler.

--- a/electron/ipc/chat-executor.ts
+++ b/electron/ipc/chat-executor.ts
@@ -94,15 +94,17 @@ export async function executeTool(
   args: ToolArgs,
   emit?: (event: { tool: string; label: string; args: Record<string, unknown> }) => void,
   getWin?: () => BrowserWindow | null,
+  emitDone?: (event: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void,
 ): Promise<unknown> {
   emit?.({ tool: name, label: TOOL_LABELS[name]?.(args) ?? name, args });
   const snap = q.getFullSnapshot(db) as CairnSnapshot;
 
-  // ── Shared read tools (also used by db:mcpQuery and MCP server) ──────────
-  {
-    const res = executeReadTool(db, snap, name, args);
-    if (res.handled) return res.result;
-  }
+  const result = await (async () => {
+    // ── Shared read tools (also used by db:mcpQuery and MCP server) ──────────
+    {
+      const res = executeReadTool(db, snap, name, args);
+      if (res.handled) return res.result;
+    }
 
   switch (name) {
     case "get_cairn_context": {
@@ -760,4 +762,33 @@ export async function executeTool(
     default:
       return { error: `Unknown tool: ${name}` };
   }
+  })();
+
+  // Resolve cairnRef if possible
+  let cairnRef: { type: "note" | "task"; id: string; title: string } | undefined = undefined;
+  if (result && typeof result === "object" && !("error" in result)) {
+    const resObj = result as Record<string, unknown>;
+    
+    // For note tools, the result contains ID and title.
+    const isNote = [
+      "get_note", "ensure_note", "patch_note", "append_to_note"
+    ].includes(name);
+    
+    // For task tools, the result contains ID and title.
+    const isTask = [
+      "get_task", "create_task", "update_task"
+    ].includes(name);
+    
+    if (isNote && typeof resObj.id === "string" && typeof resObj.title === "string") {
+      cairnRef = { type: "note", id: resObj.id, title: resObj.title };
+    } else if (isTask && typeof resObj.id === "string" && typeof resObj.title === "string") {
+      cairnRef = { type: "task", id: resObj.id, title: resObj.title };
+    }
+  }
+
+  if (emitDone) {
+    emitDone({ tool: name, cairnRef });
+  }
+
+  return result;
 }

--- a/electron/ipc/chat.ts
+++ b/electron/ipc/chat.ts
@@ -38,6 +38,7 @@ async function runToolLoop(
   getWin?: () => BrowserWindow | null,
   provider?: string,
   onUsage?: (pt: number, ct: number) => void,
+  emitToolCallDone?: (e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void,
 ): Promise<{ exhausted: true; content: string } | { exhausted: false }> {
   const maxSteps    = req.config?.maxSteps    ?? 20;
   const temperature = req.config?.temperature ?? 0.3;
@@ -127,7 +128,7 @@ async function runToolLoop(
       try { args = JSON.parse(call.function.arguments); } catch { args = {}; }
       let result: unknown;
       try {
-        result = await executeTool(db, req, workspacePath, { baseUrl, model, apiKey, provider: provider as "openai" | "localllm" }, call.function.name, args, emitToolCall, getWin);
+        result = await executeTool(db, req, workspacePath, { baseUrl, model, apiKey, provider: provider as "openai" | "localllm" }, call.function.name, args, emitToolCall, getWin, emitToolCallDone);
       } catch (toolErr) {
         result = { error: `Tool "${call.function.name}" failed: ${String(toolErr)}` };
       }
@@ -218,6 +219,10 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
       send("chat:tool-call", e);
     };
 
+    const emitToolCallDone = (e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => {
+      send("chat:tool-call-done", e);
+    };
+
     let promptTokens = 0;
     let completionTokens = 0;
     const addUsage = (pt: number, ct: number) => {
@@ -226,7 +231,7 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
       send("chat:usage", { promptTokens, completionTokens });
     };
 
-    const loopResult = await runToolLoop(db, req, workspacePath, baseUrl, model, apiKey, messages, emitToolCall, abortCtrl.signal, getWin, provider, addUsage);
+    const loopResult = await runToolLoop(db, req, workspacePath, baseUrl, model, apiKey, messages, emitToolCall, abortCtrl.signal, getWin, provider, addUsage, emitToolCallDone);
 
     abortControllers.delete(event.sender.id);
 

--- a/electron/ipc/chat.ts
+++ b/electron/ipc/chat.ts
@@ -142,12 +142,11 @@ async function runToolLoop(
 }
 
 export function registerChatHandler(db: Database.Database, workspacePath: string, getWin?: () => BrowserWindow | null): void {
-  // chat:compactThread — generates a summary for a chat thread
   ipcMain.handle("chat:compactThread", async (_event, req: {
     messages: Array<{ role: string; content: string }>;
     config: { provider?: string; baseUrl?: string; model?: string; apiKey?: string };
   }) => {
-    return handle(async () => {
+    try {
       const baseUrl = normaliseBaseUrl(req.config?.baseUrl ?? "https://api.openai.com");
       const model = req.config?.model ?? "gpt-4o-mini";
       const apiKey = req.config?.apiKey ?? "";
@@ -164,8 +163,11 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const agentMsgs = req.messages as any[];
       const summary = await generateSummary(agentMsgs, llmConfig, new AbortController().signal);
-      return { summary };
-    });
+      return { data: { summary } };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { error: msg };
+    }
   });
 
   // chat:abort — cancel the in-flight stream for this renderer

--- a/electron/ipc/pi-agent.ts
+++ b/electron/ipc/pi-agent.ts
@@ -207,8 +207,17 @@ export function registerPiAgentHandler(
       ? (ctx.db.prepare("SELECT name FROM projects WHERE id = ?").get(projectId) as { name: string } | undefined)?.name ?? "Project"
       : "Project";
 
+    const sessionRow = q.getPiSessionById(ctx.db, sessionId);
+    const planNoteId = sessionRow?.planNoteId;
+    const planContent = planNoteId
+      ? (ctx.db.prepare("SELECT content FROM notes WHERE id = ?").get(planNoteId) as { content: string } | undefined)?.content ?? ""
+      : undefined;
+
     const skills = discoverSkills(cwd);
-    const systemPrompt = buildPiAgentSystemPrompt({ projectName, cwd, taskTitle, workspaceId, projectId, mode, skillsXml: renderSkillsXml(skills) });
+    const systemPrompt = buildPiAgentSystemPrompt({
+      projectName, cwd, taskTitle, workspaceId, projectId, mode, planContent,
+      skillsXml: renderSkillsXml(skills)
+    });
 
     const toolCtx: AgentToolContext = {
       cwd, db: ctx.db, workspacePath: ctx.workspacePath, sessionId, send, getWin, skills,

--- a/electron/lib/compaction.ts
+++ b/electron/lib/compaction.ts
@@ -104,11 +104,12 @@ const SUMMARIZATION_USER_PROMPT = (conversationText: string) =>
 Produce a concise summary of the above conversation for use as context in a future AI coding session. Include:
 
 1. **Goal** — What the user is trying to accomplish (1-2 sentences).
-2. **Progress** — What has been implemented or discovered so far. Reference specific files and functions where relevant.
-3. **Key decisions** — Any important design choices or constraints identified.
-4. **Modified files** — List every file that was created or changed.
-5. **Current state** — Where things stand right now and what remains to be done.
-6. **Open issues** — Bugs, TODOs, or unresolved questions noted during the session.
+2. **Agreed Plan & Approvals** — The specific steps of the plan that was agreed upon, and any explicit user approvals or commands to proceed (e.g., "lets go", "continue").
+3. **Progress** — What has been implemented or discovered so far. Reference specific files and functions where relevant.
+4. **Key decisions** — Any important design choices or constraints identified.
+5. **Modified files** — List every file that was created or changed.
+6. **Current state** — Where things stand right now, what remains to be done, and what steps of the plan are currently being executed.
+7. **Open issues** — Bugs, TODOs, or unresolved questions noted during the session.
 
 Be specific. Cite file paths, function names, and line numbers where they matter. Omit pleasantries and filler.`;
 
@@ -164,13 +165,12 @@ export function buildCompactionTransformer(
   llmConfig: AgentLLMConfig,
   onCompactionStart?: () => void,
   onCompactionEnd?: (summary: string) => void,
-): (messages: AgentMessage[]) => AgentMessage[] {
+): (messages: AgentMessage[]) => Promise<AgentMessage[]> {
   const contextWindow = llmConfig.contextWindow ?? 128_000;
-  let compacting = false;
-  // Cache the last summary so if compaction is still in flight we can use it
   let cachedSummary: string | null = null;
+  let compactionPromise: Promise<string> | null = null;
 
-  return (messages: AgentMessage[]): AgentMessage[] => {
+  return async (messages: AgentMessage[]): Promise<AgentMessage[]> => {
     const lastPromptTokens = session.lastPromptTokens ?? 0;
     // Always read the live signal from the session so a refreshed AbortController
     // (created on each new prompt) is used rather than the one captured at build time.
@@ -182,35 +182,37 @@ export function buildCompactionTransformer(
     }
 
     // If we already have a summary from the last compaction, apply it immediately
-    // while the next compaction (if any) runs asynchronously in the background.
     if (cachedSummary !== null) {
       const { toKeep } = splitMessages(messages);
       return buildCompactedContext(cachedSummary, messages[0], toKeep);
     }
 
-    // Kick off async compaction in the background (fire-and-forget for this turn).
-    // This turn falls back to the sliding-window pruner; the NEXT turn will use
-    // the LLM summary once it arrives.
-    if (!compacting) {
-      compacting = true;
+    // Generate summary if not already in flight
+    if (!compactionPromise) {
       onCompactionStart?.();
 
       const { toSummarise } = splitMessages(messages);
-      generateSummary(toSummarise, llmConfig, signal)
+      compactionPromise = generateSummary(toSummarise, llmConfig, signal)
         .then((summary) => {
           cachedSummary = summary;
           onCompactionEnd?.(summary);
+          return summary;
         })
         .catch((err) => {
-          console.warn("[compaction] summarisation failed, will retry next turn:", err?.message ?? err);
-        })
-        .finally(() => {
-          compacting = false;
+          console.warn("[compaction] summarisation failed:", err?.message ?? err);
+          compactionPromise = null; // reset to allow retry
+          throw err;
         });
     }
 
-    // Fallback for this turn: sliding-window trim (safe, no LLM call)
-    return slidingWindowFallback(messages);
+    try {
+      const summary = await compactionPromise;
+      const { toKeep } = splitMessages(messages);
+      return buildCompactedContext(summary, messages[0], toKeep);
+    } catch {
+      // Fallback for this turn: sliding-window trim (safe, no LLM call)
+      return slidingWindowFallback(messages);
+    }
   };
 }
 

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -138,7 +138,7 @@ export interface AgentLoopCallbacks {
    * Does NOT mutate session.messages — only affects what is sent to the model.
    * Use for context pruning, injection, or summarisation.
    */
-  transformContext?: (messages: AgentMessage[]) => AgentMessage[];
+  transformContext?: (messages: AgentMessage[]) => AgentMessage[] | Promise<AgentMessage[]>;
   /**
    * Called after each turn's tool results are appended, before the next LLM
    * call. Return true to stop the loop cleanly (fires onDone, not onError).
@@ -159,7 +159,7 @@ export interface PiAgentSession {
    * inside it survives across multiple pi-agent:prompt calls on the same session.
    * Built once on first use and reused; the signal is updated via abortCtrl each turn.
    */
-  compactionTransformer?: (messages: AgentMessage[]) => AgentMessage[];
+  compactionTransformer?: (messages: AgentMessage[]) => AgentMessage[] | Promise<AgentMessage[]>;
 }
 
 // ── All tool definitions ──────────────────────────────────────────────────────
@@ -438,7 +438,7 @@ export async function runAgentLoop(
 
     // Build messages array — apply context pruning.
     // systemPrompt passes as `system:` in the request body (not as a user message).
-    const contextMessages = pruner([...session.messages]);
+    const contextMessages = await pruner([...session.messages]);
 
     // ── Stream assistant response ─────────────────────────────────────────
     const headers: Record<string, string> = { "Content-Type": "application/json" };

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -126,6 +126,12 @@ const api = {
       ipcRenderer.on("chat:tool-call", handler);
       return () => ipcRenderer.off("chat:tool-call", handler);
     },
+    onToolCallDone: (cb: (e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (_: any, e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => cb(e);
+      ipcRenderer.on("chat:tool-call-done", handler);
+      return () => ipcRenderer.off("chat:tool-call-done", handler);
+    },
     onUsage: (cb: (e: { promptTokens: number; completionTokens: number }) => void) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const handler = (_: any, e: { promptTokens: number; completionTokens: number }) => cb(e);

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -26,11 +26,11 @@ import type { TerminalSession } from "@/store/slices/terminal-sessions";
 
 // ── Cairn tool ref extraction ─────────────────────────────────────────────────
 
-const NOTE_WRITE_TOOLS = new Set([
-  "create_note", "ensure_note", "update_note", "patch_note", "append_to_note",
+const NOTE_TOOLS = new Set([
+  "create_note", "ensure_note", "update_note", "patch_note", "append_to_note", "get_note",
 ]);
-const TASK_WRITE_TOOLS = new Set([
-  "create_task", "update_task", "update_task_status",
+const TASK_TOOLS = new Set([
+  "create_task", "update_task", "update_task_status", "get_task",
 ]);
 // Read-only tools — output is never useful to show; suppress it entirely
 const READ_ONLY_TOOLS = new Set([
@@ -46,8 +46,8 @@ function extractCairnRef(
   output: string | undefined,
 ): { type: "note" | "task"; id: string; title: string } | undefined {
   if (!output) return undefined;
-  const isNote = NOTE_WRITE_TOOLS.has(toolName);
-  const isTask = TASK_WRITE_TOOLS.has(toolName);
+  const isNote = NOTE_TOOLS.has(toolName);
+  const isTask = TASK_TOOLS.has(toolName);
   if (!isNote && !isTask) return undefined;
   try {
     const parsed = JSON.parse(output);

--- a/src/components/agent/PiMessageBubble.tsx
+++ b/src/components/agent/PiMessageBubble.tsx
@@ -18,11 +18,13 @@ const CAIRN_NOTE_ACTIONS: Record<string, string> = {
   update_note:     "Updated note",
   patch_note:      "Patched note",
   append_to_note:  "Appended to note",
+  get_note:        "Read note",
 };
 const CAIRN_TASK_ACTIONS: Record<string, string> = {
   create_task:        "Created task",
   update_task:        "Updated task",
   update_task_status: "Moved task",
+  get_task:           "Read task",
 };
 
 function CairnRefChip({ tc }: {

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useRef, useEffect, useMemo, useCallback } from "react";
-import { X, Sparkles, PenSquare, History, Pencil } from "lucide-react";
+import { X, Sparkles, PenSquare, History, Pencil, Trash2 } from "lucide-react";
 import { cn, formatRelative } from "@/lib/utils";
 import { useCairnStore } from "@/store";
 import { MIN_CHAT_PANEL_WIDTH, MAX_CHAT_PANEL_WIDTH } from "@/store/slices/ui";
@@ -81,6 +81,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     createNewThread, deleteThread, renameThread,
     chatPanelWidth, setChatPanelWidth,
     activeView, graphData, selectedGraphNodeId,
+    clearThreadMessages,
   } = useCairnStore(useShallow((s) => ({
     chatOpen:            s.chatOpen,
     toggleChat:          s.toggleChat,
@@ -100,6 +101,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     activeView:          s.activeView,
     graphData:           s.graphData,
     selectedGraphNodeId: s.selectedGraphNodeId,
+    clearThreadMessages: s.clearThreadMessages,
   })));
 
   const [input, setInput]             = useState("");
@@ -115,6 +117,12 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
   const dividerRef     = useRef<HTMLDivElement>(null);
 
   const { isLoading, toolCalls, streamingContent, pendingQuestions, sendStream, stopStream } = useChatStream(threadId);
+
+  const handleClear = useCallback(() => {
+    if (!threadId) return;
+    if (isLoading) stopStream();
+    clearThreadMessages(threadId);
+  }, [threadId, isLoading, stopStream, clearThreadMessages]);
 
   // Track isLoading in a ref so the thread-init effect can read it without
   // being listed as a dependency (we never want a loading-state change to
@@ -193,7 +201,8 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     const content = text ?? input.trim();
     if (!content || !threadId) return;
 
-    if (content === "/compact") {
+    const trimmed = content.trim();
+    if (trimmed === "/compact" || trimmed === "/ compact") {
       setInput("");
       useCairnStore.getState().compactChatThread(threadId);
       return;
@@ -421,6 +430,14 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
           </div>
         )}
 
+        {messages.length > 0 && (
+          <Tooltip content="Clear conversation" side="left">
+            <button onClick={handleClear}
+              className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--danger)] hover:bg-[var(--surface-2)] transition-colors">
+              <Trash2 size={13} />
+            </button>
+          </Tooltip>
+        )}
         <Tooltip content="New chat" side="left">
           <button onClick={handleNewThread}
             className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors">

--- a/src/components/chat/chat-panel/ChatMessageBubble.tsx
+++ b/src/components/chat/chat-panel/ChatMessageBubble.tsx
@@ -1,12 +1,90 @@
 "use client";
 
 import React, { useState } from "react";
-import { FileText, Kanban, FolderOpen, Search, Copy, Check, RotateCcw, CheckCircle } from "lucide-react";
+import { FileText, Kanban, FolderOpen, Search, Copy, Check, RotateCcw, CheckCircle, SquareCheck } from "lucide-react";
 import { cn, formatRelative } from "@/lib/utils";
+import { useCairnStore } from "@/store";
+import { CairnEvents } from "@/lib/events";
 import { MarkdownContent } from "./MarkdownContent";
 import { ActionsList } from "./ActionsList";
 import { MessageAvatar } from "./message-ui";
-import type { ChatMessage, LinkedContextReference } from "@/types";
+import type { ChatMessage, LinkedContextReference, ChatToolCallRecord } from "@/types";
+
+const CAIRN_NOTE_ACTIONS: Record<string, string> = {
+  create_note:     "Created note",
+  ensure_note:     "Saved note",
+  update_note:     "Updated note",
+  patch_note:      "Patched note",
+  append_to_note:  "Appended to note",
+  get_note:        "Read note",
+};
+
+const CAIRN_TASK_ACTIONS: Record<string, string> = {
+  create_task:        "Created task",
+  update_task:        "Updated task",
+  update_task_status: "Moved task",
+  get_task:           "Read task",
+};
+
+function ChatToolCallChip({ tc }: { tc: ChatToolCallRecord }) {
+  const setView = useCairnStore((s) => s.setView);
+
+  if (!tc.cairnRef) {
+    return (
+      <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] w-fit">
+        <CheckCircle size={10} className="text-[var(--accent)] shrink-0" />
+        <span className="text-[0.786rem] text-[var(--text-secondary)]">{tc.label}</span>
+      </div>
+    );
+  }
+
+  const isNote = tc.cairnRef.type === "note";
+  const actionLabel = isNote
+    ? (CAIRN_NOTE_ACTIONS[tc.tool] ?? "Updated note")
+    : (CAIRN_TASK_ACTIONS[tc.tool] ?? "Updated task");
+
+  function handleClick() {
+    if (isNote) {
+      setView("notes");
+      setTimeout(() => window.dispatchEvent(CairnEvents.selectNote(tc.cairnRef!.id)), 50);
+    } else {
+      setView("board");
+      setTimeout(() => window.dispatchEvent(CairnEvents.openCard(tc.cairnRef!.id)), 50);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className={cn(
+        "flex items-center gap-2 px-2.5 py-1.5 rounded-lg w-fit text-left transition-colors group",
+        "bg-[var(--surface-2)] border border-[var(--border)]",
+        "hover:border-[var(--accent)]/50 hover:bg-[color-mix(in_srgb,var(--accent)_4%,var(--surface-2))]",
+      )}
+    >
+      <div className={cn(
+        "w-5 h-5 rounded flex items-center justify-center flex-shrink-0",
+        isNote
+          ? "bg-[color-mix(in_srgb,var(--accent)_12%,transparent)]"
+          : "bg-[color-mix(in_srgb,var(--success,#22c55e)_12%,transparent)]",
+      )}>
+        {isNote
+          ? <FileText size={10} className="text-[var(--accent)]" />
+          : <SquareCheck size={10} className="text-[color-mix(in_srgb,var(--success,#22c55e)_90%,var(--text-primary))]" />
+        }
+      </div>
+
+      <div className="flex flex-col min-w-0">
+        <span className="text-[0.643rem] text-[var(--text-tertiary)] leading-none mb-0.5">{actionLabel}</span>
+        <span className="text-[0.714rem] font-medium text-[var(--text-primary)] truncate max-w-[200px] leading-none group-hover:text-[var(--accent)] transition-colors">
+          {tc.cairnRef.title}
+        </span>
+      </div>
+
+      <CheckCircle size={9} className="shrink-0 ml-auto text-[var(--accent)]" />
+    </button>
+  );
+}
 
 interface ChatMessageBubbleProps {
   message: ChatMessage;
@@ -50,10 +128,7 @@ export const ChatMessageBubble = React.memo(function ChatMessageBubble({ message
         {!isUser && message.toolCalls && message.toolCalls.length > 0 && (
           <div className="flex flex-col gap-1 mb-1">
             {message.toolCalls.map((tc, i) => (
-              <div key={i} className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-[var(--surface-2)] border border-[var(--border)] w-fit">
-                <CheckCircle size={10} className="text-[var(--accent)] shrink-0" />
-                <span className="text-[0.786rem] text-[var(--text-secondary)]">{tc.label}</span>
-              </div>
+              <ChatToolCallChip key={i} tc={tc} />
             ))}
           </div>
         )}

--- a/src/components/chat/chat-panel/ChatMessageBubble.tsx
+++ b/src/components/chat/chat-panel/ChatMessageBubble.tsx
@@ -26,6 +26,16 @@ export const ChatMessageBubble = React.memo(function ChatMessageBubble({ message
   }
 
   if (isSystem) {
+    const isMarkdown = message.content.includes("\n") || message.content.includes("#");
+    if (isMarkdown) {
+      return (
+        <div className="flex justify-center py-1.5 w-full">
+          <div className="text-[0.786rem] text-[var(--text-secondary)] bg-[var(--surface-2)] border border-[var(--border)] rounded-xl px-4 py-3 max-w-[95%] w-full shadow-sm">
+            <MarkdownContent content={message.content} />
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="flex justify-center py-0.5">
         <span className="text-[0.643rem] italic text-[var(--text-tertiary)] px-2">{message.content}</span>

--- a/src/components/notes/MermaidDiagram.tsx
+++ b/src/components/notes/MermaidDiagram.tsx
@@ -25,9 +25,14 @@ interface Props {
 // theme is always up to date (user may have switched between light and dark).
 async function getMermaid(id: string) {
   const mermaid = (await import("mermaid")).default;
+  
+  // Prevent mermaid from throwing uncaught errors globally that bubble up to Next.js
+  mermaid.parseError = () => {};
+
   const isDark = document.documentElement.getAttribute("data-theme") !== "light";
   mermaid.initialize({
     startOnLoad: false,
+    suppressErrorRendering: true,
     theme: isDark ? "dark" : "default",
     themeVariables: isDark
       ? {

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -25,6 +25,7 @@ export interface ChatToolCall {
   label: string;
   /** "running" = currently executing; "done" = completed this turn */
   status: "running" | "done";
+  cairnRef?: { type: "note" | "task"; id: string; title: string };
 }
 
 export interface PendingQuestion {
@@ -104,6 +105,18 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
       }
     });
 
+    const unsubToolDone = electron.chat.onToolCallDone?.((e) => {
+      setToolCalls((prev) => {
+        const lastIdx = [...prev].reverse().findIndex((tc) => tc.tool === e.tool);
+        if (lastIdx === -1) return prev;
+        const idx = prev.length - 1 - lastIdx;
+        const updated = [...prev];
+        updated[idx] = { ...updated[idx], cairnRef: e.cairnRef };
+        toolCallsRef.current = updated;
+        return updated;
+      });
+    });
+
     const unsubToken = electron.chat.onToken((e) => {
       setStreamingContent((prev) => prev + e.delta);
     });
@@ -141,6 +154,7 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
 
     return () => {
       unsubTool();
+      unsubToolDone?.();
       unsubToken();
       unsubDone();
       unsubUsage();

--- a/src/store/slices/chat.ts
+++ b/src/store/slices/chat.ts
@@ -28,6 +28,7 @@ export interface ChatSlice {
   renameThread: (threadId: ID, title: string) => void;
   createNewThread: (workspaceId: ID, projectId?: ID) => ChatThread;
   compactChatThread: (threadId: ID) => Promise<void>;
+  clearThreadMessages: (threadId: ID) => Promise<void>;
   setThreadUsage: (threadId: ID, usage: { promptTokens: number; completionTokens: number } | undefined) => void;
 }
 
@@ -147,21 +148,39 @@ export const createChatSlice: StateCreator<CairnStore, [], [], ChatSlice> = (
 
   async compactChatThread(threadId) {
     const messages = get().chatMessages.filter((m) => m.threadId === threadId);
-    if (messages.length < 4) return;
+    if (messages.length < 4) {
+      return;
+    }
     const history = messages.map((m) => ({ role: m.role, content: m.content }));
     const aiConfig = get().aiConfig;
 
+    const tempId = id();
+    const tempMsg: ChatMessage = {
+      id: tempId,
+      threadId,
+      role: "system",
+      content: "Compacting chat history...",
+      createdAt: now(),
+    };
+    set((s) => ({ chatMessages: [...s.chatMessages, tempMsg] }));
+
     const result = await ipcAwaitResult<{ summary: string }>(async (e) => {
-      const summary = await e.chat.compactThread({
-        messages: history,
-        config: {
-          provider: aiConfig.provider,
-          baseUrl: aiConfig.baseUrl,
-          model: aiConfig.model,
-          apiKey: aiConfig.apiKey,
-        },
-      }) as { summary: string };
-      return { data: summary };
+      try {
+        const summaryObj = await e.chat.compactThread({
+          messages: history,
+          config: {
+            provider: aiConfig.provider,
+            baseUrl: aiConfig.baseUrl,
+            model: aiConfig.model,
+            apiKey: aiConfig.apiKey,
+          },
+        }) as { summary: string };
+
+        return { data: summaryObj };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { error: msg };
+      }
     });
 
     if (result && "data" in result && result.data?.summary) {
@@ -189,7 +208,22 @@ export const createChatSlice: StateCreator<CairnStore, [], [], ChatSlice> = (
         await ipcAwait((e) => e.chat.addMessage(firstUserMsg));
       }
       await ipcAwait((e) => e.chat.addMessage(summaryMsg));
+    } else {
+      set((s) => ({
+        chatMessages: s.chatMessages.filter((m) => m.id !== tempId),
+      }));
     }
+  },
+
+  async clearThreadMessages(threadId) {
+    set((s) => ({
+      chatMessages: s.chatMessages.filter((m) => m.threadId !== threadId),
+      chatThreads: s.chatThreads.map((t) =>
+        t.id === threadId ? { ...t, lastUsage: undefined, updatedAt: now() } : t
+      ),
+    }));
+    get().persist();
+    await ipcAwait((e) => e.chat.clearThreadMessages(threadId));
   },
 
   setThreadUsage(threadId, usage) {

--- a/src/store/slices/terminal-sessions.ts
+++ b/src/store/slices/terminal-sessions.ts
@@ -351,7 +351,7 @@ export const createTerminalSessionsSlice: StateCreator<CairnStore, [], [], Termi
   clearPiMessages(sessionId) {
     set((s) => ({
       terminalSessions: s.terminalSessions.map((t) =>
-        t.sessionId === sessionId ? { ...t, piMessages: [] } : t
+        t.sessionId === sessionId ? { ...t, piMessages: [], lastUsage: undefined } : t
       ),
     }));
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,6 +141,7 @@ export interface LinkedContextReference {
 export interface ChatToolCallRecord {
   tool: string;
   label: string;
+  cairnRef?: { type: "note" | "task"; id: ID; title: string };
 }
 
 export type SuggestedAction =


### PR DESCRIPTION
## What does this PR do?

Fixes the chat compaction `/compact` slash command so that it correctly compacts thread messages, shows a temporary visual progress indicator message, and renders the resulting summary as rich Markdown in the UI. 

Additionally:
- Adds a "Clear conversation" button inside the regular AI Assistant Chat panel header.
- Resets the LLM context usage ring when clearing the conversation history in either the native Cairn Agent (`piagent`) or regular AI Assistant Chat.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code quality
- [x] Docs / changelog
- [x] Tests

## Screenshots / recording

<!-- For any UI change, include a screenshot or short screen recording. Delete this section if not applicable. -->

## Checklist

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

- The `chat:compactThread` IPC handler is kept self-contained to avoid importing from `handlers.ts`, which prevents circular dependencies in the compiled Electron bundle.
- The preload `invoke` wrapper automatically extracts payload data from success `{ data }` envelopes, which has been handled correctly in the store slice when updating the message state.
