### PR TITLE
v2.0.8 - Agent Fixes

### DIFF
--- a/changelogs/v2.0.8.md
+++ b/changelogs/v2.0.8.md
@@ -1,0 +1,39 @@
+## What's new
+
+### Features
+
+- **Project Status & Priority Editing**: The "Edit project" popover on the Overview view now includes Status (active / on hold / completed / archived) and Priority (low / medium / high / urgent) pickers with coloured dot indicators. Previously these fields had no in-app editor and could only be set via the MCP API.
+
+- **Chat Thread History in Tab Bar**: The AI Chat tab in the session pane now sports a built-in thread-history dropdown — switch, rename, or delete chat threads without reaching for the toolbar. Thread switching is driven by a new global `activeChatThreadId` store value so the tab bar and chat panel stay in sync.
+
+- **Unified "New" Menu**: A single `+` button in the session pane tab bar opens a menu with "New chat thread" and "New agent session", replacing the old session-only new button.
+
+- **Cairn Agent Pre-Session Empty State**: Clicking the Cairn Agent tab before any session exists now sets an `"agent"` sentinel and shows the empty state, rather than silently doing nothing.
+
+### Fixes
+
+- **Duplicate Assistant Messages**: Fixed duplicate LLM responses in chat. When a project had no code directory, `AgentView` rendered a `SessionPane` inside a CSS-hidden `md:hidden` container; on desktop this was still mounted, double-mounting `ChatPanel` / `useChatStream`. Both `onDone` subscriptions then called `addMessage`, producing two identical assistant bubbles. The no-codebase path now renders only an empty state — chat comes exclusively from the RightPanel drawer.
+
+- **Cairn Agent Tab Hidden Without Codebase**: Projects without a code directory no longer show the Cairn Agent (coding agent) tab, its session content, or the "New agent session" menu item in the chat sidebar. The active session falls back to chat automatically, and entering the Agent view no longer auto-activates a coding session.
+
+### Changes
+
+- **Agent View No-Codebase Empty State**: When a project has no code directory, the three-pane coding-agent workspace (file tree, editor, diff, terminal) is skipped entirely. A centred "No codebase connected" empty state with a "Choose folder" button is shown instead.
+
+- **Chat Panel Slimmed Down**: Thread history, rename, delete, and new-thread controls moved out of `ChatPanel`'s sub-header into the new `AIChatTab` component. `ChatPanel` now reads `threadId` from the store's `activeChatThreadId` instead of local state, removing the `threadId` / `historyOpen` / `renamingThreadId` state and the outside-click handler.
+
+- **New `STATUS_CSS_COLORS` Constant**: A CSS-variable map mirroring `PRIORITY_CSS_COLORS`, used by the new status picker dot indicators.
+
+---
+
+## Changed files
+
+| File | Change |
+|------|--------|
+| `src/app/page.tsx` | Agent-view auto-activate effect no longer switches to the Cairn Agent session when the project has no code directory. |
+| `src/components/agent/AgentView.tsx` | Early return for projects without a `codeDirectory` — renders "No codebase connected" empty state with a "Choose folder" CTA instead of the coding workspace. |
+| `src/components/agent/SessionPane.tsx` | New `AIChatTab` with thread-history dropdown; unified `+` new-item menu; Cairn Agent tab / content / new-session action hidden when no codebase; `"agent"` sentinel handling; fallback-to-chat effect. |
+| `src/components/chat/chat-panel.tsx` | Removed thread-history UI and local `threadId` state; `threadId` now comes from `activeChatThreadId` in the store. |
+| `src/components/layout/project-overview.tsx` | Added status & priority pickers (with coloured dots) to the "Edit project" popover. |
+| `src/lib/constants.ts` | Added `STATUS_CSS_COLORS` map for project status inline indicators. |
+| `src/store/slices/chat.ts` | Added `activeChatThreadId` state and `setActiveChatThreadId` action. |

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -273,7 +273,9 @@ export default function Home() {
       if (!state.chatOpen) {
         state.toggleChat();
       }
-      if (state.activeSessionId === null || state.activeSessionId === "chat") {
+      // Only auto-activate the Cairn Agent (coding) session when the project has a codebase.
+      const hasCodeDirectory = !!state.projects.find((p) => p.id === state.activeProjectId)?.codeDirectory;
+      if (hasCodeDirectory && (state.activeSessionId === null || state.activeSessionId === "chat")) {
         if (state.persistentPiSessionId) {
           state.setActiveSession(state.persistentPiSessionId);
         }

--- a/src/components/agent/AgentView.tsx
+++ b/src/components/agent/AgentView.tsx
@@ -18,6 +18,7 @@ import { SessionPane } from "./SessionPane";
 import { AgentBottomTerminal } from "./AgentBottomTerminal";
 import { DiffViewer } from "./DiffViewer";
 import { TerminalManager } from "./TerminalManager";
+import { Bot, FolderOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const MIN_TREE_WIDTH = 160;
@@ -30,9 +31,15 @@ const DEFAULT_BOTTOM_HEIGHT = 220;
 type CentreTab = "editor" | "diff";
 
 export function AgentView() {
-  const { activeProjectId, projects } = useCairnStore(useShallow((s) => ({ activeProjectId: s.activeProjectId, projects: s.projects })));
+  const { activeProjectId, projects, updateProject } = useCairnStore(useShallow((s) => ({ activeProjectId: s.activeProjectId, projects: s.projects, updateProject: s.updateProject })));
   const project = projects.find((p) => p.id === activeProjectId) ?? null;
   const codeDirectory = project?.codeDirectory ?? null;
+
+  async function handlePickCodeDir() {
+    if (!project) return;
+    const result = await window.electron?.agent.pickDirectory() as { data: string | null } | undefined;
+    if (result?.data) updateProject(project.id, { codeDirectory: result.data });
+  }
 
   const [centreTab, setCentreTab] = useState<CentreTab>("editor");
   const [mobileTab, setMobileTab] = useState<"agent" | "files" | "editor" | "diff" | "terminal">("agent");
@@ -127,6 +134,38 @@ export function AgentView() {
       window.removeEventListener("mouseup",   onMouseUp);
     };
   }, []);
+
+  // No codebase on this project — show only chat, not the coding-agent workspace.
+  // Chat is provided by the RightPanel drawer (auto-opened on agent view in page.tsx)
+  // on both desktop (side drawer) and mobile (full-screen overlay), so we must NOT
+  // render a SessionPane here — doing so double-mounts ChatPanel/useChatStream and
+  // causes duplicate assistant messages (both onDone subscriptions call addMessage).
+  if (!codeDirectory) {
+    return (
+      <div className="flex flex-1 min-h-0 overflow-hidden bg-[var(--background)]">
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+          <div className="w-12 h-12 rounded-full bg-[var(--accent-dim)] border border-[color-mix(in_srgb,var(--accent)_20%,transparent)] flex items-center justify-center">
+            <Bot size={20} className="text-[var(--accent)]" />
+          </div>
+          <div className="flex flex-col gap-1.5 max-w-xs">
+            <p className="text-sm font-semibold text-[var(--text-primary)]">No codebase connected</p>
+            <p className="text-xs text-[var(--text-tertiary)]">
+              This project has no code directory. Set one to launch the coding agent workspace. Chat is available in the side panel.
+            </p>
+          </div>
+          {project && (
+            <button
+              onClick={handlePickCodeDir}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-[var(--accent)] text-white text-xs font-medium hover:opacity-90 transition-opacity"
+            >
+              <FolderOpen size={12} />
+              Choose folder
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden bg-[var(--background)]">

--- a/src/components/agent/SessionPane.tsx
+++ b/src/components/agent/SessionPane.tsx
@@ -17,9 +17,9 @@ import "@xterm/xterm/css/xterm.css";
 
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { X, MessageSquare, CircleDot, Plus, ChevronDown, Trash2, Bot, History, ArrowRight, Sparkles } from "lucide-react";
+import { X, MessageSquare, CircleDot, Plus, ChevronDown, Trash2, Bot, History, ArrowRight, Sparkles, MessageSquarePlus, Terminal, Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { id } from "@/lib/utils";
+import { id, formatRelative } from "@/lib/utils";
 import { useCairnStore } from "@/store";
 import { Tooltip } from "@/components/ui/tooltip";
 import { SpawnAgentModal } from "./SpawnAgentModal";
@@ -357,6 +357,173 @@ function AgentEmptyState() {
   );
 }
 
+// ── AIChatTab — AI Chat tab with thread history dropdown ──────────────────────
+
+interface AIChatTabProps {
+  isActive: boolean;
+  onActivate: () => void;
+}
+
+function AIChatTab({ isActive, onActivate }: AIChatTabProps) {
+  const {
+    chatThreads, chatMessages, activeProjectId, activeWorkspaceId,
+    activeChatThreadId, setActiveChatThreadId,
+    createNewThread, deleteThread, renameThread,
+  } = useCairnStore(useShallow((s) => ({
+    chatThreads:           s.chatThreads,
+    chatMessages:          s.chatMessages,
+    activeProjectId:       s.activeProjectId,
+    activeWorkspaceId:     s.activeWorkspaceId,
+    activeChatThreadId:    s.activeChatThreadId,
+    setActiveChatThreadId: s.setActiveChatThreadId,
+    createNewThread:       s.createNewThread,
+    deleteThread:          s.deleteThread,
+    renameThread:          s.renameThread,
+  })));
+
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [renamingId, setRenamingId]     = useState<string | null>(null);
+  const [renameValue, setRenameValue]   = useState("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const projectThreads = chatThreads
+    .filter((t) => t.projectId === activeProjectId)
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    .slice(0, 15);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+        setRenamingId(null);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [dropdownOpen]);
+
+  function handleSwitchThread(threadId: string) {
+    setActiveChatThreadId(threadId);
+    setDropdownOpen(false);
+    setRenamingId(null);
+    onActivate();
+  }
+
+  function handleDeleteThread(e: React.MouseEvent, threadId: string) {
+    e.stopPropagation();
+    deleteThread(threadId);
+    if (activeChatThreadId === threadId && activeWorkspaceId) {
+      const next = createNewThread(activeWorkspaceId, activeProjectId ?? undefined);
+      setActiveChatThreadId(next.id);
+    }
+  }
+
+  return (
+    <div className="relative flex-shrink-0 h-full" ref={dropdownRef}>
+      {/* The tab button */}
+      <button
+        onClick={onActivate}
+        role="tab"
+        aria-selected={isActive}
+        className={cn(
+          "flex items-center gap-1.5 px-3 h-full text-xs font-semibold whitespace-nowrap border-r border-[var(--border)] transition-colors flex-shrink-0",
+          isActive
+            ? "text-[var(--text-primary)] bg-[var(--background)]"
+            : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+        )}
+      >
+        <Sparkles size={11} className={cn("flex-shrink-0", isActive ? "text-[var(--accent)]" : "text-[var(--text-tertiary)]")} />
+        <span>AI Chat</span>
+        {/* Thread history chevron */}
+        {projectThreads.length > 1 && (
+          <span
+            role="button"
+            aria-label="Chat thread history"
+            onClick={(e) => { e.stopPropagation(); setDropdownOpen((v) => !v); }}
+            className={cn(
+              "ml-0.5 p-0.5 rounded transition-colors hover:bg-[var(--surface-2)]",
+              dropdownOpen ? "text-[var(--text-primary)]" : "text-[var(--text-tertiary)]"
+            )}
+          >
+            <ChevronDown size={10} />
+          </span>
+        )}
+      </button>
+
+      {/* Thread history dropdown */}
+      {dropdownOpen && (
+        <div className="absolute left-0 top-full z-50 mt-0.5 w-72 rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-xl overflow-hidden">
+          <div className="px-3 py-2 border-b border-[var(--border)]">
+            <div className="flex items-center gap-1.5">
+              <History size={10} className="text-[var(--text-tertiary)]" />
+              <span className="text-[0.643rem] font-semibold uppercase tracking-wider text-[var(--text-tertiary)]">Chat threads</span>
+            </div>
+          </div>
+          <div className="max-h-72 overflow-y-auto">
+            {projectThreads.map((t) => {
+              const firstMsg = chatMessages.find((m) => m.threadId === t.id && m.role === "user");
+              const isActiveThread = t.id === activeChatThreadId;
+              return (
+                <div
+                  key={t.id}
+                  className={cn(
+                    "group flex items-center border-b border-[var(--border)] last:border-0 transition-colors",
+                    isActiveThread ? "bg-[var(--accent-dim)]" : "hover:bg-[var(--surface-2)]"
+                  )}
+                >
+                  <button
+                    onClick={() => handleSwitchThread(t.id)}
+                    className="flex-1 text-left px-3 py-2 flex flex-col gap-0.5 min-w-0"
+                  >
+                    {renamingId === t.id ? (
+                      <input
+                        autoFocus
+                        value={renameValue}
+                        onChange={(e) => setRenameValue(e.target.value)}
+                        onClick={(e) => e.stopPropagation()}
+                        onBlur={() => { renameThread(t.id, renameValue); setRenamingId(null); }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") { renameThread(t.id, renameValue); setRenamingId(null); }
+                          if (e.key === "Escape") setRenamingId(null);
+                          e.stopPropagation();
+                        }}
+                        className="w-full bg-transparent text-[0.786rem] font-medium text-[var(--accent)] outline-none border-b border-[var(--accent)]"
+                      />
+                    ) : (
+                      <span className={cn("text-[0.714rem] truncate font-medium", isActiveThread ? "text-[var(--accent)]" : "text-[var(--text-primary)]")}>
+                        {t.title ?? (firstMsg?.content.slice(0, 50) ?? "New thread")}{(!t.title && (firstMsg?.content.length ?? 0) > 50) ? "…" : ""}
+                      </span>
+                    )}
+                    <span className="text-[0.607rem] text-[var(--text-tertiary)]">{formatRelative(t.updatedAt)}</span>
+                  </button>
+                  <div className="opacity-0 group-hover:opacity-100 flex items-center flex-shrink-0 mr-1.5 gap-0.5 transition-all">
+                    <button
+                      onClick={(e) => { e.stopPropagation(); setRenamingId(t.id); setRenameValue(t.title ?? firstMsg?.content.slice(0, 50) ?? ""); }}
+                      className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
+                      title="Rename thread"
+                    >
+                      <Pencil size={10} />
+                    </button>
+                    <button
+                      onClick={(e) => handleDeleteThread(e, t.id)}
+                      className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--danger)] hover:bg-[color-mix(in_srgb,var(--danger)_10%,transparent)] transition-colors"
+                      title="Delete thread"
+                    >
+                      <X size={10} />
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── AgentSessionTab (pinned Cairn Agent tab with history dropdown) ─────────
 
 interface AgentSessionTabProps {
@@ -382,7 +549,7 @@ function AgentSessionTab({ isActive, onActivate }: AgentSessionTabProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const { handleNewSession: _handleNewSession, handleResumeSession: _handleResumeSession, project } = useAgentSessionActions();
+  const { handleResumeSession: _handleResumeSession } = useAgentSessionActions();
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -402,11 +569,6 @@ function AgentSessionTab({ isActive, onActivate }: AgentSessionTabProps) {
       fetchPiSessionHistory(activeProjectId);
     }
   }, [dropdownOpen, activeProjectId, fetchPiSessionHistory]);
-
-  async function handleNewSession() {
-    setDropdownOpen(false);
-    await _handleNewSession();
-  }
 
   async function handleResumeSession(summary: PiSessionSummary) {
     setDropdownOpen(false);
@@ -435,7 +597,7 @@ function AgentSessionTab({ isActive, onActivate }: AgentSessionTabProps) {
       >
         <MessageSquare size={11} className={cn("flex-shrink-0", isActive ? "text-[var(--accent)]" : "text-[var(--text-tertiary)]")} />
         <span className="max-w-[100px] truncate">Cairn Agent</span>
-        {/* History dropdown chevron */}
+        {/* Session history dropdown chevron */}
         <span
           role="button"
           aria-label="Session history"
@@ -449,21 +611,15 @@ function AgentSessionTab({ isActive, onActivate }: AgentSessionTabProps) {
         </span>
       </button>
 
-      {/* History dropdown */}
+      {/* Session history dropdown — resume or delete past sessions */}
       {dropdownOpen && (
         <div className="absolute left-0 top-full z-50 mt-0.5 w-64 rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-xl overflow-hidden">
-          {/* New session CTA */}
-          <button
-            onClick={handleNewSession}
-            disabled={!project?.codeDirectory}
-            className="w-full flex items-center gap-2 px-3 py-2.5 text-[0.714rem] font-medium text-[var(--accent)] hover:bg-[var(--surface-2)] transition-colors border-b border-[var(--border)] disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            <Plus size={11} />
-            New session
-            {!project?.codeDirectory && <span className="ml-auto text-[var(--text-tertiary)] text-[0.643rem]">No code dir</span>}
-          </button>
-
-          {/* History list */}
+          <div className="px-3 py-2 border-b border-[var(--border)]">
+            <div className="flex items-center gap-1.5">
+              <History size={10} className="text-[var(--text-tertiary)]" />
+              <span className="text-[0.643rem] font-semibold uppercase tracking-wider text-[var(--text-tertiary)]">Session history</span>
+            </div>
+          </div>
           <div className="max-h-64 overflow-y-auto">
             {piSessionHistory.length === 0 ? (
               <p className="px-3 py-3 text-[0.714rem] text-[var(--text-tertiary)] text-center">No saved sessions</p>
@@ -530,6 +686,7 @@ export function SessionPane({ isRightPanel = false, chatPrefill = null, onPrefil
     toggleChat,
     activeView,
     chatOpen,
+    projects,
   } = useCairnStore(useShallow((s) => ({
     terminalSessions:       s.terminalSessions,
     activeSessionId:        s.activeSessionId,
@@ -541,9 +698,45 @@ export function SessionPane({ isRightPanel = false, chatPrefill = null, onPrefil
     toggleChat:             s.toggleChat,
     activeView:             s.activeView,
     chatOpen:               s.chatOpen,
+    projects:              s.projects,
   })));
 
+  // Whether the active project has a codebase — the Cairn Agent (coding agent)
+  // tab, session content, and "New agent session" action are hidden without one.
+  const hasCodeDirectory = !!projects.find((p) => p.id === activeProjectId)?.codeDirectory;
+
   const [spawnOpen, setSpawnOpen] = useState(false);
+  const [newMenuOpen, setNewMenuOpen] = useState(false);
+  const newMenuRef = useRef<HTMLDivElement>(null);
+
+  // Read create-new-thread from the store for the unified + button
+  const createNewThread    = useCairnStore((s) => s.createNewThread);
+  const activeWorkspaceId  = useCairnStore((s) => s.activeWorkspaceId);
+  const { handleNewSession } = useAgentSessionActions();
+
+  // Close the new-item menu on outside click
+  useEffect(() => {
+    if (!newMenuOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (newMenuRef.current && !newMenuRef.current.contains(e.target as Node)) {
+        setNewMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [newMenuOpen]);
+
+  function handleNewChatThread() {
+    if (!activeWorkspaceId) return;
+    setNewMenuOpen(false);
+    createNewThread(activeWorkspaceId, activeProjectId ?? undefined);
+    setActiveSession("chat");
+  }
+
+  async function handleNewAgentSession() {
+    setNewMenuOpen(false);
+    await handleNewSession();
+  }
 
   // Fetch session history on mount and when project changes
   useEffect(() => {
@@ -570,6 +763,18 @@ export function SessionPane({ isRightPanel = false, chatPrefill = null, onPrefil
     }
   }, [activeSessionId, setActiveSession]);
 
+  // When the active project has no codebase, the Cairn Agent (coding agent) tab is
+  // hidden. If the active session is the agent sentinel or a pi session, fall back
+  // to chat so the hidden content is never the shown one.
+  useEffect(() => {
+    if (!hasCodeDirectory && activeSessionId !== "chat" && activeSessionId !== null) {
+      const isAgentSession =
+        activeSessionId === "agent" ||
+        (persistentPiSessionId !== null && activeSessionId === persistentPiSessionId);
+      if (isAgentSession) setActiveSession("chat");
+    }
+  }, [hasCodeDirectory, activeSessionId, persistentPiSessionId, setActiveSession]);
+
   const prevViewRef = useRef(activeView);
   const prevChatOpenRef = useRef(chatOpen);
 
@@ -587,8 +792,11 @@ export function SessionPane({ isRightPanel = false, chatPrefill = null, onPrefil
     prevChatOpenRef.current = chatOpen;
   }, [activeView, chatOpen, setActiveSession]);
 
-  // Determine if the pinned tab is active
-  const pinnedIsActive = persistentPiSessionId !== null && activeSessionId === persistentPiSessionId;
+  // Determine if the pinned tab is active.
+  // "agent" is a sentinel set when the user clicks the agent tab before any session is created.
+  const pinnedIsActive =
+    activeSessionId === "agent" ||
+    (persistentPiSessionId !== null && activeSessionId === persistentPiSessionId);
 
   return (
     <>
@@ -596,28 +804,25 @@ export function SessionPane({ isRightPanel = false, chatPrefill = null, onPrefil
       {/* Tab bar */}
       <div className="flex items-center h-11 border-b border-[var(--border)] overflow-visible relative z-20 flex-shrink-0 bg-[var(--surface)]">
         {/* AI Chat tab (always present) */}
-        <button
-          onClick={() => setActiveSession("chat")}
-          className={cn(
-            "flex items-center gap-1.5 px-3 h-full text-xs font-semibold whitespace-nowrap border-r border-[var(--border)] transition-colors flex-shrink-0",
-            activeSessionId === "chat"
-              ? "text-[var(--text-primary)] bg-[var(--background)]"
-              : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
-          )}
-        >
-          <Sparkles size={11} className={cn("flex-shrink-0", activeSessionId === "chat" ? "text-[var(--accent)]" : "text-[var(--text-tertiary)]")} />
-          <span>AI Chat</span>
-        </button>
-
-        {/* Always-present Cairn Agent pinned tab */}
-        <AgentSessionTab
-          isActive={pinnedIsActive}
-          onActivate={() => {
-            if (persistentPiSessionId) {
-              setActiveSession(persistentPiSessionId);
-            }
-          }}
+        <AIChatTab
+          isActive={activeSessionId === "chat"}
+          onActivate={() => setActiveSession("chat")}
         />
+
+        {/* Cairn Agent (coding agent) pinned tab — only when the project has a codebase */}
+        {hasCodeDirectory && (
+          <AgentSessionTab
+            isActive={pinnedIsActive}
+            onActivate={() => {
+              if (persistentPiSessionId) {
+                setActiveSession(persistentPiSessionId);
+              } else {
+                // No session yet — switch to agent tab to show empty state
+                setActiveSession("agent");
+              }
+            }}
+          />
+        )}
 
         {/* Scrollable PTY sessions */}
         <div className="flex-1 flex items-center overflow-x-auto min-w-0 h-full">
@@ -632,15 +837,52 @@ export function SessionPane({ isRightPanel = false, chatPrefill = null, onPrefil
           ))}
         </div>
 
-        {/* New session button */}
-        <Tooltip content="New session" side="bottom">
-          <button
-            onClick={() => setSpawnOpen(true)}
-            className="flex-shrink-0 px-3 h-full text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors border-l border-[var(--border)] flex items-center justify-center"
-          >
-            <Plus size={12} />
-          </button>
-        </Tooltip>
+        {/* Unified new-item button */}
+        <div ref={newMenuRef} className="relative flex-shrink-0">
+          <Tooltip content="New…" side="bottom">
+            <button
+              id="unified-new-btn"
+              onClick={() => setNewMenuOpen((v) => !v)}
+              className={cn(
+                "px-3 h-11 flex items-center justify-center transition-colors border-l border-[var(--border)]",
+                newMenuOpen
+                  ? "text-[var(--text-primary)] bg-[var(--surface-2)]"
+                  : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)]"
+              )}
+            >
+              <Plus size={12} />
+            </button>
+          </Tooltip>
+
+          {newMenuOpen && (
+            <div className="absolute right-0 top-full mt-0.5 w-52 z-50 rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-xl overflow-hidden">
+              <button
+                id="new-chat-thread-btn"
+                onClick={handleNewChatThread}
+                className="w-full flex items-center gap-2.5 px-3 py-2.5 text-[0.714rem] text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors"
+              >
+                <MessageSquarePlus size={13} className="text-[var(--accent)] flex-shrink-0" />
+                <div className="text-left">
+                  <p className="font-medium">New chat thread</p>
+                  <p className="text-[0.643rem] text-[var(--text-tertiary)]">Start a fresh AI conversation</p>
+                </div>
+              </button>
+              {hasCodeDirectory && (
+                <button
+                  id="new-agent-session-btn"
+                  onClick={handleNewAgentSession}
+                  className="w-full flex items-center gap-2.5 px-3 py-2.5 text-[0.714rem] text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors border-t border-[var(--border)]"
+                >
+                  <Terminal size={13} className="text-[var(--accent)] flex-shrink-0" />
+                  <div className="text-left">
+                    <p className="font-medium">New agent session</p>
+                    <p className="text-[0.643rem] text-[var(--text-tertiary)]">Cairn Agent coding session</p>
+                  </div>
+                </button>
+              )}
+            </div>
+          )}
+        </div>
 
         {/* Close panel button (visible only in right panel drawer) */}
         {isRightPanel && (
@@ -663,16 +905,18 @@ export function SessionPane({ isRightPanel = false, chatPrefill = null, onPrefil
           <ChatPanel prefill={chatPrefill} onPrefillConsumed={onPrefillConsumed} />
         </div>
 
-        {/* Pinned agent session content */}
-        {persistentSession ? (
-          <div className={pinnedIsActive ? "flex flex-1 min-h-0 overflow-hidden" : "hidden"}>
-            <AgentChatPane session={persistentSession} isActive={pinnedIsActive} />
-          </div>
-        ) : pinnedIsActive ? (
-          <div className="flex-1 min-h-0 overflow-hidden">
-            <AgentEmptyState />
-          </div>
-        ) : null}
+        {/* Pinned agent session content — only when the project has a codebase */}
+        {hasCodeDirectory && (
+          persistentSession ? (
+            <div className={pinnedIsActive ? "flex flex-col flex-1 min-h-0 overflow-hidden" : "hidden"}>
+              <AgentChatPane session={persistentSession} isActive={pinnedIsActive} />
+            </div>
+          ) : pinnedIsActive ? (
+            <div className="flex-1 min-h-0 overflow-hidden">
+              <AgentEmptyState />
+            </div>
+          ) : null
+        )}
 
         {/* PTY sessions */}
         {ptySessions.map((session) => (

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React, { useState, useRef, useEffect, useMemo, useCallback } from "react";
-import { X, PenSquare, History, Pencil, Trash2 } from "lucide-react";
-import { cn, formatRelative } from "@/lib/utils";
+import { Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { useChatStream } from "@/hooks/useChatStream";
@@ -84,41 +84,38 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     projects, workspaces,
     addMessage,
     chatMessages, chatThreads, aiConfig,
-    createNewThread, deleteThread, renameThread,
     chatPanelWidth,
     activeView, graphData, selectedGraphNodeId,
     clearThreadMessages,
     createNote,
     notes, cards,
+    activeChatThreadId, setActiveChatThreadId,
   } = useCairnStore(useShallow((s) => ({
-    chatOpen:            s.chatOpen,
-    activeProjectId:     s.activeProjectId,
-    activeWorkspaceId:   s.activeWorkspaceId,
-    projects:            s.projects,
-    workspaces:          s.workspaces,
-    addMessage:          s.addMessage,
-    chatMessages:        s.chatMessages,
-    chatThreads:         s.chatThreads,
-    aiConfig:            s.aiConfig,
-    createNewThread:     s.createNewThread,
-    deleteThread:        s.deleteThread,
-    renameThread:        s.renameThread,
-    chatPanelWidth:      s.chatPanelWidth,
-    activeView:          s.activeView,
-    graphData:           s.graphData,
-    selectedGraphNodeId: s.selectedGraphNodeId,
-    clearThreadMessages: s.clearThreadMessages,
-    createNote:          s.createNote,
-    notes:               s.notes,
-    cards:               s.cards,
+    chatOpen:              s.chatOpen,
+    activeProjectId:       s.activeProjectId,
+    activeWorkspaceId:     s.activeWorkspaceId,
+    projects:              s.projects,
+    workspaces:            s.workspaces,
+    addMessage:            s.addMessage,
+    chatMessages:          s.chatMessages,
+    chatThreads:           s.chatThreads,
+    aiConfig:              s.aiConfig,
+    chatPanelWidth:        s.chatPanelWidth,
+    activeView:            s.activeView,
+    graphData:             s.graphData,
+    selectedGraphNodeId:   s.selectedGraphNodeId,
+    clearThreadMessages:   s.clearThreadMessages,
+    createNote:            s.createNote,
+    notes:                 s.notes,
+    cards:                 s.cards,
+    activeChatThreadId:    s.activeChatThreadId,
+    setActiveChatThreadId: s.setActiveChatThreadId,
   })));
 
-  const [input, setInput]             = useState("");
-  const [threadId, setThreadId]       = useState<string | null>(null);
-  const [historyOpen, setHistoryOpen] = useState(false);
-  const [renamingThreadId, setRenamingThreadId] = useState<string | null>(null);
-  const [renameValue, setRenameValue] = useState("");
-  const historyRef     = useRef<HTMLDivElement>(null);
+  // threadId is driven by the store so the tab bar can switch threads externally
+  const threadId = activeChatThreadId;
+
+  const [input, setInput] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef       = useRef<HTMLTextAreaElement>(null);
 
@@ -295,19 +292,19 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
   useEffect(() => {
     if (!activeWorkspaceId) return;
     if (isLoadingRef.current) return;
+    // Only initialise if no thread is active yet (tab bar may have already set one)
+    if (activeChatThreadId) return;
     const t = useCairnStore.getState().getOrCreateThread(activeWorkspaceId, activeProjectId ?? undefined);
-    setThreadId(t.id);
-  }, [activeWorkspaceId, activeProjectId]);
+    setActiveChatThreadId(t.id);
+  }, [activeWorkspaceId, activeProjectId, activeChatThreadId, setActiveChatThreadId]);
 
-  // Close history on outside click
+  // Also initialise on first mount when activeChatThreadId is already null
   useEffect(() => {
-    if (!historyOpen) return;
-    function handle(e: MouseEvent) {
-      if (historyRef.current && !historyRef.current.contains(e.target as Node)) setHistoryOpen(false);
-    }
-    document.addEventListener("mousedown", handle);
-    return () => document.removeEventListener("mousedown", handle);
-  }, [historyOpen]);
+    if (!activeWorkspaceId || activeChatThreadId) return;
+    const t = useCairnStore.getState().getOrCreateThread(activeWorkspaceId, activeProjectId ?? undefined);
+    setActiveChatThreadId(t.id);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const messages = useMemo(
     () => threadId ? chatMessages.filter((m) => m.threadId === threadId) : [],
@@ -405,11 +402,6 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
     }
   }, [threadId, input, prefill, handleSend]);
 
-  const handleNewThread = useCallback(() => {
-    if (!activeWorkspaceId) return;
-    setThreadId(createNewThread(activeWorkspaceId, activeProjectId ?? undefined).id);
-  }, [activeWorkspaceId, activeProjectId, createNewThread]);
-
   return (
     <div className="flex flex-1 flex-col min-h-0 overflow-hidden bg-[var(--surface)]">
       {/* Sub-header / toolbar */}
@@ -426,80 +418,6 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
           />
         )}
 
-        {/* Thread history */}
-        {projectThreads.length > 1 && (
-          <div ref={historyRef} className="relative">
-            <Tooltip content="Thread history" side="left">
-              <button onClick={() => setHistoryOpen((o) => !o)}
-                className={cn("p-1 rounded transition-colors",
-                  historyOpen ? "text-[var(--accent)] bg-[var(--accent-dim)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-3)]")}>
-                <History size={11} />
-              </button>
-            </Tooltip>
-            {historyOpen && (
-              <div className="absolute right-0 top-full mt-1 w-64 z-50 bg-[var(--surface)] border border-[var(--border)] rounded-xl shadow-2xl overflow-hidden">
-                <div className="px-3 py-2 border-b border-[var(--border)]">
-                  <span className="text-[0.714rem] font-semibold uppercase tracking-wider text-[var(--text-tertiary)]">Recent threads</span>
-                </div>
-                <div className="max-h-72 overflow-y-auto">
-                  {projectThreads.map((t) => {
-                    const firstMsg = chatMessages.find((m) => m.threadId === t.id && m.role === "user");
-                    const isActive = t.id === threadId;
-                    return (
-                      <div key={t.id}
-                        className={cn("group flex items-center border-b border-[var(--border-subtle)] last:border-0 transition-colors",
-                          isActive ? "bg-[var(--accent-dim)]" : "hover:bg-[var(--surface-2)]")}>
-                        <button onClick={() => { setThreadId(t.id); setHistoryOpen(false); }}
-                          className="flex-1 text-left px-3 py-2.5 flex flex-col gap-0.5 min-w-0">
-                          {renamingThreadId === t.id ? (
-                            <input
-                              autoFocus
-                              value={renameValue}
-                              onChange={(e) => setRenameValue(e.target.value)}
-                              onClick={(e) => e.stopPropagation()}
-                              onBlur={() => { renameThread(t.id, renameValue); setRenamingThreadId(null); }}
-                              onKeyDown={(e) => {
-                                if (e.key === "Enter") { renameThread(t.id, renameValue); setRenamingThreadId(null); }
-                                if (e.key === "Escape") setRenamingThreadId(null);
-                                e.stopPropagation();
-                              }}
-                              className="w-full bg-transparent text-[0.786rem] font-medium text-[var(--accent)] outline-none border-b border-[var(--accent)]"
-                            />
-                          ) : (
-                            <span className={cn("text-[0.786rem] truncate font-medium", isActive ? "text-[var(--accent)]" : "text-[var(--text-secondary)]")}>
-                              {t.title ?? (firstMsg?.content.slice(0, 50) ?? "New thread")}{(!t.title && (firstMsg?.content.length ?? 0) > 50) ? "…" : ""}
-                            </span>
-                          )}
-                          <span className="text-[0.714rem] text-[var(--text-tertiary)]">{formatRelative(t.updatedAt)}</span>
-                        </button>
-                        <div className="opacity-0 group-hover:opacity-100 flex items-center flex-shrink-0 mr-1 transition-all">
-                          <button onClick={(e) => { e.stopPropagation(); setRenamingThreadId(t.id); setRenameValue(t.title ?? firstMsg?.content.slice(0, 50) ?? ""); }}
-                            className="p-1.5 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
-                            title="Rename thread">
-                            <Pencil size={10} />
-                          </button>
-                          <button onClick={(e) => {
-                              e.stopPropagation();
-                              deleteThread(t.id);
-                              if (isActive && activeWorkspaceId) {
-                                const next = createNewThread(activeWorkspaceId, activeProjectId ?? undefined);
-                                  setThreadId(next.id);
-                                  setHistoryOpen(false);
-                                }
-                              }}
-                              className="p-1.5 rounded text-[var(--text-tertiary)] hover:text-[var(--danger)] transition-colors"
-                              title="Delete thread">
-                              <X size={10} />
-                            </button>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
 
         {messages.length > 0 && (
           <Tooltip content="Clear conversation" side="left">
@@ -509,12 +427,6 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
             </button>
           </Tooltip>
         )}
-        <Tooltip content="New chat" side="left">
-          <button onClick={handleNewThread}
-            className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-3)] transition-colors">
-            <PenSquare size={11} />
-          </button>
-        </Tooltip>
       </div>
 
       {/* Messages */}

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { Trash2 } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { useChatStream } from "@/hooks/useChatStream";
@@ -145,14 +144,6 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
       "Suggest new tags to organize this graph",
     ];
   }, [selectedNode]);
-
-  const projectThreads = useMemo(
-    () => chatThreads
-      .filter((t) => t.projectId === activeProjectId)
-      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
-      .slice(0, 15),
-    [chatThreads, activeProjectId],
-  );
 
   const activeThread = useMemo(
     () => chatThreads.find((t) => t.id === threadId),

--- a/src/components/layout/project-overview.tsx
+++ b/src/components/layout/project-overview.tsx
@@ -9,11 +9,11 @@ import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { ProjectIcon, WORKSPACE_ICONS } from "@/lib/workspace-icons";
 import { cn, formatDate, formatRelative, STATUS_COLORS } from "@/lib/utils";
-import { COLUMN_COLORS, PRIORITY_CSS_COLORS } from "@/lib/constants";
+import { COLUMN_COLORS, PRIORITY_CSS_COLORS, PRIORITY_OPTIONS, PROJECT_STATUS_OPTIONS, STATUS_CSS_COLORS } from "@/lib/constants";
 import { CairnEvents } from "@/lib/events";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import type { TaskCard, Note, BoardColumn } from "@/types";
+import type { TaskCard, Note, BoardColumn, ProjectStatus, Priority } from "@/types";
 import { useProjectMetrics, type ActivityGroup } from "./project-overview/useProjectMetrics";
 import { ChatInput, SuggestionItem } from "@/components/chat/ChatInput";
 
@@ -53,6 +53,8 @@ export function ProjectOverview() {
   const [editOpen, setEditOpen] = useState(false);
   const [editIcon, setEditIcon] = useState("");
   const [editDesc, setEditDesc] = useState("");
+  const [editStatus, setEditStatus] = useState<ProjectStatus | "">("");
+  const [editPriority, setEditPriority] = useState<Priority | "">("");
   const [codeDirInput, setCodeDirInput] = useState("");
   const popoverRef = useRef<HTMLDivElement>(null);
 
@@ -61,6 +63,8 @@ export function ProjectOverview() {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setEditIcon(project.icon ?? "");
       setEditDesc(project.description ?? "");
+      setEditStatus(project.status);
+      setEditPriority(project.priority);
     }
   }, [editOpen, project]);
 
@@ -88,6 +92,8 @@ export function ProjectOverview() {
     updateProject(project.id, {
       icon: editIcon.trim() || undefined,
       description: editDesc.trim() || undefined,
+      status: editStatus || undefined,
+      priority: editPriority || undefined,
     });
     setEditOpen(false);
   }
@@ -177,6 +183,56 @@ export function ProjectOverview() {
                         rows={3}
                         className="w-full px-2 py-1.5 text-xs rounded-md bg-[var(--surface)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)] resize-none"
                       />
+                    </div>
+                    {/* Status */}
+                    <div>
+                      <label className="text-[0.786rem] text-[var(--text-tertiary)] block mb-1">Status</label>
+                      <div className="grid grid-cols-2 gap-1">
+                        {PROJECT_STATUS_OPTIONS.map((s) => (
+                          <button
+                            key={s}
+                            type="button"
+                            onClick={() => setEditStatus(s)}
+                            className={cn(
+                              "flex items-center gap-1.5 px-2 py-1.5 rounded-md text-xs transition-colors capitalize",
+                              editStatus === s
+                                ? "bg-[var(--surface)] ring-1 ring-[var(--accent)] text-[var(--text-primary)]"
+                                : "text-[var(--text-tertiary)] hover:bg-[var(--surface)]"
+                            )}
+                          >
+                            <span
+                              className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                              style={{ background: STATUS_CSS_COLORS[s] ?? "var(--text-tertiary)" }}
+                            />
+                            {s.replace("_", " ")}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    {/* Priority */}
+                    <div>
+                      <label className="text-[0.786rem] text-[var(--text-tertiary)] block mb-1">Priority</label>
+                      <div className="grid grid-cols-2 gap-1">
+                        {PRIORITY_OPTIONS.map((p) => (
+                          <button
+                            key={p}
+                            type="button"
+                            onClick={() => setEditPriority(p)}
+                            className={cn(
+                              "flex items-center gap-1.5 px-2 py-1.5 rounded-md text-xs capitalize transition-colors",
+                              editPriority === p
+                                ? "bg-[var(--surface)] ring-1 ring-[var(--accent)] text-[var(--text-primary)]"
+                                : "text-[var(--text-tertiary)] hover:bg-[var(--surface)]"
+                            )}
+                          >
+                            <span
+                              className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                              style={{ background: PRIORITY_CSS_COLORS[p] ?? "var(--text-tertiary)" }}
+                            />
+                            {p}
+                          </button>
+                        ))}
+                      </div>
                     </div>
                     <div className="flex justify-end">
                       <Button variant="accent" size="xs" onClick={handleSaveEdit}>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -67,6 +67,17 @@ export const PRIORITY_CSS_COLORS: Record<Priority | string, string> = {
   low:    "var(--text-tertiary)",
 };
 
+/**
+ * CSS variable strings for project status stripe / inline indicators.
+ * Use for inline `style` props where Tailwind isn't suitable.
+ */
+export const STATUS_CSS_COLORS: Record<ProjectStatus | string, string> = {
+  active:    "var(--success)",
+  on_hold:   "var(--warning)",
+  completed: "var(--info)",
+  archived:  "var(--text-tertiary)",
+};
+
 /** Default AI/LLM config values. */
 export const DEFAULT_AI_CONFIG: AIConfig = {
   provider:     "localllm",

--- a/src/store/slices/chat.ts
+++ b/src/store/slices/chat.ts
@@ -13,8 +13,10 @@ import { ipc, ipcAwait, ipcAwaitResult } from "../ipc";
 export interface ChatSlice {
   chatThreads: ChatThread[];
   chatMessages: ChatMessage[];
+  activeChatThreadId: string | null;
 
   getOrCreateThread: (workspaceId: ID, projectId?: ID) => ChatThread;
+  setActiveChatThreadId: (threadId: string | null) => void;
   addMessage: (
     threadId: ID,
     role: ChatMessage["role"],
@@ -40,6 +42,11 @@ export const createChatSlice: StateCreator<CairnStore, [], [], ChatSlice> = (
 ) => ({
   chatThreads: [],
   chatMessages: [],
+  activeChatThreadId: null,
+
+  setActiveChatThreadId(threadId) {
+    set({ activeChatThreadId: threadId });
+  },
 
   getOrCreateThread(workspaceId, projectId) {
     const existing = get().chatThreads.find(


### PR DESCRIPTION
## What does this PR do?

Hides the Cairn Agent (coding agent) from the chat sidebar and Agent view when a project has no code directory, fixing duplicate LLM responses caused by a double-mounted `ChatPanel`. Also adds project status & priority editing to the Overview "Edit project" popover, moves chat thread history into a new `AIChatTab`, and introduces a unified "New…" menu in the session pane.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code quality
- [ ] Docs / changelog
- [ ] Tests


## Checklist

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts`
- [ ] `mcp-server.ts` changes use inlined SQL only — no import from `queries.ts`

## Notes for reviewer

- The duplicate-message bug was the highest-impact fix: on no-codebase projects `AgentView` rendered a `SessionPane` inside `md:hidden`, which stays mounted on desktop. Combined with the auto-opened `RightPanel` drawer, two `ChatPanel`/`useChatStream` instances each subscribed to `chat.onDone` and both called `addMessage`. The no-codebase path now renders an empty state only — chat is provided solely by the RightPanel drawer.
- `activeChatThreadId` is now global store state (previously local to `ChatPanel`) so the new `AIChatTab` can drive thread switching. `ChatPanel` was slimmed down accordingly.
- Topbar pill changes from an earlier exploration were reverted — status/priority pills remain as before; the new editing UI lives in the Overview popover.
- E2E tests not run locally — please run `npm run test:e2e` before merging.