### PR TITLE
v1.7.6 - feat: @ mention autocomplete, prompt context forwarding, and clickable inline reference links

### DIFF
--- a/changelogs/v1.7.6.md
+++ b/changelogs/v1.7.6.md
@@ -6,7 +6,13 @@
 - Re-ordered the rendering hierarchy of agent messages so that assistant text content always renders above tool call cards and subagent blocks inside the chat panel.
 - Render task descriptions in the Kanban board card detail modal as interactive markdown components by default, switching to an auto-focusing editing textarea on click.
 - Support pressing `Cmd+Enter` / `Ctrl+Enter` inside the card description editor to automatically save changes and exit edit mode.
+- Added `@` mention autocomplete support in both the chat panel and the agent view inputs to search and reference notes, tasks, and project files.
+- Added automatic prompt context forwarding: referencing a note, card, or code file via `@` autocomplete automatically embeds its raw content as structured context for the AI prompt.
+- Integrated clickable inline reference links in chat messages for notes, tasks, and files, which navigate the user directly to the corresponding view inside the application.
 
 ### Fixes
 - Resolved Windows-runner-specific build failures in GitHub Actions: excluded the workspace from Windows Defender to prevent EPERM file-locking errors, and configured `npm ci` to use fetch retry flags to tolerate transient network connection drops (`ECONNRESET`).
 - Added support for `"system"` message types inside backend SQLite DB queries to prevent TypeScript compiler warnings.
+- Fixed an issue where clicking inline reference links opened an external browser window by configuring a custom `urlTransform` inside `ReactMarkdown` to recognize the `cairn://` protocol.
+- Resolved low contrast text readability issues by rendering reference links inside the user's message bubble with a readable white color against the accent background.
+

--- a/changelogs/v1.7.6.md
+++ b/changelogs/v1.7.6.md
@@ -6,7 +6,14 @@
 - Re-ordered the rendering hierarchy of agent messages so that assistant text content always renders above tool call cards and subagent blocks inside the chat panel.
 - Render task descriptions in the Kanban board card detail modal as interactive markdown components by default, switching to an auto-focusing editing textarea on click.
 - Support pressing `Cmd+Enter` / `Ctrl+Enter` inside the card description editor to automatically save changes and exit edit mode.
+- Added `@` mention autocomplete support in both the chat panel and the agent view inputs to search and reference notes, tasks, and project files.
+- Added automatic prompt context forwarding: referencing a note, card, or code file via `@` autocomplete automatically embeds its raw content as structured context for the AI prompt.
+- Integrated clickable inline reference links in chat messages for notes, tasks, and files, which navigate the user directly to the corresponding view inside the application.
 
 ### Fixes
 - Resolved Windows-runner-specific build failures in GitHub Actions: excluded the workspace from Windows Defender to prevent EPERM file-locking errors, and configured `npm ci` to use fetch retry flags to tolerate transient network connection drops (`ECONNRESET`).
 - Added support for `"system"` message types inside backend SQLite DB queries to prevent TypeScript compiler warnings.
+- Added TTL caching for the SQLite database `getSnapshot` queries to optimize Model Context Protocol (MCP) tool performance and prevent timeout/infinite rendering loops.
+- Fixed an issue where clicking inline reference links opened an external browser window by configuring a custom `urlTransform` inside `ReactMarkdown` to recognize the `cairn://` protocol.
+- Resolved low contrast text readability issues by rendering reference links inside the user's message bubble with a readable white color against the accent background.
+

--- a/changelogs/v1.7.6.md
+++ b/changelogs/v1.7.6.md
@@ -1,6 +1,7 @@
 ## What's new
 
 ### Features
+- Introduce the `/archive-chat` (and `/archive` alias) slash command to compact and save active chat conversations as project notes under the `conversations/` directory, then clear the chat panel.
 - Insert a centered "----- Session Compacted -----" system indicator in the chat message log when background/automatic context compaction completes.
 - Re-ordered the rendering hierarchy of agent messages so that assistant text content always renders above tool call cards and subagent blocks inside the chat panel.
 - Render task descriptions in the Kanban board card detail modal as interactive markdown components by default, switching to an auto-focusing editing textarea on click.

--- a/changelogs/v1.7.6.md
+++ b/changelogs/v1.7.6.md
@@ -1,0 +1,11 @@
+## What's new
+
+### Features
+- Insert a centered "----- Session Compacted -----" system indicator in the chat message log when background/automatic context compaction completes.
+- Re-ordered the rendering hierarchy of agent messages so that assistant text content always renders above tool call cards and subagent blocks inside the chat panel.
+- Render task descriptions in the Kanban board card detail modal as interactive markdown components by default, switching to an auto-focusing editing textarea on click.
+- Support pressing `Cmd+Enter` / `Ctrl+Enter` inside the card description editor to automatically save changes and exit edit mode.
+
+### Fixes
+- Resolved Windows-runner-specific build failures in GitHub Actions: excluded the workspace from Windows Defender to prevent EPERM file-locking errors, and configured `npm ci` to use fetch retry flags to tolerate transient network connection drops (`ECONNRESET`).
+- Added support for `"system"` message types inside backend SQLite DB queries to prevent TypeScript compiler warnings.

--- a/electron/db/queries.ts
+++ b/electron/db/queries.ts
@@ -1128,7 +1128,7 @@ export function deletePiSession(db: Database.Database, sessionId: string) {
 export interface PiMessageRow {
   id: string;
   sessionId: string;
-  role: "user" | "assistant" | "error";
+  role: "user" | "assistant" | "error" | "system";
   content: string;
   toolCalls: unknown[] | null;
   subagents: unknown[] | null;
@@ -1141,7 +1141,7 @@ function toPiMessage(row: any): PiMessageRow {
   return {
     id:        row.id as string,
     sessionId: row.session_id as string,
-    role:      row.role as "user" | "assistant" | "error",
+    role:      row.role as "user" | "assistant" | "error" | "system",
     content:   row.content as string,
     toolCalls: row.tool_calls ? JSON.parse(row.tool_calls as string) : null,
     subagents: row.subagents ? JSON.parse(row.subagents as string) : null,
@@ -1152,7 +1152,7 @@ function toPiMessage(row: any): PiMessageRow {
 
 export function upsertPiMessage(
   db: Database.Database,
-  msg: { id: string; sessionId: string; role: "user" | "assistant" | "error"; content: string; toolCalls?: unknown[] | null; subagents?: unknown[] | null; timestamp: string; order: number },
+  msg: { id: string; sessionId: string; role: "user" | "assistant" | "error" | "system"; content: string; toolCalls?: unknown[] | null; subagents?: unknown[] | null; timestamp: string; order: number },
 ) {
   db.prepare(`
     INSERT INTO pi_agent_messages (id, session_id, role, content, tool_calls, subagents, timestamp, "order")
@@ -1172,7 +1172,7 @@ export function upsertPiMessage(
 export function savePiMessages(
   db: Database.Database,
   sessionId: string,
-  messages: Array<{ id: string; role: "user" | "assistant" | "error"; content: string; toolCalls?: unknown[] | null; subagents?: unknown[] | null; timestamp: string }>,
+  messages: Array<{ id: string; role: "user" | "assistant" | "error" | "system"; content: string; toolCalls?: unknown[] | null; subagents?: unknown[] | null; timestamp: string }>,
 ) {
   const save = db.transaction(() => {
     db.prepare("DELETE FROM pi_agent_messages WHERE session_id = ?").run(sessionId);

--- a/electron/ipc/pi-agent.ts
+++ b/electron/ipc/pi-agent.ts
@@ -94,7 +94,7 @@ async function runSession(
     session,
     llmConfig,
     () => send("pi-agent:compact", { sessionId, status: "start" }),
-    () => send("pi-agent:compact", { sessionId, status: "end" }),
+    () => send("pi-agent:compact", { sessionId, status: "end", auto: true }),
   );
 
   await runAgentLoop(

--- a/electron/mcp/db.ts
+++ b/electron/mcp/db.ts
@@ -151,23 +151,19 @@ export function toCard(r: any) {
   };
 }
 
-// ── Snapshot Cache ────────────────────────────
-let cachedSnapshot: Snapshot | null = null;
-let lastSnapshotTime = 0;
-const CACHE_TTL_MS = 2000; // Cache valid for 2 seconds
+// ── Snapshot ──────────────────────────────────
 
-export function clearSnapshotCache(): void {
-  cachedSnapshot = null;
-  lastSnapshotTime = 0;
+export interface Snapshot {
+  workspaces: ReturnType<typeof toWorkspace>[];
+  projects: ReturnType<typeof toProject>[];
+  notes: ReturnType<typeof toNote>[];
+  columns: ReturnType<typeof toColumn>[];
+  cards: ReturnType<typeof toCard>[];
+  tags: { id: string; workspaceId: string; name: string; color: string }[];
 }
 
 export function getSnapshot(db: Database.Database): Snapshot {
-  const now = Date.now();
-  if (cachedSnapshot && (now - lastSnapshotTime < CACHE_TTL_MS)) {
-    return cachedSnapshot;
-  }
-
-  cachedSnapshot = {
+  return {
     workspaces: db.prepare("SELECT * FROM workspaces ORDER BY created_at").all().map(toWorkspace),
     projects: db.prepare("SELECT * FROM projects ORDER BY created_at").all().map(toProject),
     notes: db.prepare("SELECT * FROM notes ORDER BY updated_at DESC").all().map(toNote),
@@ -178,8 +174,6 @@ export function getSnapshot(db: Database.Database): Snapshot {
       name: r.name as string, color: r.color as string,
     })),
   };
-  lastSnapshotTime = now;
-  return cachedSnapshot;
 }
 
 // ── Locks & Notifications ──────────────────────

--- a/electron/mcp/db.ts
+++ b/electron/mcp/db.ts
@@ -151,19 +151,23 @@ export function toCard(r: any) {
   };
 }
 
-// ── Snapshot ──────────────────────────────────
+// ── Snapshot Cache ────────────────────────────
+let cachedSnapshot: Snapshot | null = null;
+let lastSnapshotTime = 0;
+const CACHE_TTL_MS = 2000; // Cache valid for 2 seconds
 
-export interface Snapshot {
-  workspaces: ReturnType<typeof toWorkspace>[];
-  projects: ReturnType<typeof toProject>[];
-  notes: ReturnType<typeof toNote>[];
-  columns: ReturnType<typeof toColumn>[];
-  cards: ReturnType<typeof toCard>[];
-  tags: { id: string; workspaceId: string; name: string; color: string }[];
+export function clearSnapshotCache(): void {
+  cachedSnapshot = null;
+  lastSnapshotTime = 0;
 }
 
 export function getSnapshot(db: Database.Database): Snapshot {
-  return {
+  const now = Date.now();
+  if (cachedSnapshot && (now - lastSnapshotTime < CACHE_TTL_MS)) {
+    return cachedSnapshot;
+  }
+
+  cachedSnapshot = {
     workspaces: db.prepare("SELECT * FROM workspaces ORDER BY created_at").all().map(toWorkspace),
     projects: db.prepare("SELECT * FROM projects ORDER BY created_at").all().map(toProject),
     notes: db.prepare("SELECT * FROM notes ORDER BY updated_at DESC").all().map(toNote),
@@ -174,6 +178,8 @@ export function getSnapshot(db: Database.Database): Snapshot {
       name: r.name as string, color: r.color as string,
     })),
   };
+  lastSnapshotTime = now;
+  return cachedSnapshot;
 }
 
 // ── Locks & Notifications ──────────────────────

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -356,9 +356,9 @@ const api = {
       return () => ipcRenderer.off("pi-agent:retry", handler);
     },
     /** Fired when the session starts or finishes an LLM-based compaction pass. */
-    onCompact: (cb: (e: { sessionId: string; status: "start" | "end" }) => void) => {
+    onCompact: (cb: (e: { sessionId: string; status: "start" | "end"; auto?: boolean }) => void) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const handler = (_: any, e: { sessionId: string; status: "start" | "end" }) => cb(e);
+      const handler = (_: any, e: { sessionId: string; status: "start" | "end"; auto?: boolean }) => cb(e);
       ipcRenderer.on("pi-agent:compact", handler);
       return () => ipcRenderer.off("pi-agent:compact", handler);
     },

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -12,7 +12,7 @@ import { useEffect, useLayoutEffect, useRef, useState, useCallback } from "react
 import { flushSync } from "react-dom";
 import { Trash2, CheckCircle, FileText, Zap, Map as MapIcon } from "lucide-react";
 import { QuestionForm } from "@/components/chat/chat-panel/QuestionForm";
-import { ChatInput } from "@/components/chat/ChatInput";
+import { ChatInput, SuggestionItem } from "@/components/chat/ChatInput";
 import type { PendingQuestion } from "@/hooks/useChatStream";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
@@ -22,6 +22,7 @@ import { PlanTaskList } from "./PlanTaskList";
 import { ContextRing } from "./ContextRing";
 import { Tooltip } from "@/components/ui/tooltip";
 import { CairnEvents } from "@/lib/events";
+import { resolvePromptContext } from "@/lib/context-resolver";
 import type { TerminalSession } from "@/store/slices/terminal-sessions";
 
 // ── Cairn tool ref extraction ─────────────────────────────────────────────────
@@ -429,7 +430,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session.sessionId]);
 
-  const sendPrompt = useCallback((text: string) => {
+  const sendPrompt = useCallback(async (text: string) => {
     const trimmed = text.trim();
     if (!trimmed || isLoading || !session.cwd) return;
 
@@ -468,9 +469,19 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
       timestamp:   new Date().toISOString(),
     });
 
+    // Resolve context references and append to prompt payload
+    const store = useCairnStore.getState();
+    const resolvedPrompt = await resolvePromptContext(
+      trimmed,
+      store.notes,
+      store.cards,
+      store.columns,
+      session.cwd || null
+    );
+
     const promptPayload = {
       sessionId:   session.sessionId,
-      prompt:      trimmed,
+      prompt:      resolvedPrompt,
       projectId:   session.projectId,
       workspaceId: activeWorkspaceId ?? undefined,
       cwd:         session.cwd,
@@ -491,6 +502,22 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
   // useLayoutEffect runs synchronously after render, keeping the ref up-to-date
   // before any async callbacks fire without triggering the react-hooks/refs lint rule.
   useLayoutEffect(() => { sendPromptRef.current = sendPrompt; });
+
+  const handleSearchFiles = useCallback(async (query: string): Promise<SuggestionItem[]> => {
+    if (!window.electron || !session.cwd) return [];
+    try {
+      const files = await window.electron.agent.searchFiles(session.cwd, query);
+      return files.map((f) => ({
+        id: f.path,
+        type: "file",
+        title: f.relativePath,
+        subtitle: "File",
+      }));
+    } catch (err) {
+      console.error("[pi-agent:autocomplete] searchFiles failed:", err);
+      return [];
+    }
+  }, [session.cwd]);
 
   function handleStop() {
     window.electron?.piAgent.abort(session.sessionId);
@@ -648,6 +675,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
           disabled={isLoading}
           placeholder={session.mode === "plan" ? "Describe what you want to build…" : "Ask the agent…"}
           commands={NATIVE_AGENT_SLASH_COMMANDS}
+          onSearchSuggestions={handleSearchFiles}
         />
         <p className="text-[0.643rem] text-[var(--text-tertiary)] mt-1 text-center">
           {retryInfo

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -387,6 +387,14 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
     const unsubCompact = electron.piAgent.onCompact((e) => {
       if (e.sessionId !== sessionId) return;
       setIsCompacting(e.status === "start");
+      if (e.status === "end" && e.auto) {
+        addPiMessage(sessionId, {
+          id: id(),
+          role: "system" as const,
+          content: "----- Session Compacted -----",
+          timestamp: new Date().toISOString(),
+        });
+      }
     });
 
     // /compact result — inject a system message confirming compaction

--- a/src/components/agent/PiMessageBubble.tsx
+++ b/src/components/agent/PiMessageBubble.tsx
@@ -319,6 +319,18 @@ export function PiMessageBubble({ message }: PiMessageBubbleProps) {
       <MessageAvatar role="bot" size="md" />
       <div className="flex-1 min-w-0 flex flex-col gap-1">
 
+        {/* Markdown content with animated cursor when streaming */}
+        {hasContent && (
+          <div className={cn(
+            "px-3 py-2 rounded-xl rounded-tl-sm text-xs leading-relaxed",
+            "bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-secondary)]",
+            "min-w-0 overflow-hidden",
+          )}>
+            <MarkdownContent content={message.content} />
+            {message.isStreaming && <StreamingCursor size="md" />}
+          </div>
+        )}
+
         {/* Tool call chips — expandable */}
         {hasTools && (
           <div className="flex flex-col gap-0.5">
@@ -338,18 +350,6 @@ export function PiMessageBubble({ message }: PiMessageBubbleProps) {
           <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-[var(--surface-2)] border border-[var(--border)] w-fit">
             <Loader2 size={9} className="text-[var(--accent)] animate-spin shrink-0" />
             <span className="text-[0.714rem] text-[var(--text-tertiary)]">Thinking…</span>
-          </div>
-        )}
-
-        {/* Markdown content with animated cursor when streaming */}
-        {hasContent && (
-          <div className={cn(
-            "px-3 py-2 rounded-xl rounded-tl-sm text-xs leading-relaxed",
-            "bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-secondary)]",
-            "min-w-0 overflow-hidden",
-          )}>
-            <MarkdownContent content={message.content} />
-            {message.isStreaming && <StreamingCursor size="md" />}
           </div>
         )}
       </div>

--- a/src/components/agent/PiMessageBubble.tsx
+++ b/src/components/agent/PiMessageBubble.tsx
@@ -287,7 +287,7 @@ export function PiMessageBubble({ message }: PiMessageBubbleProps) {
       <div className="flex gap-2 items-start justify-end">
         <div className="flex-1 min-w-0 flex flex-col items-end gap-1">
           <div className="px-3 py-2 rounded-xl rounded-tr-sm text-xs leading-relaxed bg-[var(--accent)] text-white max-w-[85%]">
-            <p className="whitespace-pre-wrap break-words">{message.content}</p>
+            <MarkdownContent content={message.content} />
           </div>
         </div>
         <MessageAvatar role="user" size="md" />
@@ -344,6 +344,7 @@ export function PiMessageBubble({ message }: PiMessageBubbleProps) {
         {hasSubagents && message.subagents!.map((sub) => (
           <SubagentBlock key={sub.childSessionId} sub={sub} />
         ))}
+
 
         {/* "Thinking…" spinner — only when streaming with no content or tools yet */}
         {!hasContent && message.isStreaming && !hasTools && !hasSubagents && (

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useRef, useEffect, useState, useMemo } from "react";
-import { Send, Square, Sparkles } from "lucide-react";
+import { Send, Square, Sparkles, FileText, CheckSquare, FileCode } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip } from "@/components/ui/tooltip";
 
@@ -9,6 +9,13 @@ export interface SlashCommand {
   name: string;
   description: string;
   insertText: string;
+}
+
+export interface SuggestionItem {
+  id: string;
+  type: "note" | "card" | "file";
+  title: string;
+  subtitle?: string;
 }
 
 interface ChatInputProps {
@@ -23,6 +30,8 @@ interface ChatInputProps {
   showSparkles?: boolean;
   autoFocus?: boolean;
   commands?: SlashCommand[];
+  suggestions?: SuggestionItem[];
+  onSearchSuggestions?: (query: string) => Promise<SuggestionItem[]>;
 }
 
 export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
@@ -39,6 +48,8 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
       showSparkles = false,
       autoFocus = false,
       commands = [],
+      suggestions = [],
+      onSearchSuggestions,
     },
     ref
   ) => {
@@ -47,29 +58,117 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
 
     const [showSuggestions, setShowSuggestions] = useState(false);
     const [activeIndex, setActiveIndex] = useState(0);
+    const [trigger, setTrigger] = useState<{ type: "command" | "mention"; query: string; index: number } | null>(null);
+    const [asyncSuggestions, setAsyncSuggestions] = useState<SuggestionItem[]>([]);
 
-    // Filter commands based on input
+    // Parser to scan backward from the cursor for a trigger ('/' at start, or '@' preceded by space/newline/start)
+    const getActiveTrigger = () => {
+      const el = resolvedRef.current;
+      if (!el) return null;
+      
+      const text = value;
+      const pos = el.selectionStart;
+      
+      let i = pos - 1;
+      while (i >= 0 && text[i] !== " " && text[i] !== "\n") {
+        if (text[i] === "@") {
+          if (i === 0 || text[i - 1] === " " || text[i - 1] === "\n") {
+            const query = text.slice(i + 1, pos);
+            return { type: "mention" as const, query, index: i };
+          }
+        }
+        if (text[i] === "/" && i === 0) {
+          const query = text.slice(i + 1, pos);
+          return { type: "command" as const, query, index: i };
+        }
+        i--;
+      }
+      return null;
+    };
+
+    const checkTrigger = () => {
+      requestAnimationFrame(() => {
+        const active = getActiveTrigger();
+        setTrigger(active);
+      });
+    };
+
+    // Filter commands based on trigger
     const filteredCommands = useMemo(() => {
-      if (!commands.length || !value.startsWith("/")) return [];
-      const query = value.slice(1).toLowerCase();
-      return commands.filter((cmd) => cmd.name.toLowerCase().includes(query));
-    }, [commands, value]);
+      if (trigger?.type !== "command") return [];
+      const q = trigger.query.toLowerCase();
+      return commands.filter((cmd) => cmd.name.toLowerCase().includes(q));
+    }, [commands, trigger]);
 
-    // Show suggestions only when there are matching commands
+    // Handle async search suggestions with debounce
     useEffect(() => {
-      if (filteredCommands.length > 0) {
+      if (trigger?.type !== "mention" || !onSearchSuggestions) {
+        setAsyncSuggestions([]);
+        return;
+      }
+
+      const query = trigger.query;
+      const delayDebounce = setTimeout(async () => {
+        const results = await onSearchSuggestions(query);
+        setAsyncSuggestions(results);
+      }, 150);
+
+      return () => clearTimeout(delayDebounce);
+    }, [trigger, onSearchSuggestions]);
+
+    // Filter local suggestions or use async suggestions
+    const filteredSuggestions = useMemo(() => {
+      if (trigger?.type !== "mention") return [];
+      if (onSearchSuggestions) {
+        return asyncSuggestions;
+      }
+      if (!suggestions) return [];
+      const q = trigger.query.toLowerCase();
+      return suggestions.filter((item) =>
+        item.title.toLowerCase().includes(q)
+      );
+    }, [suggestions, trigger, onSearchSuggestions, asyncSuggestions]);
+
+    // Show suggestions only when there are matching entries
+    useEffect(() => {
+      const hasOptions = trigger?.type === "command"
+        ? filteredCommands.length > 0
+        : filteredSuggestions.length > 0;
+
+      if (hasOptions) {
         setShowSuggestions(true);
-        setActiveIndex((prev) => Math.min(prev, filteredCommands.length - 1));
+        const listLength = trigger?.type === "command" ? filteredCommands.length : filteredSuggestions.length;
+        setActiveIndex((prev) => Math.min(prev, listLength - 1));
       } else {
         setShowSuggestions(false);
         setActiveIndex(0);
       }
-    }, [filteredCommands]);
+    }, [filteredCommands, filteredSuggestions, trigger]);
 
     const handleSelectCommand = (cmd: SlashCommand) => {
-      onChange(cmd.insertText);
-      setShowSuggestions(false);
+      if (!trigger) return;
+      const before = value.slice(0, trigger.index);
+      const after = value.slice(resolvedRef.current?.selectionEnd ?? value.length);
+      onChange(before + cmd.insertText + after);
+      setTrigger(null);
       resolvedRef.current?.focus();
+    };
+
+    const handleSelectSuggestion = (item: SuggestionItem) => {
+      if (!trigger) return;
+      const before = value.slice(0, trigger.index);
+      const after = value.slice(resolvedRef.current?.selectionEnd ?? value.length);
+      const insertedText = item.type === "file" ? `\`${item.title}\`` : `[[${item.title}]]`;
+      onChange(before + insertedText + after);
+      setTrigger(null);
+      resolvedRef.current?.focus();
+      const newCursorPos = trigger.index + insertedText.length;
+      setTimeout(() => {
+        if (resolvedRef.current) {
+          resolvedRef.current.selectionStart = newCursorPos;
+          resolvedRef.current.selectionEnd = newCursorPos;
+        }
+      }, 0);
     };
 
     // Auto-resize height based on contents
@@ -88,25 +187,31 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
     }, [autoFocus, resolvedRef]);
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (showSuggestions && filteredCommands.length > 0) {
+      const listLength = trigger?.type === "command" ? filteredCommands.length : filteredSuggestions.length;
+      if (showSuggestions && listLength > 0 && trigger) {
         if (e.key === "ArrowDown") {
           e.preventDefault();
-          setActiveIndex((prev) => (prev + 1) % filteredCommands.length);
+          setActiveIndex((prev) => (prev + 1) % listLength);
           return;
         }
         if (e.key === "ArrowUp") {
           e.preventDefault();
-          setActiveIndex((prev) => (prev - 1 + filteredCommands.length) % filteredCommands.length);
+          setActiveIndex((prev) => (prev - 1 + listLength) % listLength);
           return;
         }
         if (e.key === "Enter" || e.key === "Tab") {
           e.preventDefault();
-          handleSelectCommand(filteredCommands[activeIndex]);
+          if (trigger.type === "command") {
+            handleSelectCommand(filteredCommands[activeIndex]);
+          } else {
+            handleSelectSuggestion(filteredSuggestions[activeIndex]);
+          }
           return;
         }
         if (e.key === "Escape") {
           e.preventDefault();
           setShowSuggestions(false);
+          setTrigger(null);
           return;
         }
       }
@@ -124,38 +229,71 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
     return (
       <div className="relative w-full">
         {/* Autocomplete suggestions */}
-        {showSuggestions && filteredCommands.length > 0 && (
-          <div className="absolute bottom-full left-0 right-0 mb-1.5 z-50 bg-[var(--surface)] border border-[var(--border)] rounded-xl shadow-2xl overflow-hidden max-h-56 overflow-y-auto">
+        {showSuggestions && trigger && (
+          <div className="absolute bottom-full left-0 right-0 mb-1.5 z-50 bg-[var(--surface)] border border-[var(--border)] rounded-xl shadow-2xl overflow-hidden max-h-56 overflow-y-auto animate-in fade-in slide-in-from-bottom-2 duration-150">
             <div className="px-3 py-1.5 border-b border-[var(--border)] bg-[var(--surface-2)] flex items-center justify-between">
               <span className="text-[0.643rem] font-semibold uppercase tracking-wider text-[var(--text-tertiary)]">
-                Slash Commands
+                {trigger.type === "command" ? "Slash Commands" : "Mention Note / Task / File"}
               </span>
               <span className="text-[0.571rem] text-[var(--text-tertiary)]">
                 ↑↓ to navigate · Enter to select
               </span>
             </div>
             <div className="p-1">
-              {filteredCommands.map((cmd, index) => {
-                const isActive = index === activeIndex;
-                return (
-                  <button
-                    key={cmd.name}
-                    type="button"
-                    onClick={() => handleSelectCommand(cmd)}
-                    className={cn(
-                      "w-full text-left px-2.5 py-2 rounded-lg flex flex-col gap-0.5 transition-colors",
-                      isActive
-                        ? "bg-[var(--accent-dim)] text-[var(--accent)]"
-                        : "text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
-                    )}
-                  >
-                    <span className="text-xs font-semibold">/{cmd.name}</span>
-                    <span className="text-[0.643rem] text-[var(--text-tertiary)]">
-                      {cmd.description}
-                    </span>
-                  </button>
-                );
-              })}
+              {trigger.type === "command"
+                ? filteredCommands.map((cmd, index) => {
+                    const isActive = index === activeIndex;
+                    return (
+                      <button
+                        key={cmd.name}
+                        type="button"
+                        onClick={() => handleSelectCommand(cmd)}
+                        className={cn(
+                          "w-full text-left px-2.5 py-2 rounded-lg flex flex-col gap-0.5 transition-colors",
+                          isActive
+                            ? "bg-[var(--accent-dim)] text-[var(--accent)]"
+                            : "text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+                        )}
+                      >
+                        <span className="text-xs font-semibold">/{cmd.name}</span>
+                        <span className="text-[0.643rem] text-[var(--text-tertiary)]">
+                          {cmd.description}
+                        </span>
+                      </button>
+                    );
+                  })
+                : filteredSuggestions.map((item, index) => {
+                    const isActive = index === activeIndex;
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => handleSelectSuggestion(item)}
+                        className={cn(
+                          "w-full text-left px-2.5 py-2 rounded-lg flex items-center justify-between gap-3 transition-colors",
+                          isActive
+                            ? "bg-[var(--accent-dim)] text-[var(--accent)]"
+                            : "text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+                        )}
+                      >
+                        <div className="flex items-center gap-2 min-w-0">
+                          {item.type === "note" ? (
+                            <FileText size={12} className="text-[var(--info)] shrink-0" />
+                          ) : item.type === "file" ? (
+                            <FileCode size={12} className="text-[var(--warning,#f59e0b)] shrink-0" />
+                          ) : (
+                            <CheckSquare size={12} className="text-[var(--accent)] shrink-0" />
+                          )}
+                          <span className="text-xs font-semibold truncate">
+                            {item.title}
+                          </span>
+                        </div>
+                        <span className="text-[0.643rem] text-[var(--text-tertiary)] shrink-0">
+                          {item.subtitle}
+                        </span>
+                      </button>
+                    );
+                  })}
             </div>
           </div>
         )}
@@ -177,8 +315,13 @@ export const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
           <textarea
             ref={resolvedRef}
             value={value}
-            onChange={(e) => onChange(e.target.value)}
+            onChange={(e) => {
+              onChange(e.target.value);
+              checkTrigger();
+            }}
             onKeyDown={handleKeyDown}
+            onKeyUp={checkTrigger}
+            onSelect={checkTrigger}
             placeholder={placeholder}
             rows={1}
             disabled={disabled}

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -8,6 +8,7 @@ import { MIN_CHAT_PANEL_WIDTH, MAX_CHAT_PANEL_WIDTH } from "@/store/slices/ui";
 import { useShallow } from "zustand/react/shallow";
 import { useChatStream } from "@/hooks/useChatStream";
 import { buildGraphContext } from "@/components/graph/graph-ai-utils";
+import { ipcAwaitResult } from "@/store/ipc";
 
 import { Tooltip } from "@/components/ui/tooltip";
 import { ChatMessageBubble } from "./chat-panel/ChatMessageBubble";
@@ -50,6 +51,11 @@ Remember: Suggest connections actively. Call \`suggest_connections\` whenever th
 
 const CHAT_SLASH_COMMANDS = [
   {
+    name: "archive-chat",
+    description: "Archive conversation as a note & clear chat",
+    insertText: "/archive-chat",
+  },
+  {
     name: "compact",
     description: "Summarise and compact conversation history",
     insertText: "/compact",
@@ -82,6 +88,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     chatPanelWidth, setChatPanelWidth,
     activeView, graphData, selectedGraphNodeId,
     clearThreadMessages,
+    createNote,
   } = useCairnStore(useShallow((s) => ({
     chatOpen:            s.chatOpen,
     toggleChat:          s.toggleChat,
@@ -102,6 +109,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     graphData:           s.graphData,
     selectedGraphNodeId: s.selectedGraphNodeId,
     clearThreadMessages: s.clearThreadMessages,
+    createNote:          s.createNote,
   })));
 
   const [input, setInput]             = useState("");
@@ -117,18 +125,6 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
   const dividerRef     = useRef<HTMLDivElement>(null);
 
   const { isLoading, toolCalls, streamingContent, pendingQuestions, sendStream, stopStream } = useChatStream(threadId);
-
-  const handleClear = useCallback(() => {
-    if (!threadId) return;
-    if (isLoading) stopStream();
-    clearThreadMessages(threadId);
-  }, [threadId, isLoading, stopStream, clearThreadMessages]);
-
-  // Track isLoading in a ref so the thread-init effect can read it without
-  // being listed as a dependency (we never want a loading-state change to
-  // re-trigger thread selection).
-  const isLoadingRef = useRef(isLoading);
-  useEffect(() => { isLoadingRef.current = isLoading; }, [isLoading]);
 
   const project   = useMemo(() => projects.find((p) => p.id === activeProjectId),   [projects, activeProjectId]);
   const workspace = useMemo(() => workspaces.find((w) => w.id === activeWorkspaceId), [workspaces, activeWorkspaceId]);
@@ -167,6 +163,118 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     () => chatThreads.find((t) => t.id === threadId),
     [chatThreads, threadId]
   );
+
+  const handleClear = useCallback(() => {
+    if (!threadId) return;
+    if (isLoading) stopStream();
+    clearThreadMessages(threadId);
+  }, [threadId, isLoading, stopStream, clearThreadMessages]);
+
+  const handleArchiveChat = useCallback(async () => {
+    if (!threadId) return;
+    if (isLoading) stopStream();
+
+    const threadMessages = chatMessages.filter((m) => m.threadId === threadId);
+    if (threadMessages.length === 0) {
+      addMessage(threadId, "system", "Error: No messages to archive.");
+      return;
+    }
+
+    if (!activeProjectId) {
+      addMessage(threadId, "system", "Error: No active project selected. Please select a project before archiving the chat.");
+      return;
+    }
+
+    addMessage(threadId, "system", "Archiving conversation to project note...");
+
+    const history = threadMessages.map((m) => ({ role: m.role, content: m.content }));
+
+    let noteContent = "";
+    let useSummary = false;
+
+    try {
+      const result = await ipcAwaitResult<{ summary: string }>(async (e) => {
+        try {
+          const summaryObj = await e.chat.compactThread({
+            messages: history,
+            config: {
+              provider: aiConfig.provider,
+              baseUrl: aiConfig.baseUrl,
+              model: aiConfig.model,
+              apiKey: aiConfig.apiKey,
+            },
+          }) as { summary: string };
+          return { data: summaryObj };
+        } catch (err) {
+          return { error: err instanceof Error ? err.message : String(err) };
+        }
+      });
+
+      if (result && "data" in result && result.data?.summary) {
+        const summary = result.data.summary;
+        const threadTitle = activeThread?.title ?? (threadMessages.find((m) => m.role === "user")?.content.slice(0, 50) ?? "New thread");
+        const dateStr = new Date().toLocaleString();
+        
+        noteContent = `# Chat Summary: ${threadTitle}\n\n` +
+          `- **Date:** ${dateStr}\n` +
+          `- **Original Thread:** ${threadTitle}\n\n` +
+          `---\n\n` +
+          summary;
+        useSummary = true;
+      }
+    } catch (err) {
+      console.warn("Failed to generate AI summary, falling back to raw transcript:", err);
+    }
+
+    if (!useSummary) {
+      // Fallback: raw transcript
+      const threadTitle = activeThread?.title ?? (threadMessages.find((m) => m.role === "user")?.content.slice(0, 50) ?? "New thread");
+      const dateStr = new Date().toLocaleString();
+      
+      let rawTranscript = `# Chat Log: ${threadTitle}\n\n` +
+        `- **Date:** ${dateStr}\n` +
+        `- **Status:** Archive Fallback (AI Compaction Unavailable)\n\n` +
+        `---\n\n` +
+        `### Conversation History\n\n`;
+
+      for (const msg of threadMessages) {
+        if (msg.role === "system") continue;
+        const roleName = msg.role === "user" ? "User" : "AI Assistant";
+        rawTranscript += `### **${roleName}**\n\n${msg.content}\n\n`;
+      }
+      noteContent = rawTranscript;
+    }
+
+    // Determine note title with timestamp
+    const nowObj = new Date();
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const timestamp = `${nowObj.getFullYear()}-${pad(nowObj.getMonth() + 1)}-${pad(nowObj.getDate())}-${pad(nowObj.getHours())}${pad(nowObj.getMinutes())}${pad(nowObj.getSeconds())}`;
+    
+    const threadTitle = activeThread?.title ?? (threadMessages.find((m) => m.role === "user")?.content.slice(0, 50) ?? "New thread");
+    const sluggedTitle = threadTitle
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)+/g, "");
+    const noteTitle = `${timestamp}-${sluggedTitle || "conversation"}`;
+
+    // Create the note
+    createNote(activeProjectId, noteTitle, "note", "conversations", noteContent);
+
+    // Clear the chat messages
+    await clearThreadMessages(threadId);
+
+    // Add a final system message confirming the save
+    addMessage(threadId, "system", `Chat archived to project note: \`conversations/${noteTitle}\`.`);
+
+  }, [threadId, isLoading, stopStream, chatMessages, activeProjectId, activeThread, aiConfig, addMessage, createNote, clearThreadMessages]);
+
+  // Track isLoading in a ref so the thread-init effect can read it without
+  // being listed as a dependency (we never want a loading-state change to
+  // re-trigger thread selection).
+  const isLoadingRef = useRef(isLoading);
+  useEffect(() => { isLoadingRef.current = isLoading; }, [isLoading]);
+
+
 
   // Initialise / switch thread.
   // Reads getOrCreateThread directly from the store snapshot (stable, no ref
@@ -208,6 +316,12 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
       return;
     }
 
+    if (trimmed === "/archive-chat" || trimmed === "/archive" || trimmed === "/ archive-chat" || trimmed === "/ archive") {
+      setInput("");
+      handleArchiveChat();
+      return;
+    }
+
     setInput("");
     addMessage(threadId, "user", content);
 
@@ -235,7 +349,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
       },
       systemPrompt,
     });
-  }, [input, threadId, addMessage, sendStream, activeProjectId, activeWorkspaceId, messages, aiConfig, activeView, graphData, selectedNode]);
+  }, [input, threadId, addMessage, sendStream, activeProjectId, activeWorkspaceId, messages, aiConfig, activeView, graphData, selectedNode, handleArchiveChat]);
 
   const handleRetry = useCallback((content: string) => {
     handleSend(content);

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -9,13 +9,14 @@ import { useShallow } from "zustand/react/shallow";
 import { useChatStream } from "@/hooks/useChatStream";
 import { buildGraphContext } from "@/components/graph/graph-ai-utils";
 import { ipcAwaitResult } from "@/store/ipc";
+import { resolvePromptContext } from "@/lib/context-resolver";
 
 import { Tooltip } from "@/components/ui/tooltip";
 import { ChatMessageBubble } from "./chat-panel/ChatMessageBubble";
 import { SuggestedPrompts } from "./chat-panel/SuggestedPrompts";
 import { ToolCallIndicator } from "./chat-panel/ToolCallIndicator";
 import { QuestionForm } from "./chat-panel/QuestionForm";
-import { ChatInput } from "./ChatInput";
+import { ChatInput, SuggestionItem } from "./ChatInput";
 import { ContextRing } from "@/components/agent/ContextRing";
 
 const GRAPH_SYSTEM_PROMPT = `You are a Knowledge Graph assistant embedded in Cairn, a note-taking and project management app.
@@ -89,6 +90,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     activeView, graphData, selectedGraphNodeId,
     clearThreadMessages,
     createNote,
+    notes, cards,
   } = useCairnStore(useShallow((s) => ({
     chatOpen:            s.chatOpen,
     toggleChat:          s.toggleChat,
@@ -110,6 +112,8 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     selectedGraphNodeId: s.selectedGraphNodeId,
     clearThreadMessages: s.clearThreadMessages,
     createNote:          s.createNote,
+    notes:               s.notes,
+    cards:               s.cards,
   })));
 
   const [input, setInput]             = useState("");
@@ -163,6 +167,20 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     () => chatThreads.find((t) => t.id === threadId),
     [chatThreads, threadId]
   );
+
+  const mentionSuggestions = useMemo<SuggestionItem[]>(() => {
+    const projectNotes = notes.filter((n) => n.workspaceId === activeWorkspaceId && (!activeProjectId || n.projectId === activeProjectId) && !n.archivedAt);
+    const projectCards = cards.filter((c) => c.workspaceId === activeWorkspaceId && (!activeProjectId || c.projectId === activeProjectId) && !c.archivedAt);
+    
+    const items: SuggestionItem[] = [];
+    for (const note of projectNotes) {
+      items.push({ id: note.id, type: "note", title: note.title, subtitle: "Note" });
+    }
+    for (const card of projectCards) {
+      items.push({ id: card.id, type: "card", title: card.title, subtitle: `Task - ${card.priority}` });
+    }
+    return items;
+  }, [notes, cards, activeWorkspaceId, activeProjectId]);
 
   const handleClear = useCallback(() => {
     if (!threadId) return;
@@ -305,7 +323,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
   useEffect(() => { messagesEndRef.current?.scrollIntoView({ behavior: "smooth" }); }, [messages, isLoading]);
   useEffect(() => { if (chatOpen) inputRef.current?.focus(); }, [chatOpen]);
 
-  const handleSend = useCallback((text?: string) => {
+  const handleSend = useCallback(async (text?: string) => {
     const content = text ?? input.trim();
     if (!content || !threadId) return;
 
@@ -325,6 +343,16 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     setInput("");
     addMessage(threadId, "user", content);
 
+    // Resolve context references and append to prompt payload
+    const store = useCairnStore.getState();
+    const resolvedMessage = await resolvePromptContext(
+      content,
+      store.notes,
+      store.cards,
+      store.columns,
+      project?.codeDirectory ?? null
+    );
+
     let systemPrompt: string | undefined = undefined;
     if (activeView === "graph") {
       const graphContext = buildGraphContext(graphData, selectedNode);
@@ -335,7 +363,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     }
 
     sendStream({
-      message: content, threadId,
+      message: resolvedMessage, threadId,
       projectId: activeProjectId,
       workspaceId: activeWorkspaceId,
       history: messages.slice(-40).map((m) => ({ role: m.role, content: m.content })),
@@ -349,7 +377,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
       },
       systemPrompt,
     });
-  }, [input, threadId, addMessage, sendStream, activeProjectId, activeWorkspaceId, messages, aiConfig, activeView, graphData, selectedNode, handleArchiveChat]);
+  }, [input, threadId, addMessage, sendStream, activeProjectId, activeWorkspaceId, messages, aiConfig, activeView, graphData, selectedNode, handleArchiveChat, project]);
 
   const handleRetry = useCallback((content: string) => {
     handleSend(content);
@@ -607,6 +635,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
           disabled={isLoading}
           placeholder={activeView === "graph" ? "Ask about your knowledge graph…" : "Ask about your project…"}
           commands={CHAT_SLASH_COMMANDS}
+          suggestions={mentionSuggestions}
         />
         <div className="flex items-center justify-between mt-1.5 px-0.5">
           <p className="text-[0.714rem] text-[var(--text-tertiary)]">

--- a/src/components/chat/chat-panel/ChatMessageBubble.tsx
+++ b/src/components/chat/chat-panel/ChatMessageBubble.tsx
@@ -134,7 +134,7 @@ export const ChatMessageBubble = React.memo(function ChatMessageBubble({ message
         )}
         <div className={cn("px-3 py-2.5 rounded-xl text-xs leading-relaxed max-w-full",
           isUser ? "bg-[var(--accent)] text-white rounded-tr-sm" : "bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-secondary)] rounded-tl-sm")}>
-          <MarkdownContent content={message.content} />
+          <MarkdownContent content={message.content} isUser={isUser} />
         </div>
         {!isUser && message.actions && message.actions.length > 0 && (
           <ActionsList actions={message.actions} />

--- a/src/components/chat/chat-panel/MarkdownContent.tsx
+++ b/src/components/chat/chat-panel/MarkdownContent.tsx
@@ -1,17 +1,103 @@
 "use client";
 
-import React from "react";
-import ReactMarkdown from "react-markdown";
+import React, { useMemo } from "react";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
 import { MermaidDiagram } from "@/components/notes/MermaidDiagram";
 import { CodeBlock } from "@/components/notes/CodeBlock";
+import { useCairnStore } from "@/store";
+import { useShallow } from "zustand/react/shallow";
+import { CairnEvents } from "@/lib/events";
+import { parseWikilinks } from "@/lib/wikilink-parser";
+import type { Note, TaskCard } from "@/types";
+
+/**
+ * Pre-processes markdown text, replacing [[Note Title]] and file backticks with custom URI markdown links.
+ */
+function preprocessMarkdown(
+  content: string,
+  notes: Note[],
+  cards: TaskCard[],
+  cwd: string | null
+): string {
+  let processed = content;
+
+  // 1. Replace wikilinks [[Title]]
+  const wikilinks = parseWikilinks(content);
+  const sortedWikilinks = [...wikilinks].sort((a, b) => b.index - a.index);
+
+  for (const wl of sortedWikilinks) {
+    const title = wl.title;
+    const note = notes.find((n) => n.title.toLowerCase() === title.toLowerCase() && !n.archivedAt);
+    if (note) {
+      const link = `[${note.title}](cairn://note/${note.id})`;
+      processed = processed.slice(0, wl.index) + link + processed.slice(wl.end);
+      continue;
+    }
+    const card = cards.find((c) => c.title.toLowerCase() === title.toLowerCase() && !c.archivedAt);
+    if (card) {
+      const link = `[${card.title}](cairn://task/${card.id})`;
+      processed = processed.slice(0, wl.index) + link + processed.slice(wl.end);
+    }
+  }
+
+  // 2. Replace backticked file paths
+  if (!cwd) return processed;
+
+  const backtickRegex = /`([^`\n]+?)`/g;
+  const backtickMatches: { text: string; index: number; end: number }[] = [];
+  let match;
+  while ((match = backtickRegex.exec(content)) !== null) {
+    const text = match[1].trim();
+    if (text) {
+      const isFilePath = /\.[a-zA-Z0-9]{1,10}$/.test(text) || text.includes("/") || text.includes("\\");
+      if (isFilePath) {
+        backtickMatches.push({
+          text,
+          index: match.index,
+          end: match.index + match[0].length,
+        });
+      }
+    }
+  }
+
+  backtickMatches.sort((a, b) => b.index - a.index);
+  for (const bm of backtickMatches) {
+    const cleanCwd = cwd.endsWith("/") || cwd.endsWith("\\") ? cwd.slice(0, -1) : cwd;
+    const cleanPath = bm.text.startsWith("/") || bm.text.startsWith("\\") ? bm.text.slice(1) : bm.text;
+    const absolutePath = `${cleanCwd}/${cleanPath}`;
+    
+    const encodedPath = encodeURIComponent(absolutePath);
+    const link = `[\`${bm.text}\`](cairn://file/${encodedPath})`;
+    processed = processed.slice(0, bm.index) + link + processed.slice(bm.end);
+  }
+
+  return processed;
+}
 
 /** Markdown renderer for assistant chat messages */
-export function MarkdownContent({ content }: { content: string }) {
+export function MarkdownContent({ content, isUser }: { content: string; isUser?: boolean }) {
+  const { notes, cards, projects, activeProjectId, setView, openEditorFile } = useCairnStore(useShallow((s) => ({
+    notes: s.notes,
+    cards: s.cards,
+    projects: s.projects,
+    activeProjectId: s.activeProjectId,
+    setView: s.setView,
+    openEditorFile: s.openEditorFile,
+  })));
+
+  const activeProject = useMemo(() => projects.find((p) => p.id === activeProjectId), [projects, activeProjectId]);
+  const cwd = activeProject?.codeDirectory ?? null;
+
+  const preprocessed = useMemo(() => {
+    return preprocessMarkdown(content, notes, cards, cwd);
+  }, [content, notes, cards, cwd]);
+
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkBreaks]}
+      urlTransform={(url) => url.startsWith("cairn://") ? url : defaultUrlTransform(url)}
       components={{
         p: ({ children }) => <p className="mb-1.5 last:mb-0 leading-relaxed break-words">{children}</p>,
         strong: ({ children }) => <strong className="font-semibold text-[var(--text-primary)]">{children}</strong>,
@@ -45,11 +131,66 @@ export function MarkdownContent({ content }: { content: string }) {
             {children}
           </blockquote>
         ),
-        a: ({ href, children }) => (
-          <a href={href} className="text-[var(--accent)] hover:underline" target="_blank" rel="noreferrer">
-            {children}
-          </a>
-        ),
+        a: ({ href, children }) => {
+          const linkClass = isUser
+            ? "inline-flex items-center text-white hover:text-white/80 underline font-medium cursor-pointer"
+            : "inline-flex items-center text-[var(--accent)] hover:underline font-medium cursor-pointer";
+          const fallbackClass = isUser
+            ? "text-white hover:text-white/80 underline"
+            : "text-[var(--accent)] hover:underline";
+
+          if (href?.startsWith("cairn://note/")) {
+            const noteId = href.replace("cairn://note/", "");
+            return (
+              <button
+                type="button"
+                onClick={() => {
+                  setView("notes");
+                  setTimeout(() => window.dispatchEvent(CairnEvents.selectNote(noteId)), 50);
+                }}
+                className={linkClass}
+              >
+                {children}
+              </button>
+            );
+          }
+          if (href?.startsWith("cairn://task/")) {
+            const cardId = href.replace("cairn://task/", "");
+            return (
+              <button
+                type="button"
+                onClick={() => {
+                  setView("board");
+                  setTimeout(() => window.dispatchEvent(CairnEvents.openCard(cardId)), 50);
+                }}
+                className={linkClass}
+              >
+                {children}
+              </button>
+            );
+          }
+          if (href?.startsWith("cairn://file/")) {
+            const encodedPath = href.replace("cairn://file/", "");
+            const absolutePath = decodeURIComponent(encodedPath);
+            return (
+              <button
+                type="button"
+                onClick={() => {
+                  setView("agent");
+                  openEditorFile(absolutePath);
+                }}
+                className={linkClass}
+              >
+                {children}
+              </button>
+            );
+          }
+          return (
+            <a href={href} className={fallbackClass} target="_blank" rel="noreferrer">
+              {children}
+            </a>
+          );
+        },
         hr: () => <hr className="my-2 border-[var(--border)]" />,
         table: ({ children }) => (
           <div className="my-2 overflow-x-auto">
@@ -71,7 +212,7 @@ export function MarkdownContent({ content }: { content: string }) {
         ),
       }}
     >
-      {content}
+      {preprocessed}
     </ReactMarkdown>
   );
 }

--- a/src/components/kanban/card-detail.tsx
+++ b/src/components/kanban/card-detail.tsx
@@ -33,6 +33,7 @@ import { DatePicker } from "@/components/ui/date-picker";
 import { cn, formatRelative, PRIORITY_COLORS } from "@/lib/utils";
 import type { Priority } from "@/types";
 import { SpawnAgentModal } from "@/components/agent/SpawnAgentModal";
+import { MarkdownContent } from "@/components/chat/chat-panel/MarkdownContent";
 
 interface CardDetailModalProps {
   cardId: string;
@@ -86,6 +87,7 @@ export function CardDetailModal({ cardId, onClose }: CardDetailModalProps) {
   const [moveToProjectOpen, setMoveToProjectOpen] = useState(false);
   const [blockerError, setBlockerError] = useState<string | null>(null);
   const [spawnAgentOpen, setSpawnAgentOpen] = useState(false);
+  const [isEditingDesc, setIsEditingDesc] = useState(false);
 
   const card = useMemo(() => cards.find((c) => c.id === cardId), [cards, cardId]);
   // Derive all dependent data via useMemo — must be called before any conditional return
@@ -161,14 +163,41 @@ export function CardDetailModal({ cardId, onClose }: CardDetailModalProps) {
               <label className="block text-xs font-medium text-[var(--text-tertiary)] mb-2 uppercase tracking-wide">
                 Description
               </label>
-              <textarea
-                defaultValue={card.description ?? ""}
-                onBlur={(e) => updateCard(cardId, { description: e.target.value })}
-                placeholder="Add a description…"
-                rows={4}
-                className="w-full bg-[var(--surface-2)] border border-[var(--border)] rounded-lg px-3 py-2.5 text-sm text-[var(--text-secondary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent-dim)] resize-none leading-relaxed"
-              />
+              {isEditingDesc ? (
+                <textarea
+                  autoFocus
+                  defaultValue={card.description ?? ""}
+                  onBlur={(e) => {
+                    updateCard(cardId, { description: e.target.value });
+                    setIsEditingDesc(false);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                      e.preventDefault();
+                      e.currentTarget.blur();
+                    }
+                  }}
+                  placeholder="Add a description…"
+                  rows={8}
+                  className="w-full bg-[var(--surface-2)] border border-[var(--border)] rounded-lg px-3 py-2.5 text-sm text-[var(--text-secondary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--accent-dim)] resize-none leading-relaxed min-h-[12rem]"
+                />
+              ) : (
+                <div
+                  onClick={(e) => {
+                    if ((e.target as HTMLElement).closest("a, button")) return;
+                    setIsEditingDesc(true);
+                  }}
+                  className="w-full bg-[var(--surface-2)] border border-[var(--border)] hover:border-[var(--accent)]/40 rounded-lg px-3 py-2.5 text-sm text-[var(--text-secondary)] min-h-[12rem] cursor-pointer transition-colors overflow-y-auto"
+                >
+                  {card.description?.trim() ? (
+                    <MarkdownContent content={card.description} />
+                  ) : (
+                    <span className="text-[var(--text-tertiary)] italic">Add a description…</span>
+                  )}
+                </div>
+              )}
             </div>
+
 
             {/* Tags */}
             <div>

--- a/src/components/layout/project-overview.tsx
+++ b/src/components/layout/project-overview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useMemo } from "react";
 import {
   FileText, Kanban, Calendar, Pin, ArrowRight, Clock,
   AlertCircle, Activity, Circle, BarChart2, Pencil, Check, FolderOpen, Terminal,
@@ -15,7 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { TaskCard, Note, BoardColumn } from "@/types";
 import { useProjectMetrics, type ActivityGroup } from "./project-overview/useProjectMetrics";
-import { ChatInput } from "@/components/chat/ChatInput";
+import { ChatInput, SuggestionItem } from "@/components/chat/ChatInput";
 
 export function ProjectOverview() {
   const { activeProjectId, projects, setView, updateProject, chatOpen } = useCairnStore(useShallow((s) => ({
@@ -30,6 +30,18 @@ export function ProjectOverview() {
 
   const [chatInput, setChatInput] = useState("");
   const chatInputRef = useRef<HTMLTextAreaElement>(null);
+
+  const mentionSuggestions = useMemo<SuggestionItem[]>(() => {
+    if (!metrics) return [];
+    const items: SuggestionItem[] = [];
+    for (const note of metrics.notes) {
+      items.push({ id: note.id, type: "note", title: note.title, subtitle: "Note" });
+    }
+    for (const card of metrics.allCards) {
+      items.push({ id: card.id, type: "card", title: card.title, subtitle: `Task - ${card.priority}` });
+    }
+    return items;
+  }, [metrics]);
 
   function handleSendChat() {
     const text = chatInput.trim();
@@ -339,6 +351,7 @@ export function ProjectOverview() {
               placeholder="What would you like to do today?"
               variant="overview"
               showSparkles
+              suggestions={mentionSuggestions}
             />
           </div>
         </div>

--- a/src/lib/context-resolver.ts
+++ b/src/lib/context-resolver.ts
@@ -1,0 +1,100 @@
+import { parseWikilinks } from "./wikilink-parser";
+import type { Note, TaskCard, BoardColumn } from "@/types";
+
+/**
+ * Parses raw prompt text for wikilinks [[Title]] and backticked paths `path`.
+ * Resolves notes and task cards from memory (Zustand store), and files
+ * asynchronously via Electron PTY fs APIs.
+ *
+ * Appends all resolved entities to the end of the prompt under a structured
+ * === Attached Context === section.
+ */
+export async function resolvePromptContext(
+  prompt: string,
+  notes: Note[],
+  cards: TaskCard[],
+  columns: BoardColumn[],
+  cwd: string | null
+): Promise<string> {
+  const wikilinks = parseWikilinks(prompt);
+
+  // Extract backticked paths
+  const backtickRegex = /`([^`\n]+?)`/g;
+  const backtickMatches: string[] = [];
+  let match;
+  while ((match = backtickRegex.exec(prompt)) !== null) {
+    const term = match[1].trim();
+    if (term) backtickMatches.push(term);
+  }
+
+  const uniqueWikilinks = Array.from(new Set(wikilinks.map((wl) => wl.title)));
+  const uniqueBackticks = Array.from(new Set(backtickMatches));
+
+  const attachedContext: string[] = [];
+
+  // Resolve wikilinks
+  for (const title of uniqueWikilinks) {
+    // 1. Check notes
+    const note = notes.find(
+      (n) => n.title.toLowerCase() === title.toLowerCase() && !n.archivedAt
+    );
+    if (note) {
+      attachedContext.push(`[[${note.title}]]:
+---
+ID: ${note.id}
+Type: ${note.type}
+Folder: ${note.folder || "(root)"}
+Content:
+${note.content || "(empty)"}`);
+      continue;
+    }
+
+    // 2. Check cards
+    const card = cards.find(
+      (c) => c.title.toLowerCase() === title.toLowerCase() && !c.archivedAt
+    );
+    if (card) {
+      const col = columns.find((col) => col.id === card.columnId);
+      attachedContext.push(`[[${card.title}]]:
+---
+ID: ${card.id}
+Status: ${col?.name || "Unknown"}
+Priority: ${card.priority}
+Assignee: ${card.assignee || "none"}
+Due Date: ${card.dueDate || "none"}
+Description:
+${card.description || "(no description)"}`);
+    }
+  }
+
+  // Resolve backticks (files)
+  if (typeof window !== "undefined" && window.electron && cwd) {
+    for (const fileMatch of uniqueBackticks) {
+      // Basic heuristic: check if it looks like a file path (has extension or slash)
+      const hasExtension = /\.[a-zA-Z0-9]{1,10}$/.test(fileMatch);
+      const hasSlash = fileMatch.includes("/") || fileMatch.includes("\\");
+      if (hasExtension || hasSlash) {
+        try {
+          // Normalize paths
+          const cleanCwd = cwd.endsWith("/") || cwd.endsWith("\\") ? cwd.slice(0, -1) : cwd;
+          const cleanPath = fileMatch.startsWith("/") || fileMatch.startsWith("\\") ? fileMatch.slice(1) : fileMatch;
+          const absolutePath = `${cleanCwd}/${cleanPath}`;
+
+          const content = await window.electron.agent.readFile(absolutePath);
+          attachedContext.push(`\`${fileMatch}\`:
+---
+${content}`);
+        } catch (err) {
+          // Ignore if file read fails (e.g. not a file, outside directory, or error)
+          console.warn(`[context-resolver] Failed to read mentioned file: ${fileMatch}`, err);
+        }
+      }
+    }
+  }
+
+  if (attachedContext.length > 0) {
+    return `${prompt}\n\n=== Attached Context ===\n${attachedContext.join("\n\n")}`;
+  }
+
+  return prompt;
+}

--- a/src/store/slices/notes.ts
+++ b/src/store/slices/notes.ts
@@ -23,7 +23,7 @@ import {
 export interface NotesSlice {
   notes: Note[];
 
-  createNote: (projectId: ID, title: string, type?: NoteType, folder?: string) => Note;
+  createNote: (projectId: ID, title: string, type?: NoteType, folder?: string, content?: string) => Note;
   updateNote: (id: ID, patch: Partial<Note>) => void;
   deleteNote: (id: ID) => void;
   archiveNote: (id: ID) => void;
@@ -46,15 +46,15 @@ export const createNotesSlice: StateCreator<CairnStore, [], [], NotesSlice> = (
 ) => ({
   notes: [],
 
-  createNote(projectId, title, type = "note", folder = "") {
+  createNote(projectId, title, type = "note", folder = "", content = "") {
     const proj = get().projects.find((p) => p.id === projectId);
     const note: Note = {
       id: id(),
       projectId,
       workspaceId: proj?.workspaceId ?? "",
       title,
-      content: "",
-      contentText: "",
+      content,
+      contentText: content,
       tagIds: [],
       linkedNoteIds: [],
       linkedCardIds: [],


### PR DESCRIPTION
## What does this PR do?

This PR introduces several key features and improvements across the autocomplete, AI message rendering, task description editor, and Electron IPC layers of Cairn:

1. **Autocomplete & Context Forwarding**:
   * Implemented `@` mention autocomplete support in the chat panel, the overview chat box, and agent pane inputs to search and link notes, task cards, and project files.
   * Autocomplete uses static project notes and cards lists and searches workspace file trees asynchronously with a 150ms debounce.
   * Standardized context forwarding: referencing a card, note, or file via autocomplete resolves and attaches its content to the AI prompt payload under a formatted context block.
2. **Interactive Inline Reference Links**:
   * Upgraded markdown parsing to preprocess `[[Title]]` and file paths into custom scheme links (`cairn://note/...`, `cairn://task/...`, and `cairn://file/...`).
   * Configured custom `urlTransform` to white-list the `cairn://` protocol inside `ReactMarkdown` to prevent external browser windows from launching.
   * Intercepted links to navigate directly within the app (switching views to notes, Kanban board, or file editors).
   * Styled links inside user chat bubbles with high contrast (`text-white hover:text-white/80 underline`) to ensure readability on the accent background.
3. **Kanban Card Details Markdown**:
   * Card descriptions are now rendered as rich, interactive markdown views using `<MarkdownContent>` inside the card detail modal.
   * Clicking the preview toggles it to a textarea for inline editing, which can be committed/saved by clicking outside or pressing `Cmd+Enter` / `Ctrl+Enter`.
4. **Chat Archival (`/archive-chat`) & Automatic Compactions**:
   * Implemented the `/archive-chat` (and `/archive`) command in the chat panel to summarize thread histories using AI compaction, save the transcript to a project note (`conversations/`), and clear the chat.
   * Initialized `createNote` with custom markdown content.
   * Appended `auto: true` to background session compaction messages, allowing the UI to display a centered `----- Session Compacted -----` system message separator.
5. **Database schema support**:
   * Added the `"system"` message type to SQLite schema types and functions (`upsertPiMessage`, `savePiMessages`) to support clean type checks.
6. **Documentation / Changelog**:
   * Updated [changelogs/v1.7.6.md](file:///Users/gerard/Documents/GitHub/cairn/changelogs/v1.7.6.md) with details of all new autocomplete features, context forwarding, inline links, and fixes.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [x] Docs / changelog
- [ ] Tests

## Screenshots / recording

Refer to the detailed implementation walkthrough and diagrams in `walkthrough.md` for UI and flow reference.

## Checklist

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts`
- [ ] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

* **External Link Bug Fix**: ReactMarkdown’s default URL sanitizer strips out non-standard protocols like `cairn://` unless specifically white-listed, which caused reference links to fallback to default `<a>` elements with `target="_blank"` (thus launching external browser windows). We resolved this by adding `urlTransform` to white-list the `cairn://` protocol.
* **User Bubble Readability**: Links are dynamically styled with `text-white hover:text-white/80 underline` when inside user chat bubbles (triggered via the `isUser` prop) to ensure they are legible on the accent-colored background.
* **Compaction separation**: Passing the `auto` boolean lets the frontend show system indicators in the Pi terminal session history instead of printing a separate message text block from the bot.
