### PR TITLE
fix: enable manual tab-switching in RightPanel and filter zero-token categories in ContextRing

### DIFF
--- a/changelogs/v2.0.6.md
+++ b/changelogs/v2.0.6.md
@@ -1,0 +1,19 @@
+## What's new
+
+### Features & User Experience
+
+- **Filtered Context Legend**: Hidden zero-token legend entries (**Subagent definitions**, **Skills**, **Rules**, and **MCP**) from the context usage popover. This keeps the popover clean and focused on prose and tool usage during standard chat sessions, dynamically showing subagent and skill weights only when they are actually active in coding agent runs.
+
+### Bug Fixes
+
+- **Right Panel Tab Locking**: Fixed a bug where users were unable to manually switch away from the `"chat"` tab (e.g. to the Cairn Agent or PTY terminals) when opening the right drawer panel from another view. The defaulting mechanism now utilizes state transition tracking refs, resetting the active tab to `"chat"` only when the panel drawer is initially opened or when navigating away from the Agent View.
+
+---
+
+## Changed files
+
+| File | Change |
+|------|--------|
+| `src/components/agent/AgentTerminalPane.tsx` | Refactored defaulting logic to use refs for tracking `activeView` and `chatOpen` transitions. |
+| `src/components/agent/ContextRing.tsx` | Filtered out `"Subagent definitions"`, `"Skills"`, `"Rules"`, and `"MCP"` from the legend when they are `0`. |
+| `changelogs/v2.0.6.md` | [NEW] Changelog for version 2.0.6. |

--- a/src/components/agent/AgentTerminalPane.tsx
+++ b/src/components/agent/AgentTerminalPane.tsx
@@ -569,12 +569,21 @@ export function AgentTerminalPane({ isRightPanel = false, chatPrefill = null, on
     }
   }, [activeSessionId, setActiveSession]);
 
+  const prevViewRef = useRef(activeView);
+  const prevChatOpenRef = useRef(chatOpen);
+
   // Default active session to "chat" when opening chat panel outside of agent view
   // or when navigating away from the agent view.
   useEffect(() => {
-    if (activeView !== "agent") {
+    const viewChangedToNonAgent = prevViewRef.current === "agent" && activeView !== "agent";
+    const chatOpenedOutsideAgent = !prevChatOpenRef.current && chatOpen && activeView !== "agent";
+
+    if (viewChangedToNonAgent || chatOpenedOutsideAgent) {
       setActiveSession("chat");
     }
+
+    prevViewRef.current = activeView;
+    prevChatOpenRef.current = chatOpen;
   }, [activeView, chatOpen, setActiveSession]);
 
   // Determine if the pinned tab is active

--- a/src/components/agent/ContextRing.tsx
+++ b/src/components/agent/ContextRing.tsx
@@ -148,7 +148,7 @@ export function ContextRing({
           {/* Legend */}
           <div className="space-y-1.5 mt-2">
             {categories.map((c) => {
-              if (c.count === 0 && (c.label === "Rules" || c.label === "MCP")) return null;
+              if (c.count === 0 && (c.label === "Rules" || c.label === "MCP" || c.label === "Subagent definitions" || c.label === "Skills")) return null;
               return (
                 <div key={c.label} className="flex items-center justify-between text-[0.714rem]">
                   <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## What does this PR do?

This PR addresses two UX concerns regarding the sidebar panels and context breakdown:

1. **Tab Locking Fix**: Fixes a bug in `AgentTerminalPane` where a user was unable to manually switch between `"chat"`, `"pi"`, and `"pty"` tabs in the right drawer panel while in any view other than the Agent View. The defaulting hook now uses transition-tracking refs to target only drawer-open events or navigations away from the Agent View, rather than blocking click actions.
2. **Context Legend Filtering**: Prevents UI clutter by hiding zero-token categories (**Subagent definitions**, **Skills**, **Rules**, and **MCP**) from the `ContextRing` breakdown popover list. They will now dynamically reveal themselves only when they have non-zero token weights (e.g. during active subagent spawns or coding runs).

## Type of change

- [x] Bug fix
- [x] Refactor / code quality
- [x] Docs / changelog

## Checklist

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
