### PR TITLE
v2.0.2 - Standardizes primary workspace headers, extract agent

### DIFF
--- a/changelogs/v2.0.3.md
+++ b/changelogs/v2.0.3.md
@@ -23,7 +23,7 @@
 | File | Change |
 |------|--------|
 | `src/components/layout/RightPanel.tsx` | [NEW] Resizable right drawer layout wrapper component |
-| `src/app/page.tsx` | Integrated `RightPanel` and added agent tab auto-activation logic |
+| `src/app/page.tsx` | Integrated `RightPanel`, added agent tab auto-activation logic, and enabled right panel toggling/closing inside the Agent view |
 | `src/components/agent/AgentTerminalPane.tsx` | Integrated completions chat tab, unified tab layout, added close button |
 | `src/components/chat/chat-panel.tsx` | Removed drawer wrappers and adjusted header to h-9 toolbar |
 | `src/components/agent/PiAgentPane.tsx` | Aligned header to h-9 secondary toolbar |

--- a/changelogs/v2.0.3.md
+++ b/changelogs/v2.0.3.md
@@ -3,6 +3,7 @@
 ### Features
 
 - **Unified Chat and Agent Terminal Panel**: Standardized the completions Chat panel and pi-agent terminal sessions into a unified, resizable tab drawer (`RightPanel.tsx`) on the right side of the screen. Users can now seamlessly toggle between AI completions chat, Cairn Agent, and active shell/terminal sessions while navigating any workspace in the application.
+- **Agent View Panel Reopening**: Re-enabled the AI Chat topbar toggle button and the standard `⌘/` keyboard shortcut when inside the Agent view, so users can freely collapse and reopen the unified right panel drawer.
 
 ### Changes
 

--- a/changelogs/v2.0.3.md
+++ b/changelogs/v2.0.3.md
@@ -1,0 +1,38 @@
+## What's new
+
+### Features
+
+- **Unified Chat and Agent Terminal Panel**: Standardized the completions Chat panel and pi-agent terminal sessions into a unified, resizable tab drawer (`RightPanel.tsx`) on the right side of the screen. Users can now seamlessly toggle between AI completions chat, Cairn Agent, and active shell/terminal sessions while navigating any workspace in the application.
+
+### Changes
+
+- **Header Height Standardization (Row 1)**: Unified all top-level workspace headers (the Sidebar's `WorkspaceSwitcher`, `Topbar`, the Agent workspace's `FileTree` and `Editor/Diff` selectors, and the right panel's tab bar) to a clean, consistent `h-11` (44px) height.
+- **Secondary Toolbar Alignment (Row 2)**: Aligned all secondary toolbars and control sub-headers across the application to a unified `h-9` (36px) height on desktop, ensuring clean layout symmetry and an unbroken horizontal border rule. This includes:
+  - Sidebar quick action search bar.
+  - Notes list sidebar header.
+  - Note Editor control header (`md:h-9 md:py-0`).
+  - Dashboard Note view header (`md:h-9 md:py-0`).
+  - Kanban Board `Board / Archive` toggle toolbar.
+  - Working Tree Git Diff viewer toolbar.
+  - Agent Editor open files tab strip.
+
+---
+
+## Changed files
+
+| File | Change |
+|------|--------|
+| `src/components/layout/RightPanel.tsx` | [NEW] Resizable right drawer layout wrapper component |
+| `src/app/page.tsx` | Integrated `RightPanel` and added agent tab auto-activation logic |
+| `src/components/agent/AgentTerminalPane.tsx` | Integrated completions chat tab, unified tab layout, added close button |
+| `src/components/chat/chat-panel.tsx` | Removed drawer wrappers and adjusted header to h-9 toolbar |
+| `src/components/agent/PiAgentPane.tsx` | Aligned header to h-9 secondary toolbar |
+| `src/components/agent/FileTree.tsx` | Aligned header to h-9 height and bg-surface-2 background |
+| `src/components/agent/AgentView.tsx` | Simplified desktop layout and aligned editor/diff selector to h-9 bg-surface-2 |
+| `src/components/agent/AgentEditor.tsx` | Aligned open files tab strip to h-9 height |
+| `src/components/agent/DiffViewer.tsx` | Aligned diff toolbar to h-9 |
+| `src/components/kanban/board.tsx` | Aligned Board/Archive toggle bar to h-9 |
+| `src/components/notes/notes-view.tsx` | Aligned Notes sidebar header to h-9 |
+| `src/components/notes/note-editor.tsx` | Aligned note editor header to h-9 |
+| `src/components/notes/dashboard-view.tsx` | Aligned dashboard header to h-9 |
+| `src/components/layout/sidebar.tsx` | Aligned quick action search bar container to h-9 |

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,7 +48,7 @@ import { KanbanBoard } from "@/components/kanban/board";
 import { IdeaFlowView } from "@/components/flow/flow-view";
 import { KnowledgeGraphView } from "@/components/graph/KnowledgeGraphView";
 import { InsightsView } from "@/components/insights/InsightsView";
-import { ChatPanel } from "@/components/chat/chat-panel";
+import { RightPanel } from "@/components/layout/RightPanel";
 import { SearchPanel } from "@/components/search/search-panel";
 import { SettingsView } from "@/components/settings/settings-view";
 import { AgentView } from "@/components/agent/AgentView";
@@ -268,6 +268,18 @@ export default function Home() {
     };
   }, [toggleSearch, toggleChat, toggleSidebar, setView, activeProjectId, createNote, chatOpen, hiddenViews, ORDERED_VIEWS, activeView]);
 
+  // Auto-activate Cairn Agent tab if we switch to Agent view and the current tab is completions chat
+  useEffect(() => {
+    if (activeView === "agent") {
+      const state = useCairnStore.getState();
+      if (state.activeSessionId === null || state.activeSessionId === "chat") {
+        if (state.persistentPiSessionId) {
+          state.setActiveSession(state.persistentPiSessionId);
+        }
+      }
+    }
+  }, [activeView]);
+
   // Still loading
   if (onboardingState === null) {
     return (
@@ -357,8 +369,8 @@ export default function Home() {
           </div>
         </div>
 
-        {/* AI Chat panel */}
-        {chatOpen && activeView !== "agent" && <ChatPanel prefill={chatPrefill} onPrefillConsumed={() => setChatPrefill(null)} />}
+        {/* Right panel drawer (hosts both completions Chat and Agent sessions) */}
+        {(chatOpen || activeView === "agent") && <RightPanel prefill={chatPrefill} onPrefillConsumed={() => setChatPrefill(null)} />}
 
         {/* Global search overlay */}
         {searchOpen && <SearchPanel />}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -268,10 +268,13 @@ export default function Home() {
     };
   }, [toggleSearch, toggleChat, toggleSidebar, setView, activeProjectId, createNote, chatOpen, hiddenViews, ORDERED_VIEWS, activeView]);
 
-  // Auto-activate Cairn Agent tab if we switch to Agent view and the current tab is completions chat
+  // Auto-activate Cairn Agent tab and auto-open right panel drawer if we switch to Agent view
   useEffect(() => {
     if (activeView === "agent") {
       const state = useCairnStore.getState();
+      if (!state.chatOpen) {
+        state.toggleChat();
+      }
       if (state.activeSessionId === null || state.activeSessionId === "chat") {
         if (state.persistentPiSessionId) {
           state.setActiveSession(state.persistentPiSessionId);
@@ -370,7 +373,7 @@ export default function Home() {
         </div>
 
         {/* Right panel drawer (hosts both completions Chat and Agent sessions) */}
-        {(chatOpen || activeView === "agent") && <RightPanel prefill={chatPrefill} onPrefillConsumed={() => setChatPrefill(null)} />}
+        {chatOpen && <RightPanel prefill={chatPrefill} onPrefillConsumed={() => setChatPrefill(null)} />}
 
         {/* Global search overlay */}
         {searchOpen && <SearchPanel />}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -217,10 +217,8 @@ export default function Home() {
       if (mod && key === "k") { e.preventDefault(); toggleSearch(); }
       else if (mod && e.shiftKey && key.toLowerCase() === "f") { if (activeView !== "agent") { e.preventDefault(); toggleSearch(); } }
       else if (mod && key === "/") {
-        if (activeView !== "agent") {
-          e.preventDefault();
-          if (!hiddenViews.has("chat")) toggleChat();
-        }
+        e.preventDefault();
+        if (!hiddenViews.has("chat")) toggleChat();
       }
       else if (mod && key === "\\") { e.preventDefault(); toggleSidebar(); }
       else if (mod && key === "1") { e.preventDefault(); setView("overview"); }

--- a/src/components/agent/AgentEditor.tsx
+++ b/src/components/agent/AgentEditor.tsx
@@ -101,7 +101,7 @@ export function AgentEditor() {
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
 
       {/* Tab strip */}
-      <div className="flex items-stretch gap-0 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0 overflow-x-auto overflow-y-hidden">
+      <div className="flex items-stretch gap-0 h-9 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0 overflow-x-auto overflow-y-hidden">
         {openEditorFiles.map((filePath) => {
           const name = filePath.split("/").pop() ?? filePath;
           const isActive = filePath === activeFile;

--- a/src/components/agent/AgentTerminalPane.tsx
+++ b/src/components/agent/AgentTerminalPane.tsx
@@ -16,7 +16,7 @@ import "@xterm/xterm/css/xterm.css";
 
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { X, MessageSquare, CircleDot, Plus, ChevronDown, Trash2, Bot, History, ArrowRight } from "lucide-react";
+import { X, MessageSquare, CircleDot, Plus, ChevronDown, Trash2, Bot, History, ArrowRight, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { id } from "@/lib/utils";
 import { useCairnStore } from "@/store";
@@ -24,6 +24,7 @@ import { Tooltip } from "@/components/ui/tooltip";
 import { SpawnAgentModal } from "./SpawnAgentModal";
 import { TerminalManager } from "./TerminalManager";
 import { PiAgentPane } from "./PiAgentPane";
+import { ChatPanel } from "@/components/chat/chat-panel";
 import type { TerminalSession, PiSessionSummary } from "@/store/slices/terminal-sessions";
 
 // ── Single terminal session mount ─────────────────────────────────────────────
@@ -418,20 +419,20 @@ function PiAgentTab({ isActive, onActivate }: PiAgentTabProps) {
   }
 
   return (
-    <div className="relative flex-shrink-0" ref={dropdownRef}>
+    <div className="relative flex-shrink-0 h-full" ref={dropdownRef}>
       {/* The pinned tab button */}
       <button
         onClick={onActivate}
         role="tab"
         aria-selected={isActive}
         className={cn(
-          "flex items-center gap-1.5 px-3 py-2 text-[0.714rem] whitespace-nowrap border-r border-[var(--border)] transition-colors flex-shrink-0",
+          "flex items-center gap-1.5 px-3 h-full text-xs font-semibold whitespace-nowrap border-r border-[var(--border)] transition-colors flex-shrink-0",
           isActive
             ? "text-[var(--text-primary)] bg-[var(--background)]"
             : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
         )}
       >
-        <MessageSquare size={8} className={cn("flex-shrink-0", isActive ? "text-[var(--accent)]" : "text-[var(--text-tertiary)]")} />
+        <MessageSquare size={11} className={cn("flex-shrink-0", isActive ? "text-[var(--accent)]" : "text-[var(--text-tertiary)]")} />
         <span className="max-w-[100px] truncate">Cairn Agent</span>
         {/* History dropdown chevron */}
         <span
@@ -510,9 +511,13 @@ function PiAgentTab({ isActive, onActivate }: PiAgentTabProps) {
   );
 }
 
-// ── AgentTerminalPane ─────────────────────────────────────────────────────────
+interface AgentTerminalPaneProps {
+  isRightPanel?: boolean;
+  chatPrefill?: { text: string; autoSend?: boolean } | null;
+  onPrefillConsumed?: () => void;
+}
 
-export function AgentTerminalPane() {
+export function AgentTerminalPane({ isRightPanel = false, chatPrefill = null, onPrefillConsumed }: AgentTerminalPaneProps = {}) {
   const {
     terminalSessions,
     activeSessionId,
@@ -521,6 +526,7 @@ export function AgentTerminalPane() {
     persistentPiSessionId,
     activeProjectId,
     fetchPiSessionHistory,
+    toggleChat,
   } = useCairnStore(useShallow((s) => ({
     terminalSessions:       s.terminalSessions,
     activeSessionId:        s.activeSessionId,
@@ -529,6 +535,7 @@ export function AgentTerminalPane() {
     persistentPiSessionId:  s.persistentPiSessionId,
     activeProjectId:        s.activeProjectId,
     fetchPiSessionHistory:  s.fetchPiSessionHistory,
+    toggleChat:             s.toggleChat,
   })));
 
   const [spawnOpen, setSpawnOpen] = useState(false);
@@ -551,6 +558,13 @@ export function AgentTerminalPane() {
   // PTY-only sessions (shown as closeable tabs after the pinned tab)
   const ptySessions = terminalSessions.filter((t) => t.sessionType === "pty");
 
+  // Default to "chat" if activeSessionId is null on mount
+  useEffect(() => {
+    if (activeSessionId === null) {
+      setActiveSession("chat");
+    }
+  }, [activeSessionId, setActiveSession]);
+
   // Determine if the pinned tab is active
   const pinnedIsActive = persistentPiSessionId !== null && activeSessionId === persistentPiSessionId;
 
@@ -558,7 +572,21 @@ export function AgentTerminalPane() {
     <>
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
       {/* Tab bar */}
-      <div className="flex items-center border-b border-[var(--border)] overflow-visible relative z-20 flex-shrink-0 bg-[var(--surface)]">
+      <div className="flex items-center h-11 border-b border-[var(--border)] overflow-visible relative z-20 flex-shrink-0 bg-[var(--surface)]">
+        {/* AI Chat tab (always present) */}
+        <button
+          onClick={() => setActiveSession("chat")}
+          className={cn(
+            "flex items-center gap-1.5 px-3 h-full text-xs font-semibold whitespace-nowrap border-r border-[var(--border)] transition-colors flex-shrink-0",
+            activeSessionId === "chat"
+              ? "text-[var(--text-primary)] bg-[var(--background)]"
+              : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+          )}
+        >
+          <Sparkles size={11} className={cn("flex-shrink-0", activeSessionId === "chat" ? "text-[var(--accent)]" : "text-[var(--text-tertiary)]")} />
+          <span>AI Chat</span>
+        </button>
+
         {/* Always-present Cairn Agent pinned tab */}
         <PiAgentTab
           isActive={pinnedIsActive}
@@ -570,7 +598,7 @@ export function AgentTerminalPane() {
         />
 
         {/* Scrollable PTY sessions */}
-        <div className="flex-1 flex items-center overflow-x-auto min-w-0">
+        <div className="flex-1 flex items-center overflow-x-auto min-w-0 h-full">
           {ptySessions.map((session) => (
             <TerminalTab
               key={session.sessionId}
@@ -586,24 +614,43 @@ export function AgentTerminalPane() {
         <Tooltip content="New session" side="bottom">
           <button
             onClick={() => setSpawnOpen(true)}
-            className="flex-shrink-0 px-2 py-2 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors border-l border-[var(--border)]"
+            className="flex-shrink-0 px-3 h-full text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors border-l border-[var(--border)] flex items-center justify-center"
           >
             <Plus size={12} />
           </button>
         </Tooltip>
+
+        {/* Close panel button (visible only in right panel drawer) */}
+        {isRightPanel && (
+          <Tooltip content="Close panel (⌘/)" side="bottom">
+            <button
+              onClick={toggleChat}
+              className="flex-shrink-0 px-3 h-full text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors border-l border-[var(--border)] flex items-center justify-center"
+            >
+              <X size={12} />
+            </button>
+          </Tooltip>
+        )}
       </div>
 
       {/* Session content */}
       <div className="flex-1 min-h-0 flex flex-col overflow-hidden bg-[var(--background)]">
+        {/* AI Chat content */}
+        {activeSessionId === "chat" && (
+          <ChatPanel prefill={chatPrefill} onPrefillConsumed={onPrefillConsumed} />
+        )}
+
         {/* Pinned pi session content */}
-        {persistentSession ? (
-          <div className={cn("flex-1 min-h-0 overflow-hidden", !pinnedIsActive && "hidden")}>
-            <PiAgentPane session={persistentSession} isActive={pinnedIsActive} />
-          </div>
-        ) : (
-          <div className="flex-1 min-h-0 overflow-hidden">
-            <PiAgentEmptyState />
-          </div>
+        {pinnedIsActive && (
+          persistentSession ? (
+            <div className="flex-1 min-h-0 overflow-hidden">
+              <PiAgentPane session={persistentSession} isActive={pinnedIsActive} />
+            </div>
+          ) : (
+            <div className="flex-1 min-h-0 overflow-hidden">
+              <PiAgentEmptyState />
+            </div>
+          )
         )}
 
         {/* PTY sessions */}
@@ -643,7 +690,7 @@ function TerminalTab({ session, isActive, onActivate, onClose }: TerminalTabProp
       role="tab"
       aria-selected={isActive}
       className={cn(
-        "flex items-center gap-1.5 px-3 py-2 text-[0.714rem] whitespace-nowrap border-r border-[var(--border)] transition-colors flex-shrink-0 group",
+        "flex items-center gap-1.5 px-3 h-full text-xs font-semibold whitespace-nowrap border-r border-[var(--border)] transition-colors flex-shrink-0 group",
         isActive
           ? "text-[var(--text-primary)] bg-[var(--background)]"
           : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"

--- a/src/components/agent/AgentView.tsx
+++ b/src/components/agent/AgentView.tsx
@@ -41,23 +41,20 @@ export function AgentView() {
   // Bottom terminal height lives in React state so AgentBottomTerminal re-renders with the new height
   const [bottomHeight, setBottomHeight] = useState(DEFAULT_BOTTOM_HEIGHT);
 
-  // DOM refs for the two resizable panes — widths are mutated directly,
+  // DOM refs for the resizable tree pane — mutated directly,
   // never stored in React state, so no re-render occurs during drag.
   const treePaneRef      = useRef<HTMLDivElement>(null);
-  const terminalPaneRef  = useRef<HTMLDivElement>(null);
   const leftDividerRef   = useRef<HTMLDivElement>(null);
-  const rightDividerRef  = useRef<HTMLDivElement>(null);
   const bottomDividerRef = useRef<HTMLDivElement>(null);
 
   // Set initial widths once on mount via DOM (avoids a React render cycle)
   useEffect(() => {
-    if (treePaneRef.current)     treePaneRef.current.style.width     = `${DEFAULT_TREE_WIDTH}px`;
-    if (terminalPaneRef.current) terminalPaneRef.current.style.width = `${DEFAULT_TERMINAL_WIDTH}px`;
+    if (treePaneRef.current) treePaneRef.current.style.width = `${DEFAULT_TREE_WIDTH}px`;
   }, []);
 
   // ── Drag logic ─────────────────────────────────────────────────────────────
   useEffect(() => {
-    let dragging: "left" | "right" | "bottom" | null = null;
+    let dragging: "left" | "bottom" | null = null;
     let startX = 0;
     let startY = 0;
     let startWidth = 0;
@@ -69,12 +66,6 @@ export function AgentView() {
       if (dragging === "left" && treePaneRef.current) {
         const next = Math.max(MIN_TREE_WIDTH, startWidth + (e.clientX - startX));
         treePaneRef.current.style.width = `${next}px`;
-      }
-
-      if (dragging === "right" && terminalPaneRef.current) {
-        const next = Math.max(MIN_TERMINAL_WIDTH, startWidth - (e.clientX - startX));
-        terminalPaneRef.current.style.width = `${next}px`;
-        TerminalManager.fitAll();
       }
 
       if (dragging === "bottom") {
@@ -102,15 +93,6 @@ export function AgentView() {
       e.preventDefault();
     }
 
-    function startRightDrag(e: MouseEvent) {
-      dragging = "right";
-      startX = e.clientX;
-      startWidth = terminalPaneRef.current?.offsetWidth ?? DEFAULT_TERMINAL_WIDTH;
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-      e.preventDefault();
-    }
-
     function startBottomDrag(e: MouseEvent) {
       dragging = "bottom";
       startY = e.clientY;
@@ -124,18 +106,15 @@ export function AgentView() {
     }
 
     const leftDivider   = leftDividerRef.current;
-    const rightDivider  = rightDividerRef.current;
     const bottomDivider = bottomDividerRef.current;
 
     leftDivider?.addEventListener("mousedown",   startLeftDrag);
-    rightDivider?.addEventListener("mousedown",  startRightDrag);
     bottomDivider?.addEventListener("mousedown", startBottomDrag);
     window.addEventListener("mousemove", onMouseMove);
     window.addEventListener("mouseup",   onMouseUp);
 
     return () => {
       leftDivider?.removeEventListener("mousedown",   startLeftDrag);
-      rightDivider?.removeEventListener("mousedown",  startRightDrag);
       bottomDivider?.removeEventListener("mousedown", startBottomDrag);
       window.removeEventListener("mousemove", onMouseMove);
       window.removeEventListener("mouseup",   onMouseUp);
@@ -204,11 +183,11 @@ export function AgentView() {
           (mobileTab === "editor" || mobileTab === "diff") ? "flex h-full" : "hidden md:flex"
         )}>
           {/* Tab selector for editor / diff (only if not on mobile, since mobile has its own tabs) */}
-          <div className="hidden md:flex items-center gap-0.5 py-1 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0">
+          <div className="hidden md:flex items-center gap-1 px-3 h-9 border-b border-[var(--border)] bg-[var(--surface-2)] flex-shrink-0">
             <button
               onClick={() => setCentreTab("editor")}
               className={cn(
-                "px-2.5 py-0.5 rounded text-[0.714rem] transition-colors",
+                "px-2.5 py-1 rounded text-xs font-semibold transition-colors",
                 centreTab === "editor"
                   ? "text-[var(--text-primary)] bg-[var(--surface-2)]"
                   : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
@@ -220,7 +199,7 @@ export function AgentView() {
               <button
                 onClick={() => setCentreTab("diff")}
                 className={cn(
-                  "px-2.5 py-0.5 rounded text-[0.714rem] transition-colors",
+                  "px-2.5 py-1 rounded text-xs font-semibold transition-colors",
                   centreTab === "diff"
                     ? "text-[var(--text-primary)] bg-[var(--surface-2)]"
                     : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
@@ -244,22 +223,11 @@ export function AgentView() {
           )}
         </div>
 
-        {/* Right resize divider */}
+        {/* Right pane — agent terminal sessions (only on mobile, as desktop uses RightPanel drawer) */}
         <div
-          ref={rightDividerRef}
-          className="w-0 flex-shrink-0 cursor-col-resize relative z-10 hidden md:block"
-          style={{ marginLeft: "-3px", marginRight: "-3px", padding: "0 3px" }}
-          role="separator"
-          aria-label="Resize terminal pane"
-        />
-
-        {/* Right pane — agent terminal sessions */}
-        <div
-          ref={terminalPaneRef}
           className={cn(
-            "flex-shrink-0 flex flex-col border-l border-[var(--border)] overflow-hidden",
-            "w-full md:w-auto max-md:!w-full",
-            mobileTab === "agent" ? "flex flex-1" : "hidden md:flex"
+            "w-full flex-col flex-1 min-h-0 overflow-hidden md:hidden",
+            (mobileTab === "agent" || mobileTab === "terminal") ? "flex" : "hidden"
           )}
         >
           <AgentTerminalPane />

--- a/src/components/agent/AgentView.tsx
+++ b/src/components/agent/AgentView.tsx
@@ -21,9 +21,7 @@ import { TerminalManager } from "./TerminalManager";
 import { cn } from "@/lib/utils";
 
 const MIN_TREE_WIDTH = 160;
-const MIN_TERMINAL_WIDTH = 280;
 const DEFAULT_TREE_WIDTH = 220;
-const DEFAULT_TERMINAL_WIDTH = 380;
 
 const MIN_BOTTOM_HEIGHT = 80;
 const MAX_BOTTOM_HEIGHT = 600;

--- a/src/components/agent/DiffViewer.tsx
+++ b/src/components/agent/DiffViewer.tsx
@@ -103,7 +103,7 @@ export function DiffViewer({ cwd }: DiffViewerProps) {
 
   // ── Toolbar ────────────────────────────────────────────────────────────────
   const toolbar = (
-    <div className="flex items-center gap-2 px-3 py-1.5 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0">
+    <div className="flex items-center gap-2 px-3 h-9 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0">
       <FolderGit2 size={13} className="text-[var(--text-tertiary)] flex-shrink-0" />
       <span className="text-[0.714rem] text-[var(--text-tertiary)] flex-1 truncate" title={cwd}>
         {files.length > 0

--- a/src/components/agent/FileTree.tsx
+++ b/src/components/agent/FileTree.tsx
@@ -250,7 +250,7 @@ export function FileTree({ project }: FileTreeProps) {
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
       {/* Header */}
       {searchActive ? (
-        <div className="flex items-center gap-1.5 px-2 py-1.5 border-b border-[var(--border-subtle)] flex-shrink-0">
+        <div className="flex items-center gap-1.5 px-3 h-9 border-b border-[var(--border)] bg-[var(--surface-2)] flex-shrink-0">
           <Search size={11} className="text-[var(--text-tertiary)] flex-shrink-0" />
           <input
             ref={searchInputRef}
@@ -268,7 +268,7 @@ export function FileTree({ project }: FileTreeProps) {
           </button>
         </div>
       ) : (
-        <div className="flex items-center gap-1.5 px-3 py-2 border-b border-[var(--border-subtle)] flex-shrink-0">
+        <div className="flex items-center gap-1.5 px-3 h-9 border-b border-[var(--border)] bg-[var(--surface-2)] flex-shrink-0">
           <FolderOpen size={12} className="text-[var(--text-tertiary)]" />
           <span className="text-[0.714rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] truncate flex-1">
             {codeDirectory.split("/").pop() ?? "Files"}

--- a/src/components/agent/PiAgentPane.tsx
+++ b/src/components/agent/PiAgentPane.tsx
@@ -577,7 +577,7 @@ export function PiAgentPane({ session, isActive }: PiAgentPaneProps) {
     <div className="flex flex-col h-full bg-[var(--background)]">
 
       {/* Header */}
-      <div className="flex items-center gap-2 px-3 py-1.5 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0">
+      <div className="flex items-center gap-2 px-3 h-9 border-b border-[var(--border)] bg-[var(--surface-2)] flex-shrink-0">
         <span className="text-[0.714rem] text-[var(--text-tertiary)] truncate flex-1">
           {session.taskTitle !== "Ad-hoc session" ? session.taskTitle : project?.name ?? "Cairn Agent"}
         </span>

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -125,9 +125,6 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef       = useRef<HTMLTextAreaElement>(null);
 
-  const panelRef       = useRef<HTMLElement>(null);
-  const dividerRef     = useRef<HTMLDivElement>(null);
-
   const { isLoading, toolCalls, streamingContent, pendingQuestions, sendStream, stopStream } = useChatStream(threadId);
 
   const project   = useMemo(() => projects.find((p) => p.id === activeProjectId),   [projects, activeProjectId]);
@@ -409,86 +406,18 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     }
   }, [threadId, input, prefill, handleSend]);
 
-  // ── Drag-to-resize ──────────────────────────────────────────────────────────
-  // Mutates the panel DOM width directly on mousemove (no React state during
-  // drag) for zero-lag resizing, then commits to the store on mouseup.
-  useEffect(() => {
-    const divider = dividerRef.current;
-    const panel   = panelRef.current;
-    if (!divider || !panel) return;
-
-    let dragging = false;
-    let startX   = 0;
-    let startW   = 0;
-
-    function onMouseMove(e: MouseEvent) {
-      if (!dragging) return;
-      // Panel is on the right; dragging left (lower clientX) makes it wider.
-      const next = Math.min(MAX_CHAT_PANEL_WIDTH, Math.max(MIN_CHAT_PANEL_WIDTH, startW - (e.clientX - startX)));
-      panel!.style.width = `${next}px`;
-    }
-
-    function onMouseUp() {
-      if (!dragging) return;
-      dragging = false;
-      document.body.style.cursor     = "";
-      document.body.style.userSelect = "";
-      // Persist final width to store (and localStorage)
-      const finalWidth = panel!.offsetWidth;
-      setChatPanelWidth(finalWidth);
-    }
-
-    function onMouseDown(e: MouseEvent) {
-      dragging = true;
-      startX   = e.clientX;
-      startW   = panel!.offsetWidth;
-      document.body.style.cursor     = "col-resize";
-      document.body.style.userSelect = "none";
-      e.preventDefault();
-    }
-
-    divider.addEventListener("mousedown", onMouseDown);
-    window.addEventListener("mousemove", onMouseMove);
-    window.addEventListener("mouseup",   onMouseUp);
-
-    return () => {
-      divider.removeEventListener("mousedown", onMouseDown);
-      window.removeEventListener("mousemove", onMouseMove);
-      window.removeEventListener("mouseup",   onMouseUp);
-    };
-  // setChatPanelWidth is stable (Zustand action), so omitting from deps is safe.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const handleNewThread = useCallback(() => {
     if (!activeWorkspaceId) return;
     setThreadId(createNewThread(activeWorkspaceId, activeProjectId ?? undefined).id);
   }, [activeWorkspaceId, activeProjectId, createNewThread]);
 
-
-
-  if (!chatOpen) return null;
-
   return (
-    <aside
-      ref={panelRef}
-      className="fixed inset-0 z-50 md:relative md:inset-auto md:h-auto chat-panel-responsive flex flex-col border-l border-[var(--border)] bg-[var(--surface)] flex-shrink-0 animate-slide-in-right"
-      style={{ "--chat-panel-width": `${chatPanelWidth}px` } as React.CSSProperties}
-    >
-      {/* Drag-to-resize handle — sits on the left edge of the panel */}
-      <div
-        ref={dividerRef}
-        className="absolute left-0 top-0 h-full w-0 flex-shrink-0 cursor-col-resize z-10 select-none hidden md:block"
-        style={{ marginLeft: -3, padding: "0 3px" }}
-        aria-hidden
-      />
-      {/* Header */}
-      <div className="flex items-center gap-2 px-4 h-11 border-b border-[var(--border)] flex-shrink-0">
-        <Sparkles size={13} className="text-[var(--accent)]" />
-        <span className="text-sm font-semibold text-[var(--text-primary)] flex-1">
-          {activeView === "graph" ? "Graph Assistant" : "AI Assistant"}
+    <div className="flex flex-1 flex-col min-h-0 overflow-hidden bg-[var(--surface)]">
+      {/* Sub-header / toolbar */}
+      <div className="flex items-center gap-2 px-3 h-9 border-b border-[var(--border)] bg-[var(--surface-2)] flex-shrink-0">
+        <span className="text-[0.714rem] text-[var(--text-tertiary)] flex-1 truncate">
+          {activeView === "graph" ? "Graph Assistant" : project?.name ?? workspace?.name ?? "AI Assistant"}
         </span>
-        <span className="text-xs text-[var(--text-tertiary)] truncate max-w-24 mr-2">{project?.name ?? workspace?.name}</span>
 
         {activeThread?.lastUsage && (
           <ContextRing
@@ -503,8 +432,8 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
             <Tooltip content="Thread history" side="left">
               <button onClick={() => setHistoryOpen((o) => !o)}
                 className={cn("p-1 rounded transition-colors",
-                  historyOpen ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
-                <History size={13} />
+                  historyOpen ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-3)]")}>
+                <History size={11} />
               </button>
             </Tooltip>
             {historyOpen && (
@@ -554,41 +483,36 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
                               deleteThread(t.id);
                               if (isActive && activeWorkspaceId) {
                                 const next = createNewThread(activeWorkspaceId, activeProjectId ?? undefined);
-                                setThreadId(next.id);
-                                setHistoryOpen(false);
-                              }
-                            }}
-                            className="p-1.5 rounded text-[var(--text-tertiary)] hover:text-[var(--danger)] transition-colors"
-                            title="Delete thread">
-                            <X size={10} />
-                          </button>
+                                  setThreadId(next.id);
+                                  setHistoryOpen(false);
+                                }
+                              }}
+                              className="p-1.5 rounded text-[var(--text-tertiary)] hover:text-[var(--danger)] transition-colors"
+                              title="Delete thread">
+                              <X size={10} />
+                            </button>
+                          </div>
                         </div>
-                      </div>
-                    );
-                  })}
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
-            )}
-          </div>
-        )}
+              )}
+            </div>
+          )}
 
         {messages.length > 0 && (
           <Tooltip content="Clear conversation" side="left">
             <button onClick={handleClear}
-              className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--danger)] hover:bg-[var(--surface-2)] transition-colors">
-              <Trash2 size={13} />
+              className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--danger)] hover:bg-[var(--surface-3)] transition-colors">
+              <Trash2 size={11} />
             </button>
           </Tooltip>
         )}
         <Tooltip content="New chat" side="left">
           <button onClick={handleNewThread}
-            className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors">
-            <PenSquare size={13} />
-          </button>
-        </Tooltip>
-        <Tooltip content="Close chat" side="left">
-          <button onClick={toggleChat} className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors">
-            <X size={13} />
+            className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-3)] transition-colors">
+            <PenSquare size={11} />
           </button>
         </Tooltip>
       </div>
@@ -648,6 +572,6 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
           )}
         </div>
       </div>
-    </aside>
+    </div>
   );
 }

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import React, { useState, useRef, useEffect, useMemo, useCallback } from "react";
-import { X, Sparkles, PenSquare, History, Pencil, Trash2 } from "lucide-react";
+import { X, PenSquare, History, Pencil, Trash2 } from "lucide-react";
 import { cn, formatRelative } from "@/lib/utils";
 import { useCairnStore } from "@/store";
-import { MIN_CHAT_PANEL_WIDTH, MAX_CHAT_PANEL_WIDTH } from "@/store/slices/ui";
 import { useShallow } from "zustand/react/shallow";
 import { useChatStream } from "@/hooks/useChatStream";
 import { buildGraphContext } from "@/components/graph/graph-ai-utils";
@@ -80,20 +79,19 @@ interface ChatPanelProps {
 
 export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
   const {
-    chatOpen, toggleChat,
+    chatOpen,
     activeProjectId, activeWorkspaceId,
     projects, workspaces,
     addMessage,
     chatMessages, chatThreads, aiConfig,
     createNewThread, deleteThread, renameThread,
-    chatPanelWidth, setChatPanelWidth,
+    chatPanelWidth,
     activeView, graphData, selectedGraphNodeId,
     clearThreadMessages,
     createNote,
     notes, cards,
   } = useCairnStore(useShallow((s) => ({
     chatOpen:            s.chatOpen,
-    toggleChat:          s.toggleChat,
     activeProjectId:     s.activeProjectId,
     activeWorkspaceId:   s.activeWorkspaceId,
     projects:            s.projects,
@@ -106,7 +104,6 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     deleteThread:        s.deleteThread,
     renameThread:        s.renameThread,
     chatPanelWidth:      s.chatPanelWidth,
-    setChatPanelWidth:   s.setChatPanelWidth,
     activeView:          s.activeView,
     graphData:           s.graphData,
     selectedGraphNodeId: s.selectedGraphNodeId,

--- a/src/components/kanban/board.tsx
+++ b/src/components/kanban/board.tsx
@@ -351,7 +351,7 @@ export function KanbanBoard() {
       >
         <div ref={boardRef} className="flex-1 flex flex-col min-h-0 w-full overflow-hidden">
           {/* Board / Archive toggle bar */}
-          <div className="flex items-center gap-1 px-4 py-1.5 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0">
+          <div className="flex items-center gap-1 px-4 h-9 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0">
             <button
               onClick={() => setArchiveViewOpen(false)}
               className={cn(

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import React, { useRef, useEffect } from "react";
+import { useCairnStore } from "@/store";
+import { useShallow } from "zustand/react/shallow";
+import { MIN_CHAT_PANEL_WIDTH, MAX_CHAT_PANEL_WIDTH } from "@/store/slices/ui";
+import { AgentTerminalPane } from "@/components/agent/AgentTerminalPane";
+
+interface RightPanelProps {
+  prefill?: { text: string; autoSend?: boolean } | null;
+  onPrefillConsumed?: () => void;
+}
+
+export function RightPanel({ prefill, onPrefillConsumed }: RightPanelProps) {
+  const { chatPanelWidth, setChatPanelWidth } = useCairnStore(useShallow((s) => ({
+    chatPanelWidth: s.chatPanelWidth,
+    setChatPanelWidth: s.setChatPanelWidth,
+  })));
+
+  const panelRef = useRef<HTMLElement>(null);
+  const dividerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const divider = dividerRef.current;
+    const panel = panelRef.current;
+    if (!divider || !panel) return;
+
+    let dragging = false;
+    let startX = 0;
+    let startW = 0;
+
+    function onMouseMove(e: MouseEvent) {
+      if (!dragging) return;
+      // Panel is on the right; dragging left (lower clientX) makes it wider.
+      const next = Math.min(MAX_CHAT_PANEL_WIDTH, Math.max(MIN_CHAT_PANEL_WIDTH, startW - (e.clientX - startX)));
+      panel!.style.width = `${next}px`;
+    }
+
+    function onMouseUp() {
+      if (!dragging) return;
+      dragging = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      const finalWidth = panel!.offsetWidth;
+      setChatPanelWidth(finalWidth);
+    }
+
+    function onMouseDown(e: MouseEvent) {
+      dragging = true;
+      startX = e.clientX;
+      startW = panel!.offsetWidth;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      e.preventDefault();
+    }
+
+    divider.addEventListener("mousedown", onMouseDown);
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+
+    return () => {
+      divider.removeEventListener("mousedown", onMouseDown);
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup",   onMouseUp);
+    };
+  }, [setChatPanelWidth]);
+
+  return (
+    <aside
+      ref={panelRef}
+      className="fixed inset-0 z-50 md:relative md:inset-auto md:h-auto chat-panel-responsive flex flex-col border-l border-[var(--border)] bg-[var(--surface)] flex-shrink-0 animate-slide-in-right"
+      style={{ "--chat-panel-width": `${chatPanelWidth}px` } as React.CSSProperties}
+    >
+      {/* Drag-to-resize handle — sits on the left edge of the panel */}
+      <div
+        ref={dividerRef}
+        className="absolute left-0 top-0 h-full w-0 flex-shrink-0 cursor-col-resize z-10 select-none hidden md:block"
+        style={{ marginLeft: -3, padding: "0 3px" }}
+        aria-hidden
+      />
+      <AgentTerminalPane isRightPanel={true} chatPrefill={prefill} onPrefillConsumed={onPrefillConsumed} />
+    </aside>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -174,10 +174,10 @@ export function Sidebar() {
         <WorkspaceSwitcher workspace={workspace} onCollapse={toggleSidebar} />
 
         {/* Quick actions */}
-        <div className="flex items-center gap-0.5 px-2 py-1.5 border-b border-[var(--border-subtle)]">
+        <div className="flex items-center gap-0.5 px-2 h-9 border-b border-[var(--border-subtle)] flex-shrink-0">
           <Tooltip content="Search (⌘K)">
             <button onClick={() => { toggleSearch(); closeSidebarOnMobile(); }}
-              className={cn("flex items-center gap-1.5 flex-1 rounded-md px-2 py-1.5 text-xs transition-colors",
+              className={cn("flex items-center gap-1.5 flex-1 rounded-md px-2 py-1 text-xs transition-colors",
                 searchOpen ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
               <Search size={12} /><span>Search</span>
               <span className="ml-auto text-[0.714rem] text-[var(--text-tertiary)] font-mono">⌘K</span>
@@ -186,7 +186,7 @@ export function Sidebar() {
           {!hiddenViews.has("chat") && (
             <Tooltip content="AI Chat (⌘/)">
               <button onClick={() => { toggleChat(); closeSidebarOnMobile(); }}
-                className={cn("p-1.5 rounded-md transition-colors", chatOpen ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
+                className={cn("p-1 rounded-md transition-colors", chatOpen ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]")}>
                 <MessageSquare size={13} />
               </button>
             </Tooltip>

--- a/src/components/layout/topbar.tsx
+++ b/src/components/layout/topbar.tsx
@@ -179,7 +179,7 @@ export function Topbar() {
 
       {/* Right actions */}
       <div className="flex items-center gap-1">
-        {!hiddenViews.has("chat") && activeView !== "agent" && (
+        {!hiddenViews.has("chat") && (
           <Tooltip content="AI Chat (⌘/)">
             <Button
               variant="ghost"

--- a/src/components/notes/dashboard-view.tsx
+++ b/src/components/notes/dashboard-view.tsx
@@ -239,7 +239,7 @@ export function DashboardView({ note, onBack }: DashboardViewProps) {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-2.5 px-4 py-2 border-b border-[var(--border)] flex-shrink-0">
+      <div className="flex flex-wrap md:flex-nowrap items-center justify-between gap-2.5 px-4 py-2 md:py-0 md:h-9 border-b border-[var(--border)] flex-shrink-0">
         <div className="flex items-center gap-2 text-xs text-[var(--text-tertiary)]">
           {onBack && (
             <Button

--- a/src/components/notes/note-editor.tsx
+++ b/src/components/notes/note-editor.tsx
@@ -779,7 +779,7 @@ export function NoteEditor({ note, onBack }: NoteEditorProps) {
       }}
     >
       {/* ── Header ─────────────────────────────────────────────────────────── */}
-      <div className="flex flex-wrap items-center justify-between gap-2.5 px-3 py-2.5 md:px-4 md:py-2 border-b border-[var(--border)] flex-shrink-0 w-full">
+      <div className="flex flex-wrap md:flex-nowrap items-center justify-between gap-2.5 px-3 py-2.5 md:px-4 md:h-9 md:py-0 border-b border-[var(--border)] flex-shrink-0 w-full">
         <div className="flex items-center justify-between w-full md:w-auto gap-2">
           {onBack && (
             <Button
@@ -823,7 +823,7 @@ export function NoteEditor({ note, onBack }: NoteEditorProps) {
         </div>
 
         {/* Meta */}
-        <div className="flex items-center gap-2 flex-wrap">
+        <div className="flex items-center gap-2 flex-wrap md:flex-nowrap">
           {aiEnabled && (spawnLoading ? (
             <div className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-[var(--surface-2)] border border-[var(--border)]">
               <Loader2 size={11} className="animate-spin text-[var(--accent)] shrink-0" />

--- a/src/components/notes/notes-view.tsx
+++ b/src/components/notes/notes-view.tsx
@@ -314,7 +314,7 @@ export function NotesView() {
       {/* Notes list */}
       <div className={cn("w-full md:w-56 flex-shrink-0 border-r border-[var(--border)] flex flex-col bg-[var(--surface)]", mobileShowEditor ? "hidden md:flex" : "flex")}>
         {/* Header */}
-        <div className="flex items-center justify-between px-3 py-2.5 border-b border-[var(--border)]">
+        <div className="flex items-center justify-between px-3 h-9 border-b border-[var(--border)] flex-shrink-0">
           <span className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider">Notes</span>
           <div className="flex items-center gap-0.5">
             {aiEnabled && (

--- a/tests/fixtures/ipc-mock.ts
+++ b/tests/fixtures/ipc-mock.ts
@@ -245,16 +245,18 @@ export function buildIpcMock(): string {
 
     // ── Chat ──────────────────────────────────────────────────
     chat: {
-      threads:       () => Promise.resolve([]),
-      messages:      () => Promise.resolve([]),
-      upsertThread:  noop,
-      addMessage:    noop,
-      deleteThread:  noop,
-      stream:        () => {},
-      abort:         () => {},
-      onToken:       makeListener(),
-      onDone:        makeListener(),
-      onToolCall:    makeListener(),
+      threads:        () => Promise.resolve([]),
+      messages:       () => Promise.resolve([]),
+      upsertThread:   noop,
+      addMessage:     noop,
+      deleteThread:   noop,
+      stream:         () => {},
+      abort:          () => {},
+      onToken:        makeListener(),
+      onDone:         makeListener(),
+      onToolCall:     makeListener(),
+      onToolCallDone: makeListener(),
+      onUsage:        makeListener(),
     },
 
     // ── Knowledge graph ───────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Standardizes the workspace headers (to h-11/44px) and secondary toolbars (to h-9/36px) for layout symmetry. Standardizes completions Chat and Cairn Agent PTY sessions into a unified resizable right drawer component (`RightPanel.tsx`). Finally, restores the topbar AI Chat button and `⌘/` keyboard shortcut in the Agent view to allow collapsing and reopening the panel.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [x] Docs / changelog
- [ ] Tests

## Screenshots / recording

<!-- For any UI change, include a screenshot or short screen recording. Delete this section if not applicable. -->

## Checklist

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [x] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

None.
