### PR TITLE
v2.0.4 - Fix Duplicate Chat Messages.

### DIFF
--- a/changelogs/v2.0.4.md
+++ b/changelogs/v2.0.4.md
@@ -1,0 +1,24 @@
+## What's new
+
+### Features & Performance
+
+- **GitHub Actions Build Optimizations**: Implemented extensive caching strategies across CI (`ci.yml`) and Release (`release.yml`) workflows:
+  - Cached `node_modules` and compiled native binary directories (`pkg-native`, `vitest-native`, `electron-native`) to bypass slow `npm ci` and C++ module compilations on cache hits.
+  - Cached compiler tools (Electron binaries, electron-builder helper compilers, and `@yao-pkg/pkg` base Node.js binaries) to avoid repeated multi-megabyte downloads.
+  - Switched Next.js build caching to dynamic source file hashes (`src/**/*.ts*`) so that cache files correctly save and update as code changes.
+  - Configured conditional Gates on dependency installations and rebuild steps to completely bypass them when a cache is hit.
+
+### Bug Fixes
+
+- **Duplicate Chat Message Rendering**: Fixed a bug where assistant messages in the completions Chat panel and Cairn Agent were rendered twice. The root cause was `AgentTerminalPane` being mounted twice simultaneously on desktop (once in the CSS-hidden mobile slot inside `AgentView.tsx` and once in the desktop `RightPanel.tsx` drawer), causing duplicate IPC listener registrations. Resolved by adding a React media query check (`isMobile`) in `AgentView.tsx` to conditionally mount the mobile layout only when the viewport width is below 768px.
+
+---
+
+## Changed files
+
+| File | Change |
+|------|--------|
+| `.github/workflows/ci.yml` | Implemented `node_modules` caching, conditional gates, `vitest-native` caching, and dynamic Next.js cache keys. |
+| `.github/workflows/release.yml` | Added global workspace-relative paths for Electron/Builder/PKG caches and implemented full tool caching and dependency reuse. |
+| `src/components/agent/AgentView.tsx` | Added `isMobile` media query check to conditionally mount the mobile terminal pane. |
+| `changelogs/v2.0.4.md` | [NEW] Changelog for version 2.0.4. |

--- a/src/components/agent/AgentView.tsx
+++ b/src/components/agent/AgentView.tsx
@@ -45,9 +45,17 @@ export function AgentView() {
   const leftDividerRef   = useRef<HTMLDivElement>(null);
   const bottomDividerRef = useRef<HTMLDivElement>(null);
 
+  const [isMobile, setIsMobile] = useState(false);
+
   // Set initial widths once on mount via DOM (avoids a React render cycle)
   useEffect(() => {
     if (treePaneRef.current) treePaneRef.current.style.width = `${DEFAULT_TREE_WIDTH}px`;
+
+    const media = window.matchMedia("(max-width: 767px)");
+    setIsMobile(media.matches);
+    const listener = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
   }, []);
 
   // ── Drag logic ─────────────────────────────────────────────────────────────
@@ -222,14 +230,16 @@ export function AgentView() {
         </div>
 
         {/* Right pane — agent terminal sessions (only on mobile, as desktop uses RightPanel drawer) */}
-        <div
-          className={cn(
-            "w-full flex-col flex-1 min-h-0 overflow-hidden md:hidden",
-            (mobileTab === "agent" || mobileTab === "terminal") ? "flex" : "hidden"
-          )}
-        >
-          <AgentTerminalPane />
-        </div>
+        {isMobile && (
+          <div
+            className={cn(
+              "w-full flex-col flex-1 min-h-0 overflow-hidden md:hidden",
+              (mobileTab === "agent" || mobileTab === "terminal") ? "flex" : "hidden"
+            )}
+          >
+            <AgentTerminalPane />
+          </div>
+        )}
       </div>
 
       {/* ── Bottom terminal (only when a codeDirectory is set) ─────────────── */}

--- a/src/components/agent/AgentView.tsx
+++ b/src/components/agent/AgentView.tsx
@@ -52,6 +52,7 @@ export function AgentView() {
     if (treePaneRef.current) treePaneRef.current.style.width = `${DEFAULT_TREE_WIDTH}px`;
 
     const media = window.matchMedia("(max-width: 767px)");
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsMobile(media.matches);
     const listener = (e: MediaQueryListEvent) => setIsMobile(e.matches);
     media.addEventListener("change", listener);


### PR DESCRIPTION
## What does this PR do?

This PR optimizes our GitHub Actions pipelines to reduce build times by introducing dependency and tool caching. It also fixes a layout mount bug that was causing duplicate chat message rendering on desktop.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [x] Docs / changelog
- [ ] Tests

## Checklist

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts`
- [ ] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

- Added a state-driven media query check (`isMobile`) in `AgentView.tsx` to conditionally mount the mobile `AgentTerminalPane` only on viewport widths below 768px. This prevents the mobile pane from running side-by-side with the desktop `RightPanel` drawer, solving the duplicate IPC event registrations and double-message insertion bug.
- Added full `node_modules` and native compiled libraries (`pkg-native`, `vitest-native`, `electron-native`) caching to avoid slow `npm ci` and C++ module compilations.
- Replaced static Next.js cache keys with a dynamic hash based on dependency and source code changes.
- Cached downloaded compiler binaries (Electron, electron-builder tools, and `@yao-pkg/pkg` base Node versions) within a workspace `.cache/` folder.
