### PR TITLE
v1.7.5 - Fix first message confusion

### DIFF
--- a/changelogs/v1.7.5.md
+++ b/changelogs/v1.7.5.md
@@ -1,0 +1,4 @@
+## What's new
+
+### Fixes
+- Removed prepending of the stale first user message in compacted contexts. When a session is compacted, the active goal is already fully described in the session summary; prepending the original first message of the session (e.g. "implement embeddings now") was causing the agent to get confused about the active task when the user asked a fresh question.

--- a/electron/lib/compaction.ts
+++ b/electron/lib/compaction.ts
@@ -184,7 +184,7 @@ export function buildCompactionTransformer(
     // If we already have a summary from the last compaction, apply it immediately
     if (cachedSummary !== null) {
       const { toKeep } = splitMessages(messages);
-      return buildCompactedContext(cachedSummary, messages[0], toKeep);
+      return buildCompactedContext(cachedSummary, toKeep);
     }
 
     // Generate summary if not already in flight
@@ -208,7 +208,7 @@ export function buildCompactionTransformer(
     try {
       const summary = await compactionPromise;
       const { toKeep } = splitMessages(messages);
-      return buildCompactedContext(summary, messages[0], toKeep);
+      return buildCompactedContext(summary, toKeep);
     } catch {
       // Fallback for this turn: sliding-window trim (safe, no LLM call)
       return slidingWindowFallback(messages);
@@ -218,7 +218,6 @@ export function buildCompactionTransformer(
 
 function buildCompactedContext(
   summary: string,
-  firstMessage: AgentMessage | undefined,
   recentMessages: AgentMessage[],
 ): AgentMessage[] {
   const summaryMessage: AgentMessage = {
@@ -231,8 +230,6 @@ function buildCompactedContext(
   };
 
   const result: AgentMessage[] = [];
-  // Always keep the very first user message (the original task)
-  if (firstMessage && firstMessage.role === "user") result.push(firstMessage);
   result.push(summaryMessage);
   result.push(...recentMessages);
   return result;
@@ -295,7 +292,7 @@ export async function compactNow(
   if (toSummarise.length === 0) return null;
 
   const summary = await generateSummary(toSummarise, llmConfig, session.abortCtrl.signal);
-  const messages = buildCompactedContext(summary, session.messages[0], toKeep);
+  const messages = buildCompactedContext(summary, toKeep);
   return { messages, summary };
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes built in agent logic when a session is compacted mid conversation. 
 
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Docs / changelog
- [ ] Tests


## Checklist

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [ ] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [ ] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts`
- [ ] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`