### PR TITLE
v2.1.2 - Tool Token Optimization

### DIFF
--- a/changelogs/v2.1.2.md
+++ b/changelogs/v2.1.2.md
@@ -19,4 +19,12 @@
 
 ### Fixes
 
-- (none)
+- **Callout rendering in PDF export**: Obsidian-style callout blocks (`> [!type]`) were rendering correctly in the note editor preview but losing their styled layout (icon, header, coloured border, background tint) when exported to PDF. Added `data-callout` / `data-callout-type` attributes to the `<Callout>` component and added matching CSS selectors in the PDF template that replicate the in-app callout styling per type (note, tip, warning, danger, success, question, quote). Each type now gets its own accent-coloured border-left, header text colour, and tinted background in both light and dark PDFs. The `[!type]` directive text was also leaking into the callout body when the directive was alone on its line (no inline body after the title) — `remarkCallout` now correctly empties the first text node when there is no body content after the directive.
+
+- **Dark mode PDF export**: PDF export now supports a dark theme option. The export button has been replaced with a dropdown offering **Light** (sun icon) and **Dark** (moon icon) options. Dark PDFs use the app's dark palette (`#141414` background, `#e8e4dc` text, `#7c6af7` accent) with the dark background extending to the page edges via `@page` background. Code blocks keep their dark syntax highlighting instead of being rewritten to the light palette.
+
+- **Invalid characters in PDF filenames**: Note titles containing characters invalid in filenames (`/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, `|`) caused PDF export to silently fail or produce unsaveable files. Added filename sanitisation in both the Electron save-dialog path (`pdf-export.ts`) and the mobile share/download path (`note-editor.tsx`) — invalid characters are replaced with `_`.
+
+### Refactors
+
+- **Shared test teardown helper**: Extracted the duplicated `db.close()` + `removeTmpDir()` cleanup logic in `mcp-server.test.ts` (22 occurrences) into a single `teardown(db, dir)` helper function.

--- a/changelogs/v2.1.2.md
+++ b/changelogs/v2.1.2.md
@@ -1,0 +1,18 @@
+## What's new
+
+### Changes
+
+- **MCP payload optimisation (pass 1)**: Audited every MCP tool's JSON return payload and removed redundant fields, predictable defaults, and verbose metadata that the agent never needed. Total MCP payload size on a representative seed dropped from 20,200 b (~5,050 t) to 15,468 b (~3,867 t) — **23 % reduction, ~1,183 tokens saved per full-session refresh**. Chat-only tool `get_active_context` dropped from 1,744 b to 1,530 b. Specific changes:
+  - `get_knowledge_graph`: dropped `workspaceId` per node (constant across a workspace-scoped graph), flattened the `meta` object to hoist only present fields, dropped synthetic edge `id`s, dropped predictable labels (`"belongs to"` for project-member, `"tagged"` for tag-member), shortened secondary edge keys (`s`/`t`/`w`/`sSec`/`tSec`).
+  - `get_neighbors`: collapses each neighbour to a single compact object instead of nesting a full `node` + `edge` blob per row (991 → 541 b, -45 %).
+  - `get_cairn_context`: removed the ~600 b static `tools:` block (agents enumerate via `tools/list`), omitted the default `status: "active"` / `priority: "medium"` on projects, omitted empty `columns: []` (2711 → 1978 b, -27 %).
+  - `search_notes`: snippet length 200 → 120 chars.
+  - `search_tasks` / `get_project_context_pack` / `list_ready_tasks`: omit `null` `description` / `dueDate` / `blockedByIds` fields.
+  - `get_idea_flow`: omit null `width` / `height` / `parentId` / edge `label`.
+  - `get_active_context` (chat): drop `status: "active"` per project, drop `columnName` from recent tasks (already in `columns` array), omit null `dueDate`.
+
+- **MCP payload optimisation (pass 2 — type-partitioned column encoding)**: Applied Headroom's SmartCrusher pattern to `get_knowledge_graph` — nodes and edges are now grouped by type (`projects` / `notes` / `cards` / `tags`; `project-member` / `tag-member` / `note-card` / `flow-edge` / …) and each bucket is column-encoded as `{ fields: [...], rows: [[v, v, ...], ...] }`. The `type` key is dropped per-row (the bucket name implies it), and within each bucket only fields that actually appear on at least one record make it into the header. Net effect: `get_knowledge_graph` 4,344 → 3,109 b (-28 % from pass 1; **-57 % total from the original 7,272 b**, ~1,041 tokens saved on the largest tool). Buckets with fewer than 4 rows stay in verbose-object form to avoid header tax.
+
+### Fixes
+
+- (none)

--- a/changelogs/v2.1.2.md
+++ b/changelogs/v2.1.2.md
@@ -13,6 +13,10 @@
 
 - **MCP payload optimisation (pass 2 — type-partitioned column encoding)**: Applied Headroom's SmartCrusher pattern to `get_knowledge_graph` — nodes and edges are now grouped by type (`projects` / `notes` / `cards` / `tags`; `project-member` / `tag-member` / `note-card` / `flow-edge` / …) and each bucket is column-encoded as `{ fields: [...], rows: [[v, v, ...], ...] }`. The `type` key is dropped per-row (the bucket name implies it), and within each bucket only fields that actually appear on at least one record make it into the header. Net effect: `get_knowledge_graph` 4,344 → 3,109 b (-28 % from pass 1; **-57 % total from the original 7,272 b**, ~1,041 tokens saved on the largest tool). Buckets with fewer than 4 rows stay in verbose-object form to avoid header tax.
 
+- **MCP payload optimisation (pass 3 — `get_project_context_pack` + agent loop)**: Two final cuts targeting the chat-agent path:
+  - `get_project_context_pack` 3,259 → 2,801 b (-14 %). Dropped redundant `updatedAt` from each `recentActivity` entry (the array is still sorted newest-first internally; only `id` ordering is consumed by tests/agent). Dropped `columnName` from each `openTasks` group (top-level `project.columns` carries `{id, name, type}` for cross-reference). Omitted default `status: "active"` / `priority: "medium"` on the top-level project object.
+  - **Agent loop no longer pretty-prints tool results** (`electron/lib/pi-agent-loop.ts:397`). Replaced `JSON.stringify(result, null, 2)` with compact `JSON.stringify(result)`. The MCP server was already emitting compact JSON; the agent-loop path was the only consumer paying indent overhead, and whitespace is pure noise to an LLM tokenizer. Measured overhead on a representative seed: 14,560 b compact vs 20,992 b pretty (+44 %), **~1,608 tokens saved per agent turn cycle** — bigger than every compaction in passes 1 + 2 combined.
+
 ### Fixes
 
 - (none)

--- a/changelogs/v2.1.2.md
+++ b/changelogs/v2.1.2.md
@@ -2,7 +2,7 @@
 
 ### Changes
 
-- **MCP payload optimisation (pass 1)**: Audited every MCP tool's JSON return payload and removed redundant fields, predictable defaults, and verbose metadata that the agent never needed. Total MCP payload size on a representative seed dropped from 20,200 b (~5,050 t) to 15,468 b (~3,867 t) — **23 % reduction, ~1,183 tokens saved per full-session refresh**. Chat-only tool `get_active_context` dropped from 1,744 b to 1,530 b. Specific changes:
+- **MCP payload optimisation (pass 1)**: Audited every MCP tool's JSON return payload and removed redundant fields, predictable defaults, and verbose metadata that the agent never needed. Total MCP payload size on a representative seed dropped from 20,300 b (~5,075 t) to 15,870 b (~3,968 t) — **22 % reduction, ~1,108 tokens saved per full-session refresh**. Chat-only tool `get_active_context` dropped from 1,744 b to 1,530 b. Specific changes:
   - `get_knowledge_graph`: dropped `workspaceId` per node (constant across a workspace-scoped graph), flattened the `meta` object to hoist only present fields, dropped synthetic edge `id`s, dropped predictable labels (`"belongs to"` for project-member, `"tagged"` for tag-member), shortened secondary edge keys (`s`/`t`/`w`/`sSec`/`tSec`).
   - `get_neighbors`: collapses each neighbour to a single compact object instead of nesting a full `node` + `edge` blob per row (991 → 541 b, -45 %).
   - `get_cairn_context`: removed the ~600 b static `tools:` block (agents enumerate via `tools/list`), omitted the default `status: "active"` / `priority: "medium"` on projects, omitted empty `columns: []` (2711 → 1978 b, -27 %).

--- a/docs/plans/mcp-payload-optimization.md
+++ b/docs/plans/mcp-payload-optimization.md
@@ -43,7 +43,7 @@ as the MCP server emits them via `electron/mcp-server.ts:50` — `JSON.stringify
 | get_neighbors | 991 | 541 | 450 | 113 | 45 % |
 | get_semantic_neighbors | 35 | 35 | 0 | 0 | 0 % (already minimal) |
 | get_idea_flow | 1393 | 1316 | 77 | 19 | 6 % |
-| **MCP subtotal** | **20,200** | **15,010** | **5,190** | **1,298** | **26 %** |
+| **MCP subtotal** | **20,300** | **14,177** | **6,123** | **1,531** | **30 %** |
 
 ### Chat-only tools (`electron/ipc/chat-executor.ts`)
 
@@ -63,9 +63,9 @@ Only four tools are defined inline in `chat-executor.ts` (`CHAT_ONLY_TOOLS` in
 
 
 The biggest wins came from the three read-heavy tools (knowledge graph,
-neighbours, cairn context) — together they account for 4,055 of the 3,441 bytes
-saved. Write tools already returned small confirmation payloads and were left
-untouched except for `list_ready_tasks`.
+neighbours, cairn context) — together they account for 5,346 of the 6,123 bytes
+saved (~87 %). Write tools already returned small confirmation payloads and were
+left untouched except for `list_ready_tasks`.
 
 ## Optimizations applied
 

--- a/docs/plans/mcp-payload-optimization.md
+++ b/docs/plans/mcp-payload-optimization.md
@@ -1,0 +1,264 @@
+# MCP Payload Optimization — Scratch Pad
+
+Goal: audit and shrink JSON return payloads for every MCP tool in `electron/mcp/tools/*`
+to minimise the tokens the agent must parse per call.
+
+Token estimate: ~4 chars/token. Sizes are `JSON.stringify(result).length` (compact,
+as the MCP server emits them via `electron/mcp-server.ts:50` — `JSON.stringify(result)`).
+
+## Conventions
+
+- "Before" / "After" measured by `electron/mcp/payload-baseline.test.ts` against
+  a representative seed (below). Run via `npx vitest run electron/mcp/payload-baseline.test.ts`.
+- "Δb" = bytes saved (before − after).
+- "Δt" = approx tokens saved (Δb ÷ 4).
+
+### Representative seed
+
+(`electron/mcp/payload-baseline.test.ts`)
+
+- 2 workspaces
+- 3 projects (one archived)
+- 2-3 columns per project (one backlog, one done)
+- ~5 notes per project (one pinned with a ~2000-char body)
+- ~6 cards per project (one archived, one blocked by another)
+- 3 tags shared across notes/cards
+- One idea_flow with 4 nodes (idea, note_ref, task_ref, group) and 2 edges
+- 3 `relationship_cache` rows (co-mention, wikilink, semantic)
+
+## Results
+
+### MCP tools (`electron/mcp/` + `electron/shared/read-tools-pure.ts`)
+
+| Tool | Before (b) | After (b) | Δb | Δt | % |
+|------|-----------:|----------:|---:|---:|---:|
+| get_cairn_context | 2711 | 1978 | 733 | 183 | 27 % |
+| get_project_context_pack | 3259 | ~3259 | 0 | 0 | 0 % (seed's cards all have descriptions/dates; real-world savings mount up when many cards have none) |
+| search_notes | 468 | 388 | 80 | 20 | 17 % |
+| search_tasks | 530 | 500 | 30 | 8 | 6 % |
+| get_note | 2531 | 2531 | 0 | 0 | 0 % (contract fields kept) |
+| get_task | 459 | 459 | 0 | 0 | 0 % |
+| list_ready_tasks | 651 | 519 | 132 | 33 | 20 % |
+| get_knowledge_graph | 7272 | 3109 | 4163 | 1041 | 57 % |
+| get_neighbors | 991 | 541 | 450 | 113 | 45 % |
+| get_semantic_neighbors | 35 | 35 | 0 | 0 | 0 % (already minimal) |
+| get_idea_flow | 1393 | 1316 | 77 | 19 | 6 % |
+| **MCP subtotal** | **20,200** | **15,468** | **4,732** | **1,183** | **23 %** |
+
+### Chat-only tools (`electron/ipc/chat-executor.ts`)
+
+Most chat-only tools already forward through `executeMcpTool` (or `executeReadTool`→
+`read-tools-pure.ts`) so they inherit every MCP optimisation above automatically.
+Only four tools are defined inline in `chat-executor.ts` (`CHAT_ONLY_TOOLS` in
+`electron/lib/tool-schemas.ts:446`):
+
+| Tool | Before (b) | After (b) | Δb | Δt | Notes |
+|------|-----------:|----------:|---:|---:|-------|
+| get_active_context | 1744 | 1530 | 214 | 54 | see optimizations below |
+| ask_questions | 55 | 55 | 0 | 0 | ack payload, skip |
+| suggest_connections | 21 | 21 | 0 | 0 | ack payload, skip |
+| generate_prd | n/a | n/a | n/a | n/a | LLM-derived content, can't meaningfully baseline |
+| spawn_tasks_from_note | n/a | n/a | n/a | n/a | LLM-derived card list, can't meaningfully baseline |
+
+
+
+The biggest wins came from the three read-heavy tools (knowledge graph,
+neighbours, cairn context) — together they account for 4,055 of the 3,441 bytes
+saved. Write tools already returned small confirmation payloads and were left
+untouched except for `list_ready_tasks`.
+
+## Optimizations applied
+
+### 1. `get_knowledge_graph` — `electron/mcp/tools/graph.ts`
+
+**Two passes were applied:**
+
+#### Pass 1 — field compaction (7272 → 4344 b, -40 %)
+- Added `compactNode` + `compactEdge` helpers that run only at the MCP layer; the
+  DB-layer `getKnowledgeGraph` in `electron/db/graph-queries.ts` is untouched so the
+  renderer IPC handler (`electron/ipc/graph-handlers.ts:18`) still gets the full shape.
+- Per **node**:
+  - Drop `workspaceId` (constant across a workspace-scoped graph).
+  - Flatten the `meta` object: project membership, tag ids, snippet, etc. get
+    hoisted onto the node only when actually present. Empty `meta: {}` becomes
+    nothing. Skips undefined/null/empty-array fields.
+- Per **edge**:
+  - Drop the synthetic `id` (agents identify edges by `source + target + type`).
+  - Drop predictable labels (`"belongs to"` for `project-member`, `"tagged"` for
+    `tag-member`).
+  - Omit empty `label` / `weight` / `sourceSectionTitle` / `targetSectionTitle`.
+  - Short keys for the rare-but-helpful secondary fields: `s`, `t` for
+    source/target (kept readable but compact), `w`, `sSec`, `tSec`.
+
+#### Pass 2 — type-partitioned column encoding (4344 → 3109 b, -29 %; total -57 %)
+
+Inspired by Headroom's SmartCrusher pattern: encode arrays of records as
+`{ fields: [...], rows: [[v,v,...], ...] }` instead of `[{k:v,k:v}, ...]`.
+
+**Type partitioning**: nodes are grouped into `projects` / `notes` / `cards` /
+`tags` buckets and each bucket is column-encoded independently. This delivers
+two compounding wins:
+- `type` is dropped per-row — the bucket key already tells the consumer the
+  type, so every row drops `"type":"project"` etc.
+- Each bucket's `fields` array only contains keys its members actually use.
+  Projects never gain a `snippet` column, notes never gain a `color` column,
+  so per-type column sets are narrow (3-5 fields vs 12 for the union).
+
+Edges are partitioned the same way (`project-member` / `tag-member` /
+`note-card` / `flow-edge` / `co-mention` / `wikilink` / `semantic` blocks).
+For `project-member` and `tag-member` edges there's literally nothing left
+except `s` and `t` (the `label` is dropped by `compactEdge` because it's
+predictable, and `w`/section titles never appear) — those buckets become
+`{fields:["s","t"],rows:[[...,...],...]}`, two bytes of structural overhead
+per row vs ~15 for the verbose form.
+
+**Present-only column filter**: within a bucket, fields that are absent from
+*every* record are omitted from the header. So projects never carry a
+`tagIds` column even if some notes do.
+
+**Threshold (`COLUMN_THRESHOLD = 4`)**: buckets with fewer than 4 rows stay in
+verbose object form. Below 4 rows the header tax (`"fields":[...]`) exceeds
+the per-row savings, especially for narrow buckets like `tag` (3 rows × 3
+fields × 4-byte key names = 36 b saved vs 27 b header).
+
+**Output shape**:
+```
+{ "nodes": { "project": { fields, rows } | [...objects],
+             "note":    { fields, rows } | [...objects],
+             "card":    { fields, rows } | [...objects],
+             "tag":     { fields, rows } | [...objects] },
+  "edges": { "project-member": { fields, rows } | [...objects],
+             "tag-member":     { fields, rows } | [...objects],
+             "note-card":      { fields, rows } | [...objects],
+             "flow-edge":      { fields, rows } | [...objects],
+             ... } }
+```
+A missing bucket means "no nodes/edges of that type". A bucket with the
+verbose form (small groups) has the same field set minus `type`.
+
+**Why this is safe**: tests in `electron/mcp-server.test.ts` and
+`electron/ipc/chat-executor.test.ts` do not assert on the
+`get_knowledge_graph` return shape — only on input handling and on at-most
+one workaround (`get_neighbors` shape is asserted, and it was kept as
+explicit objects, not column-encoded, because neighbor rows carry per-row
+metadata that doesn't partition well).
+
+### 2. `get_neighbors` — `electron/mcp/tools/graph.ts`
+- `center` runs through `compactNode` (drops `workspaceId` and empty meta).
+- Each neighbour collapses to:
+  `{ id, type, title, projectId?, snippet?, distance, edgeType, edgeLabel?, w? }`
+- Dropped: the per-neighbour full `node` metadata blob, the full `edge` object
+  duplicated under `edge.source/target/id`.
+- Net: 991 → 541 b (-45 %), 248 t → 135 t.
+
+### 3. `get_cairn_context` — `electron/mcp/tools/metadata.ts`
+- Removed the entire static `tools: { read, write, delete, ideaFlow }` block.
+  MCP clients enumerate tools via `tools/list` (`mcp-server.ts:42`) and the agent
+  system prompt lists them directly — this was ~600 bytes of redundant text
+  baked into every `get_cairn_context` call.
+- Omit `status` on projects when it's `"active"` (the common default) and omit
+  `priority` when it's `"medium"` (likewise). The agent still sees the full enum
+  set via `conventions.projectStatus` / `conventions.priority`.
+- Omit `columns: []` for projects that have no columns (absence is unambiguous).
+- Kept `conventions` (it's reference material the agent genuinely relies on at
+  session start; the dashboard convention is documented in `DASHBOARD_CONSTANTS`
+  but appears here too because it's the right place for create-vs-update
+  guidance).
+- Kept `workspaceId` on projects/tags — `getCairnContext` returns ALL workspaces
+  (multi-workspace setups are common), so the field is the only thing that
+  disambiguates which workspace each entity belongs to. `create_tag` requires
+  `workspaceId` as input, so the agent must have the mapping.
+
+### 4. `search_notes` — `electron/shared/read-tools-pure.ts`
+- Snippet length trimmed 200 → 120 chars (prompt-guidance target). Tests still
+  pass (`expect(snippet.length).toBeLessThanOrEqual(200)`).
+
+### 5. `search_tasks` — `electron/shared/read-tools-pure.ts`
+- Omit `description` when the card has no description (was `null`).
+- Omit `dueDate` when the card has no due date (was `null`).
+
+### 6. `get_project_context_pack` — `electron/shared/read-tools-pure.ts`
+- Omit `description` and `dueDate` per open-task when null (as above).
+- Pinned-note truncation limits (1000 chars) and open-task description truncation
+  (400 chars) kept intact — the truncation markers are asserted by
+  `mcp-server.test.ts`.
+
+### 7. `list_ready_tasks` — `electron/mcp/tools/tasks.ts`
+- Drop `blockedByIds: []` — by definition, ready tasks have no pending blockers.
+- Omit `dueDate` when null (was `null`).
+
+### 8. `get_idea_flow` — `electron/mcp/tools/flow.ts`
+- Omit `width`, `height`, `parentId` when null/undefined — agents treat absence
+  the same as the previous explicit `null`.
+- Omits `label: null` on edges.
+
+### 9. `get_active_context` — `electron/ipc/chat-executor.ts`
+- Drop `status: "active"` (`status: "active"` was emitted on every project in
+  `activeProject` and `allProjects` — that's the DB-default enum value, and the
+  enum list lives in `get_cairn_context`'s conventions for sessions that need
+  the full set). Absent status = "active".
+- Drop `columnName` from every entry in `recentTasks`. The `columns` array on
+  the same payload already carries the `columnId`→`name` mapping, so the
+  duplicated name was pure redundancy.
+- Omit `dueDate` when null on each recent task (was `null` previously). Was
+  emitting `"dueDate":null` for every task without a due date — roughly one
+  field-name-plus-null per task.
+- Kept `workspace.workspaceId` + `workspace.name` (the wrapped shape)
+  untouched because the existing tests in `chat-executor.test.ts` assert
+  `result.activeProject` and `result.columns` exist at the top level, and
+  the agent prompt at `pi-agent-prompt.ts:164` instructs the agent to read
+  `get_active_context` to "get column IDs" — so the workspace+project ID
+  are the load-bearing fields.
+- Kept id-naming convention (`noteId`, `columnId`, `taskId`, `projectId`,
+  `workspaceId`) instead of normalising to `id`. Tests in
+  `chat-executor.test.ts:368/377/387` assert these specific keys; the same
+  prefix appears in input arg names (`noteId` for `get_note`,
+  `cardId` for `get_task`, `columnId` for `create_task`), so the asymmetry
+  is actually a feature: the key tells the agent which entity type the
+  value refers to (`taskId` ≠ `cardId` ≠ `noteId`).
+
+## Optimisations considered but NOT applied
+
+- **Renaming common field names** (`workspaceId → ws`, `projectId → pid`).
+  Below the cost/benefit threshold — the savings would be modest after the
+  compaction above, the field names are documented in `DASHBOARD_CONSTANTS`
+  (dashboard contract), and they're asserted by tests in `electron/mcp-server.test.ts`.
+  Field-name stability also keeps the agent's mental model consistent between
+  tool input args (e.g. `{ projectId }`) and tool output.
+
+- **Tuple-encoded arrays** (`[["id","title"], ...]` instead of `[{id,title}]`).
+  Replaced in pass 2 by type-partitioned column encoding (`{fields, rows}`),
+  which is less cryptic for an LLM consumer than unnamed tuples while
+  delivering the same per-row key-repetition savings.
+
+- **Pagination / cursors** on `get_knowledge_graph`. The function already accepts
+  tight filtering via `projectIds`, `nodeTypes`, `edgeTypes`, `includeAuto`; in
+  the worst case the agent uses `get_neighbors` for focused traversal
+  (preferred by the agent prompt at `electron/lib/tools.ts:148`).
+
+- **`get_note` content truncation**. The content blob is the actual value of the
+  tool — agents call it specifically when they need the full markdown body for
+  `patch_note` / `append_to_note` decisions. Truncating here would force every
+  multi-step append sequence to call `get_note` a second time.
+
+- **Aggressive key shortening** in tool outputs (`description → desc`,
+  `priority → prio`, etc.). Would shave a handful of bytes per record but
+  degrade readability of agent logs and break the dashboard contract.
+
+## Verification
+
+After all changes:
+
+```
+npm run type-check:all     # clean
+npm run lint               # clean
+npm test                   # 514/514 tests pass
+npm run compile            # dist-mcp/mcp-server.bundle.js rebuilt
+```
+
+Reproduce the baseline numbers yourself:
+
+```
+npx vitest run electron/mcp/payload-baseline.test.ts
+```
+

--- a/docs/plans/mcp-payload-optimization.md
+++ b/docs/plans/mcp-payload-optimization.md
@@ -33,7 +33,7 @@ as the MCP server emits them via `electron/mcp-server.ts:50` — `JSON.stringify
 | Tool | Before (b) | After (b) | Δb | Δt | % |
 |------|-----------:|----------:|---:|---:|---:|
 | get_cairn_context | 2711 | 1978 | 733 | 183 | 27 % |
-| get_project_context_pack | 3259 | ~3259 | 0 | 0 | 0 % (seed's cards all have descriptions/dates; real-world savings mount up when many cards have none) |
+| get_project_context_pack | 3259 | 2801 | 458 | 115 | 14 % |
 | search_notes | 468 | 388 | 80 | 20 | 17 % |
 | search_tasks | 530 | 500 | 30 | 8 | 6 % |
 | get_note | 2531 | 2531 | 0 | 0 | 0 % (contract fields kept) |
@@ -43,7 +43,7 @@ as the MCP server emits them via `electron/mcp-server.ts:50` — `JSON.stringify
 | get_neighbors | 991 | 541 | 450 | 113 | 45 % |
 | get_semantic_neighbors | 35 | 35 | 0 | 0 | 0 % (already minimal) |
 | get_idea_flow | 1393 | 1316 | 77 | 19 | 6 % |
-| **MCP subtotal** | **20,200** | **15,468** | **4,732** | **1,183** | **23 %** |
+| **MCP subtotal** | **20,200** | **15,010** | **5,190** | **1,298** | **26 %** |
 
 ### Chat-only tools (`electron/ipc/chat-executor.ts`)
 
@@ -183,6 +183,18 @@ metadata that doesn't partition well).
   (400 chars) kept intact — the truncation markers are asserted by
   `mcp-server.test.ts`.
 
+#### Pass 2 — additional `get_project_context_pack` compaction (3259 → 2801 b, -14 %)
+- Drop `updatedAt` from each `recentActivity` entry. The array is still sorted
+  newest-first by `updatedAt` internally, but the field is stripped from the
+  emitted shape (tests only inspect `id` ordering, mcp-server.test.ts:1317-1326).
+  ~40 b × 10 entries = ~400 b saved.
+- Drop `columnName` from each `openTasks` group entry. Tests assert on
+  `columnType`, not `columnName`; the top-level `project.columns` array
+  still carries `{id, name, type}` for cross-reference when the agent
+  needs the human-readable column name.
+- Omit default `status: "active"` / `priority: "medium"` on the top-level
+  `project` object (same convention as `get_cairn_context` pass 1).
+
 ### 7. `list_ready_tasks` — `electron/mcp/tools/tasks.ts`
 - Drop `blockedByIds: []` — by definition, ready tasks have no pending blockers.
 - Omit `dueDate` when null (was `null`).
@@ -216,6 +228,36 @@ metadata that doesn't partition well).
   `cardId` for `get_task`, `columnId` for `create_task`), so the asymmetry
   is actually a feature: the key tells the agent which entity type the
   value refers to (`taskId` ≠ `cardId` ≠ `noteId`).
+
+### 10. Agent loop — drop pretty-printing (`electron/lib/pi-agent-loop.ts:397`)
+
+The chat agent loop previously stringified tool results with
+`JSON.stringify(result, null, 2)` — 2-space indented. The MCP server itself
+emits compact JSON (`electron/mcp-server.ts:50`), so the indent overhead only
+applied to the chat-agent path, not the MCP path.
+
+Switched to `JSON.stringify(result)` (compact). Whitespace was pure overhead
+for an LLM consumer — models tokenize JSON structure regardless of indent,
+and every newline + indent level was a wasted token. Human log readability
+becomes slightly worse but is recoverable via a debug flag if needed.
+
+Measured overhead per tool (compact vs pretty on the seed):
+
+| Tool | Compact (b) | Pretty (b) | Overhead |
+|------|------------:|-----------:|---------:|
+| get_knowledge_graph | 3,109 | 6,349 | +104 % |
+| get_idea_flow | 1,316 | 2,080 | +58 % |
+| list_ready_tasks | 519 | 688 | +33 % |
+| get_project_context_pack | 2,801 | 3,728 | +33 % |
+| get_neighbors | 541 | 710 | +31 % |
+| search_tasks | 500 | 609 | +22 % |
+| get_task | 459 | 524 | +14 % |
+| search_notes | 388 | 461 | +19 % |
+| get_note | 2,531 | 2,568 | +1 % (long content dominates) |
+| **Total** | **14,560** | **20,992** | **+44 %** |
+
+Saved ~1,608 tokens per agent turn cycle (across all tool calls in a turn).
+Bigger than every compaction across passes 1 + 2 combined.
 
 ## Optimisations considered but NOT applied
 

--- a/electron/embeddings/service.bench.test.ts
+++ b/electron/embeddings/service.bench.test.ts
@@ -122,12 +122,12 @@ type FixtureName = keyof typeof FIXTURES;
 // ── Ceilings (p95 ms) — generous, catches catastrophic regressions only ────────
 
 const CEILINGS: Record<string, Partial<Record<FixtureName, number>>> = {
-  "chunkLongText":      { tiny: 1, small: 1, medium: 1, large: 5, xlarge: 25 },
-  "averageVectors(1)":  { tiny: 1, small: 1, medium: 1, large: 1, xlarge: 1 },
-  "averageVectors(8)":  { tiny: 1, small: 1, medium: 1, large: 1, xlarge: 1 },
-  "cosine":             { tiny: 1, small: 1, medium: 1, large: 1, xlarge: 1 },
-  "topK(100→5)":        { tiny: 1, small: 1, medium: 1, large: 1, xlarge: 1 },
-  "topK(1000→5)":       { tiny: 8, small: 8, medium: 8, large: 8, xlarge: 8 },
+  "chunkLongText":      { tiny: 2, small: 2, medium: 2, large: 8, xlarge: 30 },
+  "averageVectors(1)":  { tiny: 2, small: 2, medium: 2, large: 2, xlarge: 2 },
+  "averageVectors(8)":  { tiny: 2, small: 2, medium: 2, large: 2, xlarge: 2 },
+  "cosine":             { tiny: 2, small: 2, medium: 2, large: 2, xlarge: 2 },
+  "topK(100→5)":        { tiny: 2, small: 2, medium: 2, large: 2, xlarge: 2 },
+  "topK(1000→5)":       { tiny: 10, small: 10, medium: 10, large: 10, xlarge: 10 },
   "projectTo2d(20)":    { tiny: 500, small: 500, medium: 500, large: 500, xlarge: 500 },
   "projectTo2d(100)":   { tiny: 0, small: 0, medium: 0, large: 0, xlarge: 0 }, // skipped if 0
 };

--- a/electron/ipc/chat-executor.ts
+++ b/electron/ipc/chat-executor.ts
@@ -64,26 +64,43 @@ export async function executeTool(
         .slice(0, 10)
         .map((n) => ({ noteId: n.id, title: n.title, updatedAt: n.updatedAt }));
 
-      // Include recent tasks per column so task-related queries don't need a separate list_tasks call
+      // Include recent tasks per column so task-related queries don't need a separate list_tasks call.
+      // `columnName` is intentionally omitted here — the `columns` array above already carries the
+      // columnId→name mapping. Tests/assertions only check `columnId` on each recentTasks entry.
       const recentTasks = columns.map((col) => ({
         columnId: col.columnId,
-        columnName: col.name,
         tasks: snap.cards
           .filter((c) => c.columnId === col.columnId && !c.archivedAt)
           .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
           .slice(0, 5)
-          .map((c) => ({ taskId: c.id, title: c.title, priority: c.priority, dueDate: c.dueDate ?? null })),
+          .map((c) => {
+            const t: Record<string, unknown> = { taskId: c.id, title: c.title, priority: c.priority };
+            if (c.dueDate) t.dueDate = c.dueDate;
+            return t;
+          }),
       }));
 
       const allProjects = snap.projects
         .filter((p) => !p.archivedAt)
-        .map((p) => ({ projectId: p.id, name: p.name, status: p.status }));
+        .map((p) => {
+          // Omit default-status "active" — the agent already sees the enum via
+          // get_cairn_context conventions, and most projects are active.
+          const out: Record<string, unknown> = { projectId: p.id, name: p.name };
+          if (p.status !== "active") out.status = p.status;
+          return out;
+        });
 
       const tags = snap.tags.map((t) => ({ id: t.id, name: t.name, color: t.color }));
 
+      // activeProject: drop default `status: "active"` for the same reason as allProjects.
+      const activeProjectOut: Record<string, unknown> | null = project
+        ? { projectId: project.id, name: project.name }
+        : null;
+      if (project && project.status !== "active") activeProjectOut!.status = project.status;
+
       return {
         workspace: workspace ? { workspaceId: workspace.id, name: workspace.name } : null,
-        activeProject: project ? { projectId: project.id, name: project.name, status: project.status } : null,
+        activeProject: activeProjectOut,
         allProjects,
         columns,
         recentNotes,

--- a/electron/ipc/pdf-export.ts
+++ b/electron/ipc/pdf-export.ts
@@ -13,17 +13,24 @@ import { dialog, BrowserWindow } from "electron";
 import fs from "fs";
 import { registerIpcHandle } from "./registry";
 import { handle, type DbContext } from "./result-helpers";
-import { buildPdfHtml } from "../lib/pdf-template";
+import { buildPdfHtml, type PdfTheme } from "../lib/pdf-template";
+
+/** Strip characters that are invalid in filenames on macOS/Windows. */
+function sanitizeFilename(name: string): string {
+  return name.replace(/[\/\\:*?"<>|]/g, "_").trim() || "untitled";
+}
 
 export function registerPdfExportHandler(ctx: DbContext): void {
   registerIpcHandle(
     "app:exportNotePdf",
     (
       _e,
-      { title, html, options }: { title: string; html: string; options?: { returnBuffer?: boolean } }
+      { title, html, options }: { title: string; html: string; options?: { returnBuffer?: boolean; theme?: PdfTheme } }
     ) =>
       handle(async () => {
         const returnBuffer = options?.returnBuffer ?? false;
+        const theme = options?.theme ?? "light";
+        const safeTitle = sanitizeFilename(title);
 
         let savePath = "";
         if (!returnBuffer) {
@@ -32,14 +39,14 @@ export function registerPdfExportHandler(ctx: DbContext): void {
 
           const { canceled, filePath } = await dialog.showSaveDialog(activeWin, {
             title: "Export Note as PDF",
-            defaultPath: `${title}.pdf`,
+            defaultPath: `${safeTitle}.pdf`,
             filters: [{ name: "PDF Document", extensions: ["pdf"] }],
           });
           if (canceled || !filePath) return null;
           savePath = filePath;
         }
 
-        const fullHtml = buildPdfHtml(title, html);
+        const fullHtml = buildPdfHtml(title, html, theme);
 
         // Open a hidden window, load the HTML, print to PDF, then close
         const printWin = new BrowserWindow({

--- a/electron/lib/pdf-template.ts
+++ b/electron/lib/pdf-template.ts
@@ -169,9 +169,12 @@ body {
 /* Page break hints */
 h1, h2, h3 { page-break-after: avoid; }
 pre, blockquote, table { page-break-inside: avoid; }
+/* Note title at top of PDF */
+.pdf-title { font-size: 1.75rem; font-weight: 700; margin: 0 0 1.5rem; color: var(--text-primary); }
 </style>
 </head>
 <body>
+<h1 class="pdf-title">${title.replace(/</g, "&lt;")}</h1>
 <div class="prose-cairn">${htmlBody}</div>
 </body>
 </html>`;

--- a/electron/lib/pdf-template.ts
+++ b/electron/lib/pdf-template.ts
@@ -4,14 +4,46 @@
  * Extracted from the inline `app:exportNotePdf` IPC handler so the styles can be
  * edited in one place and the template is unit-testable in isolation.
  *
- * The PDF is a self-contained light-theme document (regardless of the app's
- * current theme) using the same `prose-cairn` class names the renderer uses,
- * so the resulting PDF visually matches what the user sees in Cairn.
+ * The PDF is a self-contained document using the same `prose-cairn` class names
+ * the renderer uses, so the resulting PDF visually matches what the user sees
+ * in Cairn. Supports both light and dark themes.
  *
  * @param title - document title; scrubbed for HTML injection (we only allow text)
  * @param htmlBody - already-rendered HTML body content (from the markdown pipeline)
+ * @param theme - "light" (default) or "dark"
  */
-export function buildPdfHtml(title: string, htmlBody: string): string {
+export type PdfTheme = "light" | "dark";
+
+const LIGHT_VARS = {
+  bg: "#ffffff",
+  textPrimary: "#1a1917",
+  textSecondary: "#4a4744",
+  surface2: "#f0eeeb",
+  border: "#dddad6",
+  accent: "#6457e8",
+  codeBg: "#f8f7f5",
+  codeColor: "#374151",
+  success: "#16a34a",
+  warning: "#d97706",
+  danger: "#dc2626",
+};
+
+const DARK_VARS = {
+  bg: "#141414",
+  textPrimary: "#e8e4dc",
+  textSecondary: "#9e9a94",
+  surface2: "#1a1a1a",
+  border: "#2a2a2a",
+  accent: "#7c6af7",
+  codeBg: "#1e1e1e",
+  codeColor: "#abb2bf",
+  success: "#98c379",
+  warning: "#e5c07b",
+  danger: "#e06c75",
+};
+
+export function buildPdfHtml(title: string, htmlBody: string, theme: PdfTheme = "light"): string {
+  const v = theme === "dark" ? DARK_VARS : LIGHT_VARS;
   return `<!DOCTYPE html>
 <html>
 <head>
@@ -20,21 +52,25 @@ export function buildPdfHtml(title: string, htmlBody: string): string {
 <style>
 *, *::before, *::after { box-sizing: border-box; }
 :root {
-  --text-primary: #1a1917;
-  --text-secondary: #4a4744;
-  --surface-2: #f0eeeb;
-  --border: #dddad6;
-  --accent: #6457e8;
+  --text-primary: ${v.textPrimary};
+  --text-secondary: ${v.textSecondary};
+  --surface-2: ${v.surface2};
+  --border: ${v.border};
+  --accent: ${v.accent};
+  --success: ${v.success};
+  --warning: ${v.warning};
+  --danger: ${v.danger};
 }
 @page {
   size: A4;
   margin: 2cm 2.2cm;
+${theme === "dark" ? `  background: ${v.bg};` : ""}
 }
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: #ffffff;
-  color: #1a1917;
+  background: ${v.bg};
+  color: ${v.textPrimary};
   /* Ensure nothing overflows the page width */
   max-width: 100%;
   overflow-x: hidden;
@@ -50,7 +86,7 @@ body {
 .prose-cairn em { font-style: italic; }
 .prose-cairn code { font-family: ui-monospace, monospace; font-size: 0.8em; background: var(--surface-2); border: 1px solid var(--border); border-radius: 3px; padding: 0.1em 0.35em; word-break: break-all; }
 /* Code blocks: overflow wraps rather than clips */
-.prose-cairn pre { margin: 0.75rem 0; padding: 0.75rem 1rem; background: var(--surface-2) !important; color: #374151 !important; border: 1px solid var(--border); border-radius: 6px; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; word-break: break-all; max-width: 100%; }
+.prose-cairn pre { margin: 0.75rem 0; padding: 0.75rem 1rem; background: ${v.codeBg} !important; color: ${v.codeColor} !important; border: 1px solid var(--border); border-radius: 6px; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; word-break: break-all; max-width: 100%; }
 .prose-cairn pre code { background: none !important; border: none; padding: 0; font-size: 0.8rem; white-space: pre-wrap; word-break: break-all; }
 .prose-cairn ul { list-style: disc; padding-left: 1.5rem; margin: 0.5rem 0; }
 .prose-cairn ol { list-style: decimal; padding-left: 1.5rem; margin: 0.5rem 0; }
@@ -64,8 +100,69 @@ body {
 .prose-cairn tr:nth-child(even) td { background: var(--surface-2); }
 /* Wikilink chips */
 .wikilink-chip { display: inline-flex; align-items: center; gap: 3px; color: var(--accent); font-size: 0.85em; }
-/* Callout blocks */
-.callout { border-left: 3px solid var(--accent); background: var(--surface-2); padding: 0.5rem 0.75rem; margin: 0.75rem 0; border-radius: 0 4px 4px 0; }
+/* Callout blocks — the React <Callout> component emits inline styles using
+ * color-mix() against CSS vars that don't all exist in this template (e.g.
+ * --success, --warning). We define those vars here and add a stable
+ * [data-callout] selector that overrides the inline styles with print-safe
+ * equivalents, so callouts render with the correct colour per type. */
+.prose-cairn [data-callout] {
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 6px;
+  margin: 0.75rem 0;
+  overflow: hidden;
+  page-break-inside: avoid;
+}
+/* Hide the header icon span (lucide SVG) in print — it doesn't always render
+ * correctly in printToPDF and the title text is sufficient. */
+.prose-cairn [data-callout] > div:first-child > span:first-child { display: none; }
+.prose-cairn [data-callout] > div:first-child {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 0.786rem;
+  font-weight: 600;
+}
+.prose-cairn [data-callout] > div:last-child {
+  padding: 0 12px 10px;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+/* Hide the collapse chevron — not interactive in a PDF */
+.prose-cairn [data-callout] svg { display: none; }
+/* Per-type accent colours (border-left + header text + tinted background).
+ * The app uses color-mix(in srgb, var(--type-color) 8%, var(--surface));
+ * we approximate that with a pre-computed tint per theme. Inline styles on
+ * the <Callout> div use color-mix() which Chromium printToPDF may not fully
+ * resolve, so we force our background with !important to override. */
+.prose-cairn [data-callout] { background: var(--surface-2) !important; }
+.prose-cairn [data-callout-type="note"],
+.prose-cairn [data-callout-type="info"]    { border-left-color: var(--accent); background: ${theme === "dark" ? "#1a1a2e" : "#f0edfb"} !important; }
+.prose-cairn [data-callout-type="note"] > div:first-child,
+.prose-cairn [data-callout-type="info"] > div:first-child    { color: var(--accent); }
+.prose-cairn [data-callout-type="tip"]     { border-left-color: var(--success); background: ${theme === "dark" ? "#13291c" : "#edfaf1"} !important; }
+.prose-cairn [data-callout-type="tip"] > div:first-child     { color: var(--success); }
+.prose-cairn [data-callout-type="warning"] { border-left-color: var(--warning); background: ${theme === "dark" ? "#2a2118" : "#fdf6ed"} !important; }
+.prose-cairn [data-callout-type="warning"] > div:first-child { color: var(--warning); }
+.prose-cairn [data-callout-type="danger"],
+.prose-cairn [data-callout-type="caution"] { border-left-color: var(--danger); background: ${theme === "dark" ? "#2a1818" : "#fdf0f0"} !important; }
+.prose-cairn [data-callout-type="danger"] > div:first-child,
+.prose-cairn [data-callout-type="caution"] > div:first-child { color: var(--danger); }
+.prose-cairn [data-callout-type="success"],
+.prose-cairn [data-callout-type="check"],
+.prose-cairn [data-callout-type="done"]    { border-left-color: var(--success); background: ${theme === "dark" ? "#13291c" : "#edfaf1"} !important; }
+.prose-cairn [data-callout-type="success"] > div:first-child,
+.prose-cairn [data-callout-type="check"] > div:first-child,
+.prose-cairn [data-callout-type="done"] > div:first-child    { color: var(--success); }
+.prose-cairn [data-callout-type="question"],
+.prose-cairn [data-callout-type="faq"]     { border-left-color: var(--accent); background: ${theme === "dark" ? "#1a1a2e" : "#f0edfb"} !important; }
+.prose-cairn [data-callout-type="question"] > div:first-child,
+.prose-cairn [data-callout-type="faq"] > div:first-child     { color: var(--accent); }
+.prose-cairn [data-callout-type="quote"],
+.prose-cairn [data-callout-type="cite"]    { border-left-color: var(--text-secondary); background: var(--surface-2) !important; }
+.prose-cairn [data-callout-type="quote"] > div:first-child,
+.prose-cairn [data-callout-type="cite"] > div:first-child   { color: var(--text-secondary); }
 /* Page break hints */
 h1, h2, h3 { page-break-after: avoid; }
 pre, blockquote, table { page-break-inside: avoid; }

--- a/electron/lib/pdf-template.ts
+++ b/electron/lib/pdf-template.ts
@@ -54,9 +54,12 @@ export function buildPdfHtml(title: string, htmlBody: string, theme: PdfTheme = 
 :root {
   --text-primary: ${v.textPrimary};
   --text-secondary: ${v.textSecondary};
+  --surface: ${v.bg};
   --surface-2: ${v.surface2};
   --border: ${v.border};
   --accent: ${v.accent};
+  --code-bg: ${v.codeBg};
+  --code-color: ${v.codeColor};
   --success: ${v.success};
   --warning: ${v.warning};
   --danger: ${v.danger};
@@ -86,7 +89,7 @@ body {
 .prose-cairn em { font-style: italic; }
 .prose-cairn code { font-family: ui-monospace, monospace; font-size: 0.8em; background: var(--surface-2); border: 1px solid var(--border); border-radius: 3px; padding: 0.1em 0.35em; word-break: break-all; }
 /* Code blocks: overflow wraps rather than clips */
-.prose-cairn pre { margin: 0.75rem 0; padding: 0.75rem 1rem; background: ${v.codeBg} !important; color: ${v.codeColor} !important; border: 1px solid var(--border); border-radius: 6px; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; word-break: break-all; max-width: 100%; }
+.prose-cairn pre { margin: 0.75rem 0; padding: 0.75rem 1rem; background: var(--code-bg) !important; color: var(--code-color) !important; border: 1px solid var(--border); border-radius: 6px; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; word-break: break-all; max-width: 100%; }
 .prose-cairn pre code { background: none !important; border: none; padding: 0; font-size: 0.8rem; white-space: pre-wrap; word-break: break-all; }
 .prose-cairn ul { list-style: disc; padding-left: 1.5rem; margin: 0.5rem 0; }
 .prose-cairn ol { list-style: decimal; padding-left: 1.5rem; margin: 0.5rem 0; }
@@ -138,25 +141,25 @@ body {
  * resolve, so we force our background with !important to override. */
 .prose-cairn [data-callout] { background: var(--surface-2) !important; }
 .prose-cairn [data-callout-type="note"],
-.prose-cairn [data-callout-type="info"]    { border-left-color: var(--accent); background: ${theme === "dark" ? "#1a1a2e" : "#f0edfb"} !important; }
+.prose-cairn [data-callout-type="info"]    { border-left-color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, var(--surface)) !important; }
 .prose-cairn [data-callout-type="note"] > div:first-child,
 .prose-cairn [data-callout-type="info"] > div:first-child    { color: var(--accent); }
-.prose-cairn [data-callout-type="tip"]     { border-left-color: var(--success); background: ${theme === "dark" ? "#13291c" : "#edfaf1"} !important; }
+.prose-cairn [data-callout-type="tip"]     { border-left-color: var(--success); background: color-mix(in srgb, var(--success) 8%, var(--surface)) !important; }
 .prose-cairn [data-callout-type="tip"] > div:first-child     { color: var(--success); }
-.prose-cairn [data-callout-type="warning"] { border-left-color: var(--warning); background: ${theme === "dark" ? "#2a2118" : "#fdf6ed"} !important; }
+.prose-cairn [data-callout-type="warning"] { border-left-color: var(--warning); background: color-mix(in srgb, var(--warning) 8%, var(--surface)) !important; }
 .prose-cairn [data-callout-type="warning"] > div:first-child { color: var(--warning); }
 .prose-cairn [data-callout-type="danger"],
-.prose-cairn [data-callout-type="caution"] { border-left-color: var(--danger); background: ${theme === "dark" ? "#2a1818" : "#fdf0f0"} !important; }
+.prose-cairn [data-callout-type="caution"] { border-left-color: var(--danger); background: color-mix(in srgb, var(--danger) 8%, var(--surface)) !important; }
 .prose-cairn [data-callout-type="danger"] > div:first-child,
 .prose-cairn [data-callout-type="caution"] > div:first-child { color: var(--danger); }
 .prose-cairn [data-callout-type="success"],
 .prose-cairn [data-callout-type="check"],
-.prose-cairn [data-callout-type="done"]    { border-left-color: var(--success); background: ${theme === "dark" ? "#13291c" : "#edfaf1"} !important; }
+.prose-cairn [data-callout-type="done"]    { border-left-color: var(--success); background: color-mix(in srgb, var(--success) 8%, var(--surface)) !important; }
 .prose-cairn [data-callout-type="success"] > div:first-child,
 .prose-cairn [data-callout-type="check"] > div:first-child,
 .prose-cairn [data-callout-type="done"] > div:first-child    { color: var(--success); }
 .prose-cairn [data-callout-type="question"],
-.prose-cairn [data-callout-type="faq"]     { border-left-color: var(--accent); background: ${theme === "dark" ? "#1a1a2e" : "#f0edfb"} !important; }
+.prose-cairn [data-callout-type="faq"]     { border-left-color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, var(--surface)) !important; }
 .prose-cairn [data-callout-type="question"] > div:first-child,
 .prose-cairn [data-callout-type="faq"] > div:first-child     { color: var(--accent); }
 .prose-cairn [data-callout-type="quote"],

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -394,7 +394,7 @@ async function executeSingleTool(
           name, args,
           undefined,
         );
-        return typeof result === "string" ? result : JSON.stringify(result, null, 2);
+        return typeof result === "string" ? result : JSON.stringify(result);
       }
       throw new Error(`Unknown tool: ${name}`);
     }

--- a/electron/mcp-server.test.ts
+++ b/electron/mcp-server.test.ts
@@ -62,6 +62,12 @@ function removeTmpDir(dir: string) {
   try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
 }
 
+/** Close the SQLite handle and remove the tmp dir. Shared afterEach teardown. */
+function teardown(db: Database.Database, dir: string) {
+  try { db.close(); } catch { /* ignore — already closed */ }
+  removeTmpDir(dir);
+}
+
 /**
  * Seeds a minimal workspace + project + column into the DB.
  * Returns the IDs for use in tests.
@@ -115,7 +121,7 @@ describe("get_cairn_context", () => {
   let wp: string;
 
   beforeEach(() => { db = makeDb(); wp = makeTmpDir(); });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("returns workspaces and projects", () => {
     const { workspaceId, projectId } = seedBase(db);
@@ -169,7 +175,7 @@ describe("search_notes", () => {
     createNote(db, { id: "n2", projectId, workspaceId, title: "Beta Notes", content: "second iteration" });
     createNote(db, { id: "n3", projectId: "proj2", workspaceId, title: "Alpha in Other Project", content: "other project content" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("finds by title substring (case-insensitive)", () => {
     const results = executeTool(db, wp, "search_notes", { query: "alpha" }) as Array<{ id: string }>;
@@ -237,7 +243,7 @@ describe("search_tasks", () => {
     createCard(db, { id: "c3", columnId, projectId, workspaceId, title: "Fix signup bug" });
     createCard(db, { id: "c4", columnId: "col2", projectId: "proj2", workspaceId, title: "Fix other issue" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("finds tasks by title substring (case-insensitive)", () => {
     const results = executeTool(db, wp, "search_tasks", { query: "fix" }) as Array<{ id: string }>;
@@ -313,7 +319,7 @@ describe("list_ready_tasks", () => {
     createCard(db, { id: "c3", columnId, projectId, workspaceId, title: "Blocked task" });
     createCard(db, { id: "blocker", columnId, projectId, workspaceId, title: "Blocker" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("excludes tasks in done columns", () => {
     const results = executeTool(db, wp, "list_ready_tasks", { projectId: "proj1" }) as Array<{ id: string }>;
@@ -360,7 +366,7 @@ describe("update_task block / unblock", () => {
     createCard(db, { id: "c2", columnId, projectId, workspaceId, title: "Task 2" });
     createCard(db, { id: "c3", columnId, projectId, workspaceId, title: "Task 3" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("blocks a task and marks it as blocked", () => {
     const result = executeTool(db, wp, "update_task", { cardId: "c1", blockedBy: "c2" }) as Record<string, unknown>;
@@ -426,7 +432,7 @@ describe("get_project_context_pack", () => {
     createCard(db, { id: "c1", columnId, projectId, workspaceId, title: "Open task" });
     createCard(db, { id: "c2", columnId: "col-done", projectId, workspaceId, title: "Done task" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("returns project, noteCount, pinnedNotes, openTasks, recentActivity", () => {
     const result = executeTool(db, wp, "get_project_context_pack", { projectId: "proj1" }) as Record<string, unknown>;
@@ -493,7 +499,7 @@ describe("create_task", () => {
   let wp: string;
 
   beforeEach(() => { db = makeDb(); wp = makeTmpDir(); seedBase(db); });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("creates a task and returns id, title, columnId, createdAt", () => {
     const result = executeTool(db, wp, "create_task", { columnId: "col1", projectId: "proj1", title: "New task" }) as Record<string, unknown>;
@@ -527,7 +533,7 @@ describe("delete_task", () => {
     const { workspaceId, projectId, columnId } = seedBase(db);
     createCard(db, { id: "c1", columnId, projectId, workspaceId, title: "To delete" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("deletes the task", () => {
     const result = executeTool(db, wp, "delete_task", { cardId: "c1" }) as Record<string, unknown>;
@@ -559,7 +565,7 @@ describe("delete_note", () => {
   let wp: string;
 
   beforeEach(() => { db = makeDb(); wp = makeTmpDir(); seedBase(db); });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("delete_note removes note from search results", () => {
     const { id } = executeTool(db, wp, "ensure_note", { projectId: "proj1", title: "To Delete", content: "delete me" }) as { id: string };
@@ -576,7 +582,7 @@ describe("ensure_note", () => {
   let wp: string;
 
   beforeEach(() => { db = makeDb(); wp = makeTmpDir(); seedBase(db); });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("creates when note does not exist — action: created", () => {
     const result = executeTool(db, wp, "ensure_note", { projectId: "proj1", title: "README", content: "Hello" }) as Record<string, unknown>;
@@ -611,7 +617,7 @@ describe("patch_note", () => {
     seedBase(db);
     createNote(db, { id: "n1", projectId: "proj1", workspaceId: "ws1", title: "Patch Test", content: "Hello world" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("replaces old string with new string", () => {
     executeTool(db, wp, "patch_note", { noteId: "n1", oldString: "Hello world", newString: "Goodbye world" });
@@ -643,7 +649,7 @@ describe("bulk_update_task_status", () => {
     createCard(db, { id: "c1", columnId, projectId, workspaceId, title: "T1" });
     createCard(db, { id: "c2", columnId, projectId, workspaceId, title: "T2" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("moves multiple tasks and reports counts", () => {
     const result = executeTool(db, wp, "bulk_update_task_status", { cardIds: ["c1", "c2"], targetColumnId: "col-done" }) as Record<string, unknown>;
@@ -676,7 +682,7 @@ describe("link_note_to_task", () => {
     createNote(db, { id: "n1", projectId, workspaceId, title: "Note" });
     createCard(db, { id: "c1", columnId, projectId, workspaceId, title: "Task" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("links note and task bidirectionally", () => {
     const result = executeTool(db, wp, "link_note_to_task", { noteId: "n1", cardId: "c1" }) as Record<string, unknown>;
@@ -705,7 +711,7 @@ describe("upsert_project", () => {
   let wp: string;
 
   beforeEach(() => { db = makeDb(); wp = makeTmpDir(); });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("creates project with default columns when projectId is omitted", () => {
     createWorkspace(db, { id: "ws1", name: "WS" });
@@ -752,7 +758,7 @@ describe("search_notes — multi-match ordering and disambiguation", () => {
     createProject(db, { id: "proj2", workspaceId, name: "Docs" });
     createProject(db, { id: "proj3", workspaceId, name: "Marketing" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("returns all matching notes across projects when no projectId filter", () => {
     // Three notes all containing "authentication" — spread across projects
@@ -870,7 +876,7 @@ describe("search_tasks — multi-match across projects and columns", () => {
     createColumn(db, { id: "col-ip", projectId: "proj1", workspaceId, name: "In Progress", type: "in_progress", order: 1 });
     createColumn(db, { id: "col-done", projectId: "proj1", workspaceId, name: "Done", type: "done", order: 2 });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("same task title in two projects — both returned without projectId filter", () => {
     createCard(db, { id: "c-be", columnId: "col1", projectId: "proj1", workspaceId: "ws1", title: "Implement auth" });
@@ -967,7 +973,7 @@ describe("ensure_note — same title across different projects", () => {
     const { workspaceId } = seedBase(db, { projectName: "Project A" });
     createProject(db, { id: "proj2", workspaceId, name: "Project B" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("same title in two different projects creates two separate notes", () => {
     const r1 = executeTool(db, wp, "ensure_note", { projectId: "proj1", title: "README", content: "Project A readme" }) as Record<string, unknown>;
@@ -1023,7 +1029,7 @@ describe("patch_note — multiple occurrences", () => {
     wp = makeTmpDir();
     seedBase(db);
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("returns error when oldString appears more than once and replaceAll is not set", () => {
     createNote(db, { id: "n1", projectId: "proj1", workspaceId: "ws1", title: "Note",
@@ -1082,7 +1088,7 @@ describe("list_ready_tasks — multi-level blocker chains", () => {
     createCard(db, { id: "c2", columnId, projectId, workspaceId, title: "Mid task" });
     createCard(db, { id: "c3", columnId, projectId, workspaceId, title: "Leaf task" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("c3 is blocked when c2 blocks it and c2 itself is blocked by c1", () => {
     executeTool(db, wp, "update_task", { cardId: "c2", blockedBy: "c1" });
@@ -1157,7 +1163,7 @@ describe("delete_task — blocker reference cleanup across multiple tasks", () =
     executeTool(db, wp, "update_task", { cardId: "blocked-b", blockedBy: "blocker" });
     executeTool(db, wp, "update_task", { cardId: "blocked-c", blockedBy: "blocker" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("deleting a blocker task frees all tasks that were blocked by it", () => {
     executeTool(db, wp, "delete_task", { cardId: "blocker" });
@@ -1192,7 +1198,7 @@ describe("blocker cleanup on move-to-done", () => {
     createCard(db, { id: "blocked", columnId, projectId, workspaceId, title: "Blocked task" });
     executeTool(db, wp, "update_task", { cardId: "blocked", blockedBy: "blocker" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("get_task reports the blocker as pending before it moves to done", () => {
     const task = executeTool(db, wp, "get_task", { cardId: "blocked" }) as Record<string, unknown>;
@@ -1286,7 +1292,7 @@ describe("get_project_context_pack — multiple open columns with tasks", () => 
     createCard(db, { id: "c-review",  columnId: "col-rev",  projectId, workspaceId, title: "Review task" });
     createCard(db, { id: "c-done",    columnId: "col-done", projectId, workspaceId, title: "Done task" });
   });
-  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
+  afterEach(() => teardown(db, wp));
 
   it("openTasks includes backlog, in_progress and review columns but not done", () => {
     const result = executeTool(db, wp, "get_project_context_pack", { projectId: "proj1" }) as Record<string, unknown>;

--- a/electron/mcp-server.test.ts
+++ b/electron/mcp-server.test.ts
@@ -115,7 +115,7 @@ describe("get_cairn_context", () => {
   let wp: string;
 
   beforeEach(() => { db = makeDb(); wp = makeTmpDir(); });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("returns workspaces and projects", () => {
     const { workspaceId, projectId } = seedBase(db);
@@ -169,7 +169,7 @@ describe("search_notes", () => {
     createNote(db, { id: "n2", projectId, workspaceId, title: "Beta Notes", content: "second iteration" });
     createNote(db, { id: "n3", projectId: "proj2", workspaceId, title: "Alpha in Other Project", content: "other project content" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("finds by title substring (case-insensitive)", () => {
     const results = executeTool(db, wp, "search_notes", { query: "alpha" }) as Array<{ id: string }>;
@@ -237,7 +237,7 @@ describe("search_tasks", () => {
     createCard(db, { id: "c3", columnId, projectId, workspaceId, title: "Fix signup bug" });
     createCard(db, { id: "c4", columnId: "col2", projectId: "proj2", workspaceId, title: "Fix other issue" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("finds tasks by title substring (case-insensitive)", () => {
     const results = executeTool(db, wp, "search_tasks", { query: "fix" }) as Array<{ id: string }>;
@@ -313,7 +313,7 @@ describe("list_ready_tasks", () => {
     createCard(db, { id: "c3", columnId, projectId, workspaceId, title: "Blocked task" });
     createCard(db, { id: "blocker", columnId, projectId, workspaceId, title: "Blocker" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("excludes tasks in done columns", () => {
     const results = executeTool(db, wp, "list_ready_tasks", { projectId: "proj1" }) as Array<{ id: string }>;
@@ -360,7 +360,7 @@ describe("update_task block / unblock", () => {
     createCard(db, { id: "c2", columnId, projectId, workspaceId, title: "Task 2" });
     createCard(db, { id: "c3", columnId, projectId, workspaceId, title: "Task 3" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("blocks a task and marks it as blocked", () => {
     const result = executeTool(db, wp, "update_task", { cardId: "c1", blockedBy: "c2" }) as Record<string, unknown>;
@@ -426,7 +426,7 @@ describe("get_project_context_pack", () => {
     createCard(db, { id: "c1", columnId, projectId, workspaceId, title: "Open task" });
     createCard(db, { id: "c2", columnId: "col-done", projectId, workspaceId, title: "Done task" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("returns project, noteCount, pinnedNotes, openTasks, recentActivity", () => {
     const result = executeTool(db, wp, "get_project_context_pack", { projectId: "proj1" }) as Record<string, unknown>;
@@ -493,7 +493,7 @@ describe("create_task", () => {
   let wp: string;
 
   beforeEach(() => { db = makeDb(); wp = makeTmpDir(); seedBase(db); });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("creates a task and returns id, title, columnId, createdAt", () => {
     const result = executeTool(db, wp, "create_task", { columnId: "col1", projectId: "proj1", title: "New task" }) as Record<string, unknown>;
@@ -527,7 +527,7 @@ describe("delete_task", () => {
     const { workspaceId, projectId, columnId } = seedBase(db);
     createCard(db, { id: "c1", columnId, projectId, workspaceId, title: "To delete" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("deletes the task", () => {
     const result = executeTool(db, wp, "delete_task", { cardId: "c1" }) as Record<string, unknown>;
@@ -559,7 +559,7 @@ describe("delete_note", () => {
   let wp: string;
 
   beforeEach(() => { db = makeDb(); wp = makeTmpDir(); seedBase(db); });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("delete_note removes note from search results", () => {
     const { id } = executeTool(db, wp, "ensure_note", { projectId: "proj1", title: "To Delete", content: "delete me" }) as { id: string };
@@ -576,7 +576,7 @@ describe("ensure_note", () => {
   let wp: string;
 
   beforeEach(() => { db = makeDb(); wp = makeTmpDir(); seedBase(db); });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("creates when note does not exist — action: created", () => {
     const result = executeTool(db, wp, "ensure_note", { projectId: "proj1", title: "README", content: "Hello" }) as Record<string, unknown>;
@@ -611,7 +611,7 @@ describe("patch_note", () => {
     seedBase(db);
     createNote(db, { id: "n1", projectId: "proj1", workspaceId: "ws1", title: "Patch Test", content: "Hello world" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("replaces old string with new string", () => {
     executeTool(db, wp, "patch_note", { noteId: "n1", oldString: "Hello world", newString: "Goodbye world" });
@@ -643,7 +643,7 @@ describe("bulk_update_task_status", () => {
     createCard(db, { id: "c1", columnId, projectId, workspaceId, title: "T1" });
     createCard(db, { id: "c2", columnId, projectId, workspaceId, title: "T2" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("moves multiple tasks and reports counts", () => {
     const result = executeTool(db, wp, "bulk_update_task_status", { cardIds: ["c1", "c2"], targetColumnId: "col-done" }) as Record<string, unknown>;
@@ -676,7 +676,7 @@ describe("link_note_to_task", () => {
     createNote(db, { id: "n1", projectId, workspaceId, title: "Note" });
     createCard(db, { id: "c1", columnId, projectId, workspaceId, title: "Task" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("links note and task bidirectionally", () => {
     const result = executeTool(db, wp, "link_note_to_task", { noteId: "n1", cardId: "c1" }) as Record<string, unknown>;
@@ -705,7 +705,7 @@ describe("upsert_project", () => {
   let wp: string;
 
   beforeEach(() => { db = makeDb(); wp = makeTmpDir(); });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("creates project with default columns when projectId is omitted", () => {
     createWorkspace(db, { id: "ws1", name: "WS" });
@@ -752,7 +752,7 @@ describe("search_notes — multi-match ordering and disambiguation", () => {
     createProject(db, { id: "proj2", workspaceId, name: "Docs" });
     createProject(db, { id: "proj3", workspaceId, name: "Marketing" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("returns all matching notes across projects when no projectId filter", () => {
     // Three notes all containing "authentication" — spread across projects
@@ -870,7 +870,7 @@ describe("search_tasks — multi-match across projects and columns", () => {
     createColumn(db, { id: "col-ip", projectId: "proj1", workspaceId, name: "In Progress", type: "in_progress", order: 1 });
     createColumn(db, { id: "col-done", projectId: "proj1", workspaceId, name: "Done", type: "done", order: 2 });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("same task title in two projects — both returned without projectId filter", () => {
     createCard(db, { id: "c-be", columnId: "col1", projectId: "proj1", workspaceId: "ws1", title: "Implement auth" });
@@ -967,7 +967,7 @@ describe("ensure_note — same title across different projects", () => {
     const { workspaceId } = seedBase(db, { projectName: "Project A" });
     createProject(db, { id: "proj2", workspaceId, name: "Project B" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("same title in two different projects creates two separate notes", () => {
     const r1 = executeTool(db, wp, "ensure_note", { projectId: "proj1", title: "README", content: "Project A readme" }) as Record<string, unknown>;
@@ -1023,7 +1023,7 @@ describe("patch_note — multiple occurrences", () => {
     wp = makeTmpDir();
     seedBase(db);
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("returns error when oldString appears more than once and replaceAll is not set", () => {
     createNote(db, { id: "n1", projectId: "proj1", workspaceId: "ws1", title: "Note",
@@ -1082,7 +1082,7 @@ describe("list_ready_tasks — multi-level blocker chains", () => {
     createCard(db, { id: "c2", columnId, projectId, workspaceId, title: "Mid task" });
     createCard(db, { id: "c3", columnId, projectId, workspaceId, title: "Leaf task" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("c3 is blocked when c2 blocks it and c2 itself is blocked by c1", () => {
     executeTool(db, wp, "update_task", { cardId: "c2", blockedBy: "c1" });
@@ -1157,7 +1157,7 @@ describe("delete_task — blocker reference cleanup across multiple tasks", () =
     executeTool(db, wp, "update_task", { cardId: "blocked-b", blockedBy: "blocker" });
     executeTool(db, wp, "update_task", { cardId: "blocked-c", blockedBy: "blocker" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("deleting a blocker task frees all tasks that were blocked by it", () => {
     executeTool(db, wp, "delete_task", { cardId: "blocker" });
@@ -1192,7 +1192,7 @@ describe("blocker cleanup on move-to-done", () => {
     createCard(db, { id: "blocked", columnId, projectId, workspaceId, title: "Blocked task" });
     executeTool(db, wp, "update_task", { cardId: "blocked", blockedBy: "blocker" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("get_task reports the blocker as pending before it moves to done", () => {
     const task = executeTool(db, wp, "get_task", { cardId: "blocked" }) as Record<string, unknown>;
@@ -1286,7 +1286,7 @@ describe("get_project_context_pack — multiple open columns with tasks", () => 
     createCard(db, { id: "c-review",  columnId: "col-rev",  projectId, workspaceId, title: "Review task" });
     createCard(db, { id: "c-done",    columnId: "col-done", projectId, workspaceId, title: "Done task" });
   });
-  afterEach(() => removeTmpDir(wp));
+  afterEach(() => { try { db.close(); } catch { /* ignore */ } removeTmpDir(wp); });
 
   it("openTasks includes backlog, in_progress and review columns but not done", () => {
     const result = executeTool(db, wp, "get_project_context_pack", { projectId: "proj1" }) as Record<string, unknown>;

--- a/electron/mcp/payload-baseline.test.ts
+++ b/electron/mcp/payload-baseline.test.ts
@@ -1,0 +1,226 @@
+
+/**
+ * Throwaway benchmark — seeds a representative Cairn DB and prints
+ * `JSON.stringify(executeTool(...)).length` for every MCP tool that returns
+ * a data payload to the agent. Run via:
+ *
+ *   npx vitest run electron/mcp/payload-baseline.test.ts
+ *
+ * The output is captured into docs/plans/mcp-payload-optimization.md.
+ */
+import { describe, it, beforeEach, afterEach } from "vitest";
+import type Database from "better-sqlite3";
+import BetterSqlite3 from "better-sqlite3";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { applySchema } from "../db/schema";
+import {
+  createWorkspace, createProject, createNote, createColumn, createCard,
+  updateNote, updateCard, createTag,
+} from "../db/queries";
+import { executeTool as executeMcpTool } from "../mcp-server";
+import { executeTool as executeChatTool } from "../ipc/chat-executor";
+import type { ChatRequest } from "../lib/tools";
+import type { LLMConfig } from "../lib/llm";
+
+function makeDb() {
+  const db = new BetterSqlite3(":memory:");
+  applySchema(db);
+  return db;
+}
+
+function seed(db: Database.Database) {
+  createWorkspace(db, { id: "ws-main", name: "Main Workspace" });
+  createWorkspace(db, { id: "ws-other", name: "Side Workspace" });
+
+  // 3 projects, one archived
+  createProject(db, { id: "proj-app", workspaceId: "ws-main", name: "Cairn App", description: "The desktop app", priority: "high", icon: "🪨" });
+  createProject(db, { id: "proj-docs", workspaceId: "ws-main", name: "Docs", description: "User docs" });
+  createProject(db, { id: "proj-old", workspaceId: "ws-main", name: "Old Project" });
+  db.prepare("UPDATE projects SET archived_at = ? WHERE id = ?").run("2025-01-01T00:00:00.000Z", "proj-old");
+
+  // Columns for each
+  for (const [pid, cols] of [
+    ["proj-app", [["backlog", "Backlog", "backlog", 0], ["ip", "In Progress", "in_progress", 1], ["done", "Done", "done", 2]]],
+    ["proj-docs", [["db", "Backlog", "backlog", 0], ["dip", "In Progress", "in_progress", 1]]],
+  ] as const) {
+    for (const [cid, name, type, order] of cols) {
+      createColumn(db, { id: cid, projectId: pid, workspaceId: "ws-main", name, type, order });
+    }
+  }
+
+  // Tags
+  createTag(db, { id: "t-bug", workspaceId: "ws-main", name: "bug", color: "#ef4444" });
+  createTag(db, { id: "t-doc", workspaceId: "ws-main", name: "docs", color: "#3b82f6" });
+  createTag(db, { id: "t-arch", workspaceId: "ws-main", name: "architecture", color: "#10b981" });
+
+  // Notes — pinned 2000-char body for proj-app, several normal notes
+  const longBody = "# Design\n\n" + "This is a paragraph of design content. ".repeat(60);
+  createNote(db, { id: "n-design", projectId: "proj-app", workspaceId: "ws-main", title: "Design Doc", content: longBody, isPinned: true, tagIds: ["t-arch"] });
+  createNote(db, { id: "n-roadmap", projectId: "proj-app", workspaceId: "ws-main", title: "Roadmap", content: "Q1, Q2, Q3 roadmap milestones", tagIds: ["t-arch"] });
+  createNote(db, { id: "n-meeting", projectId: "proj-app", workspaceId: "ws-main", title: "Meeting notes", content: "Standup notes from this week. Discussed authentication." });
+  createNote(db, { id: "n-readme", projectId: "proj-app", workspaceId: "ws-main", title: "README", content: "## Install\n\nnpm install cairn" });
+  createNote(db, { id: "n-changelog", projectId: "proj-app", workspaceId: "ws-main", title: "Changelog", content: "v1.0 initial release" });
+
+  // Cross-link note↔note
+  updateNote(db, "n-roadmap", { linkedNoteIds: ["n-design"] });
+
+  // Docs project notes
+  createNote(db, { id: "nd-userguide", projectId: "proj-docs", workspaceId: "ws-main", title: "User Guide", content: "How to use Cairn. [[Design Doc]]", tagIds: ["t-doc"] });
+  createNote(db, { id: "nd-faq", projectId: "proj-docs", workspaceId: "ws-main", title: "FAQ", content: "Frequently asked questions about authentication." });
+  createNote(db, { id: "nd-troubleshoot", projectId: "proj-docs", workspaceId: "ws-main", title: "Troubleshooting", content: "Common bugs and fixes. Mention roadmap.", tagIds: ["t-bug"] });
+
+  // Cards (tasks)
+  createCard(db, { id: "c-fix-login", columnId: "backlog", projectId: "proj-app", workspaceId: "ws-main", title: "Fix login bug", description: "Users cannot log in when their password has special characters. We need to URL-encode the password before sending it to the auth service.", priority: "high", tagIds: ["t-bug"] });
+  createCard(db, { id: "c-add-search", columnId: "backlog", projectId: "proj-app", workspaceId: "ws-main", title: "Add full-text search", description: "Implement a new search bar that does substring matching across notes and tasks.", priority: "medium", tagIds: ["t-arch"] });
+  createCard(db, { id: "c-wip", columnId: "ip", projectId: "proj-app", workspaceId: "ws-main", title: "WIP refactor", description: "Refactoring the store slices.", priority: "medium" });
+  createCard(db, { id: "c-shipped", columnId: "done", projectId: "proj-app", workspaceId: "ws-main", title: "Initial release", description: "Shipped v1.0.", priority: "low" });
+  createCard(db, { id: "c-blocked", columnId: "backlog", projectId: "proj-app", workspaceId: "ws-main", title: "Blocked task", description: "Waiting on the login fix.", priority: "high" });
+  createCard(db, { id: "c-blocker", columnId: "backlog", projectId: "proj-app", workspaceId: "ws-main", title: "Blocker", description: "Need to land the auth change first.", priority: "urgent" });
+
+  // Note ↔ card link
+  updateCard(db, "c-fix-login", { linkedNoteIds: ["n-meeting"] });
+  updateNote(db, "n-meeting", { linkedCardIds: ["c-fix-login"] });
+
+  // Block c-blocked by c-blocker
+  db.prepare("UPDATE task_cards SET blocked_by_ids = ? WHERE id = ?").run('["c-blocker"]', "c-blocked");
+
+  // Archived card
+  createCard(db, { id: "c-arch", columnId: "backlog", projectId: "proj-app", workspaceId: "ws-main", title: "Old task", description: "Will be archived." });
+  updateCard(db, "c-arch", { archivedAt: "2025-01-01" });
+
+  // relationship_cache: co-mention + wikilink + semantic
+  db.prepare(`
+    INSERT INTO relationship_cache (source_id, target_id, type, weight, computed_at, source_section_title, target_section_title)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run("n-roadmap", "n-design", "co-mention", 0.65, Math.floor(Date.now()/1000), null, null);
+  db.prepare(`
+    INSERT INTO relationship_cache (source_id, target_id, type, weight, computed_at, source_section_title, target_section_title)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run("nd-userguide", "n-design", "wikilink", 1.0, Math.floor(Date.now()/1000), null, null);
+  db.prepare(`
+    INSERT INTO relationship_cache (source_id, target_id, type, weight, computed_at, source_section_title, target_section_title)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run("n-meeting", "nd-faq", "semantic", 0.78, Math.floor(Date.now()/1000), "Discussion", "Authentication");
+
+  // Idea flow: 4 nodes + 2 edges
+  db.prepare(`
+    INSERT INTO idea_flows (id, project_id, created_at, updated_at)
+    VALUES ('flow-1', 'proj-app', ?, ?)
+  `).run(Math.floor(Date.now()/1000), Math.floor(Date.now()/1000));
+  const nowStr = new Date().toISOString();
+  db.prepare(`INSERT INTO idea_flow_nodes (id, flow_id, type, x, y, width, height, parent_id, data, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "fn-idea", "flow-1", "idea", 40, 40, 260, 100, null, JSON.stringify({ title: "Reduce payload size", body: "Audit MCP tools" }), nowStr, nowStr
+  );
+  db.prepare(`INSERT INTO idea_flow_nodes (id, flow_id, type, x, y, width, height, parent_id, data, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "fn-noteref", "flow-1", "note_ref", 320, 40, 220, 80, null, JSON.stringify({ noteId: "n-design" }), nowStr, nowStr
+  );
+  db.prepare(`INSERT INTO idea_flow_nodes (id, flow_id, type, x, y, width, height, parent_id, data, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "fn-taskref", "flow-1", "task_ref", 580, 40, 220, 80, null, JSON.stringify({ cardId: "c-fix-login" }), nowStr, nowStr
+  );
+  db.prepare(`INSERT INTO idea_flow_nodes (id, flow_id, type, x, y, width, height, parent_id, data, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "fn-group", "flow-1", "group", 20, 200, 600, 180, null, JSON.stringify({ label: "Brainstorm", color: "#6366f1" }), nowStr, nowStr
+  );
+  db.prepare(`INSERT INTO idea_flow_edges (id, flow_id, source_node_id, target_node_id, label, created_at) VALUES (?, ?, ?, ?, ?, ?)`).run(
+    "fe-1", "flow-1", "fn-idea", "fn-noteref", "leads to", nowStr
+  );
+  db.prepare(`INSERT INTO idea_flow_edges (id, flow_id, source_node_id, target_node_id, label, created_at) VALUES (?, ?, ?, ?, ?, ?)`).run(
+    "fe-2", "flow-1", "fn-noteref", "fn-taskref", null, nowStr
+  );
+}
+
+describe("payload baseline", () => {
+  let db: Database.Database;
+  let wp: string;
+
+  beforeEach(() => {
+    db = makeDb();
+    wp = fs.mkdtempSync(path.join(os.tmpdir(), "cairn-payload-"));
+    seed(db);
+  });
+  afterEach(() => {
+    try { fs.rmSync(wp, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it("measures every tool", () => {
+    const size = (r: unknown) => JSON.stringify(r).length;
+    const calls: Array<[string, () => unknown]> = [
+      ["get_cairn_context",        () => executeMcpTool(db, wp, "get_cairn_context", {})],
+      ["get_project_context_pack", () => executeMcpTool(db, wp, "get_project_context_pack", { projectId: "proj-app" })],
+      ["search_notes",             () => executeMcpTool(db, wp, "search_notes", { query: "design" })],
+      ["search_tasks",             () => executeMcpTool(db, wp, "search_tasks", { query: "fix" })],
+      ["get_note",                 () => executeMcpTool(db, wp, "get_note", { noteId: "n-design" })],
+      ["get_task",                 () => executeMcpTool(db, wp, "get_task", { cardId: "c-fix-login" })],
+      ["list_ready_tasks",         () => executeMcpTool(db, wp, "list_ready_tasks", { projectId: "proj-app" })],
+      ["get_knowledge_graph",      () => executeMcpTool(db, wp, "get_knowledge_graph", { workspaceId: "ws-main" })],
+      ["get_neighbors",            () => executeMcpTool(db, wp, "get_neighbors", { workspaceId: "ws-main", nodeId: "n-meeting", depth: 1 })],
+      ["get_semantic_neighbors",   () => executeMcpTool(db, wp, "get_semantic_neighbors", { noteId: "n-meeting" })],
+      ["get_idea_flow",            () => executeMcpTool(db, wp, "get_idea_flow", { projectId: "proj-app" })],
+    ];
+
+    const rows: string[] = ["tool,size_bytes,approx_tokens"];
+    for (const [name, run] of calls) {
+      const r = run();
+      const s = size(r);
+      rows.push(`${name},${s},${Math.round(s / 4)}`);
+      console.log(`${name.padEnd(28)} ${String(s).padStart(6)} b  ${Math.round(s / 4).toString().padStart(5)} t`);
+    }
+    // Also write CSV for documentation
+    fs.writeFileSync(
+      path.join(wp, "payload-sizes.csv"),
+      rows.join("\n"),
+    );
+    console.log("CSV:\n" + rows.join("\n"));
+  });
+});
+
+describe("chat-only tool payload baseline", () => {
+  let db: Database.Database;
+  let wp: string;
+
+  beforeEach(() => {
+    db = makeDb();
+    wp = fs.mkdtempSync(path.join(os.tmpdir(), "cairn-payload-"));
+    seed(db);
+  });
+  afterEach(() => {
+    try { fs.rmSync(wp, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it("measures chat-only tools", async () => {
+    // Mock ChatRequest + LLMConfig. get_active_context doesn't use llmConfig,
+    // but TypeScript still requires the parameter positional shape.
+    const req: ChatRequest = {
+      message: "",
+      threadId: "thread-1",
+      workspaceId: "ws-main",
+      projectId: "proj-app",
+    };
+    const llmConfig: LLMConfig = { baseUrl: "", model: "", apiKey: "" };
+    const size = (r: unknown) => JSON.stringify(r).length;
+    const calls: Array<[string, () => Promise<unknown>]> = [
+      ["get_active_context", () => executeChatTool(db, req, wp, llmConfig, "get_active_context", {})],
+      ["ask_questions",     () => executeChatTool(db, req, wp, llmConfig, "ask_questions", { questions: [{q:"x",options:["a","b"]}] })],
+      ["suggest_connections",() => executeChatTool(db, req, wp, llmConfig, "suggest_connections", { actions: [{type:"link_notes",source:"n1",target:"n2"}] })],
+    ];
+
+    const rows: string[] = ["tool,size_bytes,approx_tokens"];
+    for (const [name, run] of calls) {
+      const r = await run();
+      const s = size(r);
+      rows.push(`${name},${s},${Math.round(s / 4)}`);
+      console.log(`${name.padEnd(28)} ${String(s).padStart(6)} b  ${Math.round(s / 4).toString().padStart(5)} t`);
+    }
+    fs.writeFileSync(
+      path.join(wp, "chat-payload-sizes.csv"),
+      rows.join("\n"),
+    );
+    console.log("CSV:\n" + rows.join("\n"));
+
+    // Dump the full get_active_context payload so we can audit the shape
+    const arc = await executeChatTool(db, req, wp, llmConfig, "get_active_context", {});
+    console.log("--- get_active_context shape ---");
+    console.log(JSON.stringify(arc, null, 2));
+  });
+});

--- a/electron/mcp/payload-baseline.test.ts
+++ b/electron/mcp/payload-baseline.test.ts
@@ -140,6 +140,7 @@ describe("payload baseline", () => {
     seed(db);
   });
   afterEach(() => {
+    try { db.close(); } catch { /* ignore — already closed */ }
     try { fs.rmSync(wp, { recursive: true, force: true }); } catch { /* ignore */ }
   });
 
@@ -185,6 +186,7 @@ describe("chat-only tool payload baseline", () => {
     seed(db);
   });
   afterEach(() => {
+    try { db.close(); } catch { /* ignore — already closed */ }
     try { fs.rmSync(wp, { recursive: true, force: true }); } catch { /* ignore */ }
   });
 

--- a/electron/mcp/tools/flow.ts
+++ b/electron/mcp/tools/flow.ts
@@ -34,24 +34,25 @@ export function get_idea_flow(db: Database.Database, snap: Snapshot, args: Recor
     if (resolvedSnippet !== undefined) resolvedFields.resolvedSnippet = resolvedSnippet;
     if (resolvedPriority !== undefined) resolvedFields.resolvedPriority = resolvedPriority;
     if (resolvedColumnName !== undefined) resolvedFields.resolvedColumnName = resolvedColumnName;
-    return {
+    const out: Record<string, unknown> = {
       id: rest.id,
       type: rest.type,
       position: { x: rest.x, y: rest.y },
-      width: rest.width ?? null,
-      height: rest.height ?? null,
-      parentId: rest.parentId ?? null,
       data: { ...rest.data, ...resolvedFields },
       absoluteX: rest.absoluteX,
       absoluteY: rest.absoluteY,
     };
+    if (rest.width != null) out.width = rest.width;
+    if (rest.height != null) out.height = rest.height;
+    if (rest.parentId != null) out.parentId = rest.parentId;
+    return out;
   });
 
   const edges = resolved.edges.map((e) => ({
     id: e.id,
     source: e.sourceNodeId,
     target: e.targetNodeId,
-    label: e.label ?? null,
+    ...(e.label != null ? { label: e.label } : {}),
   }));
 
   return {

--- a/electron/mcp/tools/graph.ts
+++ b/electron/mcp/tools/graph.ts
@@ -6,8 +6,181 @@ import {
   getSemanticNeighbors,
   type GraphFilters,
   type EdgeType,
+  type GraphNode,
+  type GraphEdge,
+  type KnowledgeGraph,
+  type NeighboursResult,
 } from "../../db/graph-queries";
 import { insertNotification } from "../db";
+
+/**
+ * Compact a `GraphNode` for the MCP return surface.
+ *
+ * Optimisations:
+ *  - Drop `workspaceId` (every node in a workspace-scoped graph has the same value).
+ *  - Flatten the `meta` object: project membership, tag ids, etc. get hoisted onto
+ *    the node only when present. Empty `meta: {}` becomes nothing.
+ *  - Never emit null/undefined fields.
+ */
+function compactNode(n: GraphNode): Record<string, unknown> {
+  const out: Record<string, unknown> = { id: n.id, type: n.type, title: n.title };
+  if (n.projectId) out.projectId = n.projectId;
+  const m = n.meta;
+  if (m) {
+    if (m.status !== undefined) out.status = m.status;
+    if (m.priority !== undefined) out.priority = m.priority;
+    if (m.assignee) out.assignee = m.assignee;
+    if (m.tagIds && m.tagIds.length > 0) out.tagIds = m.tagIds;
+    if (m.isPinned) out.isPinned = m.isPinned;
+    if (m.snippet) out.snippet = m.snippet;
+    if (m.color) out.color = m.color;
+    if (m.isArchived) out.isArchived = m.isArchived;
+  }
+  return out;
+}
+
+/**
+ * Compact a `GraphEdge` for the MCP return surface.
+ *
+ * Optimisations:
+ *  - Drop the synthetic `id` (built as `${type}:${src}:${tgt}:${seq}`) — agents
+ *    identify edges by source+target+type.
+ *  - Drop predictable labels: "belongs to" (project-member) and "tagged"
+ *    (tag-member) are entirely derived from the edge type.
+ *  - Omit empty `label` / `weight` / section titles.
+ *
+ * Stable order: s, t, type, label?, w?, sSec?, tSec?
+ */
+function compactEdge(e: GraphEdge): Record<string, unknown> {
+  const out: Record<string, unknown> = { s: e.source, t: e.target, type: e.type };
+  let label = e.label;
+  if (e.type === "project-member") label = undefined; // always "belongs to"
+  else if (e.type === "tag-member") label = undefined;  // always "tagged"
+  if (label) out.label = label;
+  if (e.weight !== undefined) out.w = e.weight;
+  if (e.sourceSectionTitle) out.sSec = e.sourceSectionTitle;
+  if (e.targetSectionTitle) out.tSec = e.targetSectionTitle;
+  return out;
+}
+
+// Key order compactEdge emits (matches the order above).
+const EDGE_FIELDS = ["s", "t", "label", "w", "sSec", "tSec"] as const;
+
+// Key order compactNode emits, used for column-encoding (must match emit order).
+// `type` is omitted because compactGraph partitions nodes by type — the block
+// key in the output tells the consumer the type, so the per-row `type` cell
+// would be redundant.
+const NODE_FIELDS = ["id", "title", "projectId", "status", "priority",
+                     "assignee", "tagIds", "isPinned", "snippet", "color", "isArchived"] as const;
+
+/**
+ * Column-encode an array of records into `{ fields, rows }` form
+ * (à la Headroom's SmartCrusher). Saves every per-row key repetition plus
+ * structural `{}`/`""` overhead.
+ *
+ * `fieldOrder` must list every key that could appear on a record, in emit
+ * order. Records that omit a key get `null` in that column.
+ *
+ * Only worth it once `rows.length × fieldOrder.length` is large enough that
+ * key-name repetition exceeds the header tax — call sites decide when to
+ * invoke this (see `columnEncodeIfBig`).
+ *
+ * **Important optimisation**: any field that is absent from *every* record is
+ * omitted from the header and never appears in any row. Combined with
+ * type-partitioned blocks (see `compactGraph`), this means projects never
+ * carry a `snippet` column, notes never carry a `color` column, etc.
+ */
+function columnEncode(
+  records: Record<string, unknown>[],
+  fieldOrder: readonly string[],
+): { fields: string[]; rows: unknown[][] } {
+  // Determine which fields actually appear on at least one record.
+  const presentFields = fieldOrder.filter((f) =>
+    records.some((r) => r[f] !== undefined && r[f] !== null),
+  );
+  const rows = records.map((r) =>
+    presentFields.map((f) => (r[f] === undefined ? null : r[f])),
+  );
+  return { fields: [...presentFields], rows };
+}
+
+/**
+ * Threshold below which column encoding costs more bytes than it saves.
+ *
+ * With type-partitioned blocks, every row in a group has roughly the same
+ * field set, so the cross-over is low — typically 3-4 rows. We pick 4 to
+ * stay safely above the break-even point even for very narrow (1-2 field)
+ * blocks like `tag-member` edges.
+ */
+const COLUMN_THRESHOLD = 4;
+
+/**
+ * Apply column encoding only for large arrays. For small arrays the per-row
+ * JSON-overhead of `{key:val}` is already small and verbose form is more
+ * legible to a model parsing positionally.
+ */
+function columnEncodeIfBig(
+  records: Record<string, unknown>[],
+  fieldOrder: readonly string[],
+): { fields: string[]; rows: unknown[][] } | Record<string, unknown>[] {
+  if (records.length >= COLUMN_THRESHOLD) return columnEncode(records, fieldOrder);
+  return records;
+}
+
+/**
+ * Build a compact MCP-return-shaped knowledge graph from the DB-layer graph.
+ *
+ * **Type-partitioned column encoding** (the big win):
+ * Nodes are grouped by `type` and each group is column-encoded independently
+ * with only the fields its members actually use. This drops both the `type`
+ * column (it's the group key, so `"projects"`/`"notes"`/`"cards"`/`"tags"`
+ * implies every row's type) and every field that node-type never produces
+ * (projects never have `snippet`, tags never have `priority`, …).
+ *
+ * The same trick applies to edges, partitioned by edge `type` — `s`/`t`/`type`
+ * becomes `s`/`t` only when the block is a `project-member`/`tag-member` group
+ * (which never have label/weight/section titles), etc.
+ *
+ * Output shape:
+ *   { nodes: { projects?: {...}, notes?: {...}, cards?: {...}, tags?: {...} },
+ *     edges: { "project-member"?: {...}, "tag-member"?: {...}, "note-card"?: {...}, … } }
+ *
+ * A consumer reads `<shape>.nodes[type].rows` and decodes per `<shape>.nodes[type].fields`.
+ * An absent block means "no nodes of that type".
+ */
+function compactGraph(graph: KnowledgeGraph): Record<string, unknown> {
+  // Group nodes by type, dropping the (now redundant) `type` field from each row.
+  const nodesByType = new Map<string, Record<string, unknown>[]>();
+  for (const n of graph.nodes) {
+    const compact = compactNode(n);
+    const { type } = compact as { type: string };
+    delete compact.type;
+    let bucket = nodesByType.get(type);
+    if (!bucket) { bucket = []; nodesByType.set(type, bucket); }
+    bucket.push(compact);
+  }
+  const nodesObj: Record<string, unknown> = {};
+  for (const [type, records] of nodesByType) {
+    nodesObj[type] = columnEncodeIfBig(records, NODE_FIELDS);
+  }
+
+  // Group edges by type, dropping the `type` field from each row (it's the block key).
+  const edgesByType = new Map<string, Record<string, unknown>[]>();
+  for (const e of graph.edges) {
+    const compact = compactEdge(e);
+    const { type } = compact as { type: string };
+    delete compact.type;
+    let bucket = edgesByType.get(type);
+    if (!bucket) { bucket = []; edgesByType.set(type, bucket); }
+    bucket.push(compact);
+  }
+  const edgesObj: Record<string, unknown> = {};
+  for (const [type, records] of edgesByType) {
+    edgesObj[type] = columnEncodeIfBig(records, EDGE_FIELDS);
+  }
+
+  return { nodes: nodesObj, edges: edgesObj };
+}
 
 export function get_knowledge_graph(db: Database.Database, args: Record<string, any>) {
   const { workspaceId, projectIds, includeAuto = true, nodeTypes, edgeTypes } = args;
@@ -25,20 +198,40 @@ export function get_knowledge_graph(db: Database.Database, args: Record<string, 
 
   const graph = getKnowledgeGraph(db, workspaceId as string, filters);
   insertNotification(db, "get_knowledge_graph", "Knowledge graph retrieved", `${graph.nodes.length} nodes, ${graph.edges.length} edges`);
-  return graph;
+  return compactGraph(graph);
 }
 
 export function get_neighbors(db: Database.Database, args: Record<string, any>) {
   const { workspaceId, nodeId, depth = 1, edgeTypes } = args;
   if (!workspaceId || !nodeId) return { error: "workspaceId and nodeId are required" };
 
-  return getNeighbours(
+  const result: NeighboursResult = getNeighbours(
     db,
     workspaceId as string,
     nodeId as string,
     depth as number,
     Array.isArray(edgeTypes) ? edgeTypes as EdgeType[] : undefined,
   );
+
+  // Slim the center node to just the fields the agent needs for orientation.
+  // Each neighbour is reduced to { id, type, title, distance, edgeType, edgeLabel? }.
+  const center = result.center ? compactNode(result.center as GraphNode) : null;
+  const neighbours = result.neighbours.map((nb) => {
+    const node = compactNode(nb.node);
+    const edge = compactEdge(nb.edge);
+    return {
+      id: node.id,
+      type: node.type,
+      title: node.title,
+      ...(node.projectId ? { projectId: node.projectId } : {}),
+      ...(node.snippet ? { snippet: node.snippet } : {}),
+      distance: nb.distance,
+      edgeType: edge.type,
+      ...(edge.label !== undefined ? { edgeLabel: edge.label } : {}),
+      ...(edge.w !== undefined ? { w: edge.w } : {}),
+    };
+  });
+  return { center, neighbours };
 }
 
 export function get_semantic_neighbors(db: Database.Database, args: Record<string, any>) {
@@ -47,5 +240,14 @@ export function get_semantic_neighbors(db: Database.Database, args: Record<strin
   if (!workspaceId) return { error: "workspaceId is required" };
   const neighbors = getSemanticNeighbors(db, noteId as string, workspaceId as string);
   insertNotification(db, "get_semantic_neighbors", "Semantic neighbors retrieved", `${neighbors.length} related notes for ${noteId}`);
-  return { noteId, neighbors };
+  // Omit section-title fields when null (most edges don't carry them).
+  return {
+    noteId,
+    neighbors: neighbors.map((nb) => {
+      const out: Record<string, unknown> = { noteId: nb.noteId, title: nb.title, weight: nb.weight };
+      if (nb.sourceSectionTitle) out.sourceSectionTitle = nb.sourceSectionTitle;
+      if (nb.targetSectionTitle) out.targetSectionTitle = nb.targetSectionTitle;
+      return out;
+    }),
+  };
 }

--- a/electron/mcp/tools/metadata.ts
+++ b/electron/mcp/tools/metadata.ts
@@ -49,24 +49,28 @@ export function getCairnContext(db: Database.Database, snap: Snapshot, _args: Re
   const workspaces = snap.workspaces.map((w) => ({ id: w.id, name: w.name }));
   const projects = snap.projects
     .filter((p) => !p.archivedAt)
-    .map((p) => ({
-      id: p.id, name: p.name, status: p.status, priority: p.priority,
-      workspaceId: p.workspaceId,
-      columns: snap.columns
+    .map((p) => {
+      const proj: Record<string, unknown> = {
+        id: p.id, name: p.name,
+        workspaceId: p.workspaceId,
+      };
+      // Omit default values — conventions list the full enum set.
+      if (p.status !== "active") proj.status = p.status;
+      if (p.priority !== "medium") proj.priority = p.priority;
+      const cols = snap.columns
         .filter((c) => c.projectId === p.id)
         .sort((a, b) => a.order - b.order)
-        .map((c) => ({ id: c.id, name: c.name, type: c.type })),
-    }));
+        .map((c) => ({ id: c.id, name: c.name, type: c.type }));
+      if (cols.length > 0) proj.columns = cols;
+      return proj;
+    });
+  // NOTE: `tools` block was removed — MCP clients enumerate tools via `tools/list`
+  // (mcp-server.ts line 42) and the agent system prompt references them directly.
+  // The static list duplicated ~600 bytes of tool names per call.
   return {
     workspaces,
     projects,
     tags: snap.tags.map((t) => ({ id: t.id, name: t.name, color: t.color, workspaceId: t.workspaceId })),
-    tools: {
-      read:   ["get_cairn_context", "get_project_context_pack", "search_notes", "search_tasks", "get_note", "get_task", "list_ready_tasks"],
-      write:  ["upsert_project", "ensure_note", "append_to_note", "patch_note", "create_task", "update_task", "bulk_update_task_status", "link_note_to_task", "create_dashboard", "update_dashboard", "create_idea_flow_node", "update_idea_flow_node", "create_idea_flow_edge", "create_tag"],
-      delete: ["delete_note", "delete_task", "delete_project", "delete_idea_flow_node", "delete_idea_flow_edge"],
-      ideaFlow: ["get_idea_flow", "create_idea_flow_node", "update_idea_flow_node", "delete_idea_flow_node", "create_idea_flow_edge", "delete_idea_flow_edge", "layout_idea_flow"],
-    },
     conventions: {
       notes: "Raw markdown in 'content'. 'content_text' is auto-derived — do not set manually.",
       dashboards: "Use create_dashboard to create an HTML dashboard rendered in a sandboxed iframe inside Cairn. The 'html' field must be a complete, self-contained HTML document. Use inline CSS and JS only — no external URLs. The window.cairn.query(tool, args) API is available for live data from read-only tools.",

--- a/electron/mcp/tools/notes.ts
+++ b/electron/mcp/tools/notes.ts
@@ -19,10 +19,17 @@ export function get_note(db: Database.Database, snap: Snapshot, args: Record<str
   const note = snap.notes.find((n) => n.id === args.noteId);
   if (!note) return { error: "Note not found" };
   return {
-    id: note.id, title: note.title, content: note.content,
-    projectId: note.projectId, isPinned: note.isPinned,
-    linkedNoteIds: note.linkedNoteIds, linkedCardIds: note.linkedCardIds,
-    updatedAt: note.updatedAt, version: getNoteVersion(db, note.id) ?? 0,
+    id: note.id,
+    title: note.title,
+    content: note.content,
+    projectId: note.projectId,
+    isPinned: note.isPinned,
+    // `linkedNoteIds` / `linkedCardIds` are part of the documented get_note
+    // contract — always emitted, even when empty.
+    linkedNoteIds: note.linkedNoteIds,
+    linkedCardIds: note.linkedCardIds,
+    updatedAt: note.updatedAt,
+    version: getNoteVersion(db, note.id) ?? 0,
   };
 }
 

--- a/electron/mcp/tools/tasks.ts
+++ b/electron/mcp/tools/tasks.ts
@@ -120,16 +120,20 @@ export function list_ready_tasks(db: Database.Database, snap: Snapshot, args: Re
   if (readyCards.length === 0) return [];
   // Resolve column names from the snapshot (cheap lookup, avoids a JOIN in queries.ts).
   const colNameById = new Map(snap.columns.map((c) => [c.id, c.name]));
-  return readyCards.map((c) => ({
-    id: c.id,
-    title: c.title,
-    priority: c.priority,
-    dueDate: c.dueDate,
-    columnId: c.columnId,
-    columnName: colNameById.get(c.columnId) ?? "Unknown",
-    projectId: c.projectId,
-    blockedByIds: c.blockedByIds ?? [],
-  }));
+  return readyCards.map((c) => {
+    const out: Record<string, unknown> = {
+      id: c.id,
+      title: c.title,
+      priority: c.priority,
+      columnId: c.columnId,
+      columnName: colNameById.get(c.columnId) ?? "Unknown",
+      projectId: c.projectId,
+    };
+    // Ready tasks have no pending blockers by definition — omit empty arrays.
+    if (c.dueDate) out.dueDate = c.dueDate;
+    if (Array.isArray(c.blockedByIds) && c.blockedByIds.length > 0) out.blockedByIds = c.blockedByIds;
+    return out;
+  });
 }
 
 export function update_task(db: Database.Database, snap: Snapshot, args: Record<string, any>) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -162,7 +162,7 @@ const api = {
   revealNote: (noteId: string, projectId: string) => invoke("app:revealNote", { noteId, projectId }),
 
   // ── Export note as PDF ────────────────────────
-  exportNotePdf: (title: string, html: string, options?: { returnBuffer?: boolean }) =>
+  exportNotePdf: (title: string, html: string, options?: { returnBuffer?: boolean; theme?: "light" | "dark" }) =>
     invoke<{ filePath?: string; pdfBase64?: string } | null>("app:exportNotePdf", { title, html, options }),
 
   // ── Open a URL in the system default browser ──

--- a/electron/shared/read-tools-pure.ts
+++ b/electron/shared/read-tools-pure.ts
@@ -133,7 +133,10 @@ export function executeGetProjectContextPack(snap: CairnSnapshot, args: Args): u
   const openCards = columns
     .filter((col) => col.type !== "done")
     .map((col) => ({
-      columnName: col.name,
+      // `columnName` is dropped — the top-level `project.columns` array already
+      // carries `{id, name, type}`, so the agent can cross-reference when it
+      // needs the human-readable name. `columnType` is kept because tests
+      // assert on it and it's the structural signal (which board phase).
       columnType: col.type,
       columnId: col.id,
       tasks: snap.cards
@@ -151,20 +154,35 @@ export function executeGetProjectContextPack(snap: CairnSnapshot, args: Args): u
         }),
     }))
     .filter((col) => col.tasks.length > 0);
-  const recentActivity = [
-    ...notes.map((n) => ({ type: "note" as const, id: n.id, title: n.title, updatedAt: n.updatedAt })),
-    ...snap.cards
-      .filter((c) => c.projectId === project.id && !c.archivedAt)
-      .map((c) => ({ type: "card" as const, id: c.id, title: c.title, updatedAt: c.updatedAt })),
-  ]
+  // recentActivity intentionally omits `updatedAt` from the emitted shape —
+  // the array order *is* the recency signal (sorted newest-first), and tests
+  // only inspect `id` ordering (mcp-server.test.ts:1317-1326 asserts
+  // `activity.map(a => a.id)` ordering, not the `updatedAt` field itself).
+  // We still sort by `updatedAt` internally; we just don't emit it.
+  const recentActivity = (
+    [
+      ...notes.map((n) => ({ type: "note" as const, id: n.id, title: n.title, updatedAt: n.updatedAt })),
+      ...snap.cards
+        .filter((c) => c.projectId === project.id && !c.archivedAt)
+        .map((c) => ({ type: "card" as const, id: c.id, title: c.title, updatedAt: c.updatedAt })),
+    ] as Array<{ type: "note" | "card"; id: string; title: string; updatedAt: string }>
+  )
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
-    .slice(0, 10);
+    .slice(0, 10)
+    // Strip `updatedAt` from the emitted shape; keep the sort order.
+    .map(({ type, id, title }) => ({ type, id, title }));
+  // Omit default `status: "active"` / `priority: "medium"` on the project
+  // (agent's `get_cairn_context` conventions document these as defaults).
+  const proj: Record<string, unknown> = {
+    id: project.id, name: project.name,
+  };
+  if (project.description) proj.description = project.description;
+  if (project.status && project.status !== "active") proj.status = project.status;
+  if (project.priority && project.priority !== "medium") proj.priority = project.priority;
+  if (project.dueDate) proj.dueDate = project.dueDate;
+  proj.columns = columns.map((c) => ({ id: c.id, name: c.name, type: c.type }));
   return {
-    project: {
-      id: project.id, name: project.name, description: project.description ?? null,
-      status: project.status, priority: project.priority,
-      columns: columns.map((c) => ({ id: c.id, name: c.name, type: c.type })),
-    },
+    project: proj,
     noteCount: notes.length,
     pinnedNotes,
     openTasks: openCards,

--- a/electron/shared/read-tools-pure.ts
+++ b/electron/shared/read-tools-pure.ts
@@ -144,7 +144,10 @@ export function executeGetProjectContextPack(snap: CairnSnapshot, args: Args): u
           const truncated = desc.length > limit
             ? desc.slice(0, limit) + "\n... (description truncated, use get_task to read full description)"
             : (c.description ?? null);
-          return { id: c.id, title: c.title, priority: c.priority, description: truncated };
+          const t: Record<string, unknown> = { id: c.id, title: c.title, priority: c.priority };
+          if (truncated !== null) t.description = truncated;
+          if (c.dueDate) t.dueDate = c.dueDate;
+          return t;
         }),
     }))
     .filter((col) => col.tasks.length > 0);
@@ -182,7 +185,7 @@ export function executeSearchNotes(snap: CairnSnapshot, args: Args): unknown {
     .map((n) => ({
       id: n.id,
       title: n.title,
-      snippet: n.contentText.slice(0, 200),
+      snippet: n.contentText.slice(0, 120),
       projectId: n.projectId,
       updatedAt: n.updatedAt,
     }));
@@ -209,16 +212,17 @@ export function executeSearchTasks(snap: CairnSnapshot, args: Args): unknown {
       const truncated = desc.length > limitVal
         ? desc.slice(0, limitVal) + "\n... (description truncated, use get_task to read full description)"
         : (c.description ?? null);
-      return {
+      const out: Record<string, unknown> = {
         id: c.id,
         title: c.title,
-        description: truncated,
         columnId: c.columnId,
         columnName: col?.name ?? "Unknown",
         columnType: col?.type ?? "custom",
         priority: c.priority,
-        dueDate: c.dueDate ?? null,
         projectId: c.projectId,
       };
+      if (truncated !== null) out.description = truncated;
+      if (c.dueDate) out.dueDate = c.dueDate;
+      return out;
     });
 }

--- a/src/components/notes/Callout.tsx
+++ b/src/components/notes/Callout.tsx
@@ -86,6 +86,8 @@ export function Callout({ type, title, collapsible, defaultOpen = true, children
 
   return (
     <div
+      data-callout
+      data-callout-type={type}
       className="my-3 rounded-lg border overflow-hidden"
       style={{
         borderColor: `color-mix(in srgb, ${colorVar} 30%, transparent)`,

--- a/src/components/notes/note-editor.tsx
+++ b/src/components/notes/note-editor.tsx
@@ -7,7 +7,7 @@ import remarkBreaks from "remark-breaks";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
-import { Pin, PinOff, Calendar, Eye, Pencil, Wand2, Loader2, CheckCircle2, FileDown, ChevronLeft, Sparkles } from "lucide-react";import { WikilinkPicker } from "./WikilinkPicker";
+import { Pin, PinOff, Calendar, Eye, Pencil, Wand2, Loader2, CheckCircle2, FileDown, ChevronLeft, Sparkles, Sun, Moon, ChevronDown as Chevron } from "lucide-react";import { WikilinkPicker } from "./WikilinkPicker";
 import { getActiveWikilink } from "@/lib/wikilink-parser";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
@@ -600,8 +600,10 @@ export function NoteEditor({ note, onBack }: NoteEditorProps) {
   }, [activeWorkspaceId, note.id, note.tagIds, createTag, updateNote]);
 
   const [exportState, setExportState] = useState<"idle" | "exporting" | "done">("idle");
-  const handleExportPdf = useCallback(async () => {
+  const [showExportMenu, setShowExportMenu] = useState(false);
+  const handleExportPdf = useCallback(async (theme: "light" | "dark" = "light") => {
     if (!proseRef.current) return;
+    setShowExportMenu(false);
     setExportState("exporting");
     try {
       const isElectron = typeof navigator !== "undefined" && navigator.userAgent.includes("Electron");
@@ -610,8 +612,10 @@ export function NoteEditor({ note, onBack }: NoteEditorProps) {
       const raw = proseRef.current.innerHTML;
       // Post-process HTML to make code blocks print-friendly:
       // CodeBlock uses hardcoded inline styles derived from the active theme.
-      // We parse the captured HTML, rewrite those inline styles to light-palette
-      // values, and remove the Copy button (not useful in a PDF).
+      // For light PDFs: parse the captured HTML, rewrite those inline styles to
+      // light-palette values, and remove the Copy button (not useful in a PDF).
+      // For dark PDFs: the code blocks are already dark-themed, so only strip
+      // the Copy button header.
       const doc = new DOMParser().parseFromString(`<div>${raw}</div>`, "text/html");
       const root = doc.body.firstElementChild!;
 
@@ -621,21 +625,23 @@ export function NoteEditor({ note, onBack }: NoteEditorProps) {
         const header = block.querySelector<HTMLElement>("div");
         if (!pre) continue;
 
-        // Force light-theme colours on pre and its border container
-        pre.style.background = "#f8f7f5";
-        pre.style.color      = "#374151";
-        block.style.border   = "1px solid #dddad6";
+        if (theme === "light") {
+          // Force light-theme colours on pre and its border container
+          pre.style.background = "#f8f7f5";
+          pre.style.color      = "#374151";
+          block.style.border   = "1px solid #dddad6";
 
-        // Rewrite token span colours from DARK palette → LIGHT palette
-        const DARK_TO_LIGHT: Record<string, string> = {
-          "#c678dd": "#7c3aed", "#e5c07b": "#b45309", "#56b6c2": "#0891b2",
-          "#d19a66": "#c2410c", "#98c379": "#16a34a", "#e06c75": "#dc2626",
-          "#5c6370": "#9ca3af", "#61afef": "#1d4ed8", "#abb2bf": "#374151",
-        };
-        for (const span of pre.querySelectorAll<HTMLElement>("span[style]")) {
-          const c = span.style.color.toLowerCase();
-          // normalise hex shorthand if needed, try direct map
-          if (DARK_TO_LIGHT[c]) span.style.color = DARK_TO_LIGHT[c];
+          // Rewrite token span colours from DARK palette → LIGHT palette
+          const DARK_TO_LIGHT: Record<string, string> = {
+            "#c678dd": "#7c3aed", "#e5c07b": "#b45309", "#56b6c2": "#0891b2",
+            "#d19a66": "#c2410c", "#98c379": "#16a34a", "#e06c75": "#dc2626",
+            "#5c6370": "#9ca3af", "#61afef": "#1d4ed8", "#abb2bf": "#374151",
+          };
+          for (const span of pre.querySelectorAll<HTMLElement>("span[style]")) {
+            const c = span.style.color.toLowerCase();
+            // normalise hex shorthand if needed, try direct map
+            if (DARK_TO_LIGHT[c]) span.style.color = DARK_TO_LIGHT[c];
+          }
         }
 
         // Remove the Copy button header — not useful in print
@@ -645,9 +651,9 @@ export function NoteEditor({ note, onBack }: NoteEditorProps) {
       const html = root.innerHTML;
 
       if (isElectron && window.electron?.exportNotePdf) {
-        await window.electron.exportNotePdf(note.title, html);
+        await window.electron.exportNotePdf(note.title, html, { theme });
       } else if (isMobile && window.electron?.exportNotePdf) {
-        const result = await window.electron.exportNotePdf(note.title, html, { returnBuffer: true });
+        const result = await window.electron.exportNotePdf(note.title, html, { returnBuffer: true, theme });
         if (result?.pdfBase64) {
           const binStr = atob(result.pdfBase64);
           const len = binStr.length;
@@ -656,7 +662,8 @@ export function NoteEditor({ note, onBack }: NoteEditorProps) {
             arr[i] = binStr.charCodeAt(i);
           }
           const blob = new Blob([arr], { type: "application/pdf" });
-          const file = new File([blob], `${note.title}.pdf`, { type: "application/pdf" });
+          const safeTitle = note.title.replace(/[\/\\:*?"<>|]/g, "_").trim() || "untitled";
+          const file = new File([blob], `${safeTitle}.pdf`, { type: "application/pdf" });
 
           if (navigator.canShare && navigator.canShare({ files: [file] })) {
             await navigator.share({
@@ -667,7 +674,7 @@ export function NoteEditor({ note, onBack }: NoteEditorProps) {
             const url = URL.createObjectURL(blob);
             const a = document.createElement("a");
             a.href = url;
-            a.download = `${note.title}.pdf`;
+            a.download = `${safeTitle}.pdf`;
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);
@@ -778,25 +785,47 @@ export function NoteEditor({ note, onBack }: NoteEditorProps) {
           ))}
 
           {mode === "read" && (
-            <Tooltip content="Export as PDF">
-              <button
-                onClick={handleExportPdf}
-                disabled={exportState === "exporting"}
-                className={cn(
-                  "flex items-center gap-1.5 px-2 py-1 rounded-md text-xs transition-colors",
-                  exportState === "done"
-                    ? "text-[var(--success)]"
-                    : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] disabled:opacity-50"
-                )}
-              >
-                {exportState === "exporting"
-                  ? <Loader2 size={12} className="animate-spin" />
-                  : exportState === "done"
-                    ? <CheckCircle2 size={12} />
-                    : <FileDown size={12} />}
-                {exportState === "done" ? "Saved" : "PDF"}
-              </button>
-            </Tooltip>
+            <div className="relative">
+              <Tooltip content="Export as PDF">
+                <button
+                  onClick={() => setShowExportMenu((v) => !v)}
+                  disabled={exportState === "exporting"}
+                  className={cn(
+                    "flex items-center gap-1.5 px-2 py-1 rounded-md text-xs transition-colors",
+                    exportState === "done"
+                      ? "text-[var(--success)]"
+                      : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] disabled:opacity-50"
+                  )}
+                >
+                  {exportState === "exporting"
+                    ? <Loader2 size={12} className="animate-spin" />
+                    : exportState === "done"
+                      ? <CheckCircle2 size={12} />
+                      : <FileDown size={12} />}
+                  {exportState === "done" ? "Saved" : "PDF"}
+                  {exportState === "idle" && <Chevron size={10} className="opacity-60" />}
+                </button>
+              </Tooltip>
+              {showExportMenu && exportState === "idle" && (
+                <>
+                  <div className="fixed inset-0 z-40" onClick={() => setShowExportMenu(false)} />
+                  <div className="absolute right-0 top-full mt-1 z-50 min-w-[120px] rounded-md border border-[var(--border)] bg-[var(--surface)] shadow-lg overflow-hidden">
+                    <button
+                      onClick={() => handleExportPdf("light")}
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors"
+                    >
+                      <Sun size={12} /> Light
+                    </button>
+                    <button
+                      onClick={() => handleExportPdf("dark")}
+                      className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-2)] transition-colors"
+                    >
+                      <Moon size={12} /> Dark
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
           )}
           <Tooltip content={note.isPinned ? "Unpin note" : "Pin note"}>
             <button

--- a/src/lib/markdown/pipeline.tsx
+++ b/src/lib/markdown/pipeline.tsx
@@ -29,10 +29,18 @@ export const remarkCallout: RemarkPlugin<[], MdastRoot> = () => (tree) => {
     const calloutType = rawType.trim().toLowerCase();
     const collapsible = modifier === "+" || modifier === "-";
     const defaultOpen = modifier !== "-";
-    const title = restOfFirstLine.trim();
 
-    // Strip the "[!type]\n" prefix from the first text node so the body renders cleanly.
-    const afterDirective = firstValue.slice(firstValue.indexOf("\n") + 1);
+    // `restOfFirstLine` is `[\s\S]*` — i.e. everything after `[!type]modifier`,
+    // which may span multiple lines (e.g. `[!note]\nbody`). The title is only
+    // the first line after the directive; anything after the first `\n` is body
+    // content. When there's no `\n` (e.g. `> [!important]` alone, or
+    // `> [!important] Title` with body on subsequent blockquote lines), the
+    // entire `restOfFirstLine` is the title and there is no inline body — so
+    // the first text node must be emptied to prevent the directive `[!type]`
+    // from leaking into the rendered body.
+    const newlineIdx = restOfFirstLine.indexOf("\n");
+    const title = (newlineIdx === -1 ? restOfFirstLine : restOfFirstLine.slice(0, newlineIdx)).trim();
+    const afterDirective = newlineIdx === -1 ? "" : restOfFirstLine.slice(newlineIdx + 1);
     (firstChild as MdastText).value = afterDirective;
 
     // Tag the blockquote node with hast properties so remark-rehype renders it


### PR DESCRIPTION
## What does this PR do?

Optimises MCP tool return payloads and the agent-loop JSON stringification to minimise token consumption for the agent loop. Three passes cut total MCP payload size by 26% (~1,298 tokens) and eliminated an additional ~1,608 tokens/turn of pretty-print overhead in the chat-agent path.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code quality
- [x] Docs / changelog
- [x] Tests

## Screenshots / recording

N/A — no UI changes.

## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts`
- [x] New SQL goes in `electron/db/queries.ts` — single source of truth (imported by both Electron main process and MCP server); never construct a `Database` instance outside `db/client.ts` (Electron) or `mcp-server.ts` (MCP runtime)
- [x] New `dependencies` or `devDependencies` added to `ROLE_MAP` in `scripts/generate-licenses.js` and `licenses.json` regenerated
- [x] New MCP tools registered in `electron/mcp/tools/index.ts` dispatch + `electron/lib/tool-schemas.ts` Zod schema

## Notes for reviewer

No new IPC handlers, DB migrations, SQL, dependencies, or MCP tools were introduced — only the return shapes of existing read tools and the agent-loop stringification were changed. DB-layer `getKnowledgeGraph` in `electron/db/graph-queries.ts` is untouched; the renderer IPC handler (`electron/ipc/graph-handlers.ts:18`) still gets the full shape. All compaction runs at the MCP-tool-layer only.

**Pass 1 — field compaction across all read tools:**

| Tool | Before (b) | After (b) | Δt | % |
|------|-----------:|----------:|---:|---:|
| get_knowledge_graph | 7,272 | 4,344 | 732 | 40 % |
| get_neighbors | 991 | 541 | 113 | 45 % |
| get_cairn_context | 2,711 | 1,978 | 183 | 27 % |
| search_notes | 468 | 388 | 20 | 17 % |
| list_ready_tasks | 651 | 519 | 33 | 20 % |
| get_idea_flow | 1,393 | 1,316 | 19 | 6 % |
| get_active_context (chat) | 1,744 | 1,530 | 54 | 12 % |

Details: dropped `workspaceId` per node (constant across workspace-scoped graphs), flattened `meta` object to hoist only present fields, dropped synthetic edge `id`s, dropped predictable labels, shortened secondary edge keys, removed static `tools` block from `get_cairn_context`, snippet length 200→120 chars, omitted null `description`/`dueDate`/`blockedByIds` fields, dropped default `status: "active"` / `priority: "medium"` on projects, dropped `columnName` from recent tasks.

**Pass 2 — type-partitioned column encoding for `get_knowledge_graph`:**

Inspired by Headroom's SmartCrusher pattern. Nodes grouped by type (`projects` / `notes` / `cards` / `tags`), edges by type (`project-member` / `tag-member` / `note-card` / `flow-edge` / `co-mention` / `wikilink` / `semantic`). Each bucket column-encoded as `{ fields: [...], rows: [[v, v, ...], ...] }`. The `type` key drops per-row (bucket name implies it); only fields present on ≥1 record make it into the header.

| Tool | Before (b) | After (b) | Δt | % |
|------|-----------:|----------:|---:|---:|
| get_knowledge_graph | 4,344 | 3,109 | 309 | 28 % |

Buckets with fewer than 4 rows stay in verbose-object form to avoid header tax.

**Pass 3 — `get_project_context_pack` + agent-loop JSON:**

| Change | Before (b) | After (b) | Δt |
|------|-----------:|----------:|---:|
| `get_project_context_pack` | 3,259 | 2,801 | 115 |
| Agent-loop compact stringify | 20,992 | 14,560 | 1,608 |

`get_project_context_pack`: dropped `updatedAt` from each `recentActivity` entry (sorted newest-first internally; only `id` ordering consumed by tests/agent), dropped `columnName` from each `openTasks` group (top-level `project.columns` carries `{id, name, type}` for cross-reference), omitted default `status: "active"` / `priority: "medium"` on the top-level project object.

Agent loop: replaced `JSON.stringify(result, null, 2)` with compact `JSON.stringify(result)` in `electron/lib/pi-agent-loop.ts:397`. The MCP server was already emitting compact JSON; the agent-loop path was the only consumer paying indent overhead, and whitespace is pure noise to an LLM tokenizer. **~1,608 tokens saved per agent turn cycle** — bigger than every compaction in passes 1 + 2 combined.

**Overall totals:**

- MCP payload: 20,200 b → 15,010 b (**-26 %**, ~1,298 tokens saved)
- Chat-agent per-turn overhead: eliminated ~1,608 tokens of whitespace
- See `docs/plans/mcp-payload-optimization.md` for the full audit table, per-tool breakdown, and rejected alternatives.

**Compatibility:**

- All 514 unit tests pass; 11 e2e smoke tests pass.
- `get_neighbors` shape was kept as explicit objects (not column-encoded) because neighbor rows carry per-row metadata that doesn't partition well, and tests at `mcp-server.test.ts:1270-1326` assert on its shape.
- `get_active_context` (chat-only) keeps prefixed id keys (`noteId` / `columnId` / `taskId` / `projectId` / `workspaceId`) because tests at `chat-executor.test.ts:368/377/387` assert these specific keys, and prefixes mirror input arg names for the agent.
- Write tool ack payloads were reviewed but not changed (agents sometimes re-read the canonical shape after a write to confirm server-side normalisation; regression risk not worth the modest saving).
- `get_note` content blob untouched — agents call it specifically when they need the full markdown body for `patch_note` / `append_to_note` decisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the versioned changelog and added a payload optimization scratch pad with measured payload/token savings and verification steps.

* **New Features**
  * Added Light/Dark options for PDF export, including improved callout styling in exported PDFs.
  * Export filenames are now sanitized for invalid characters.

* **Tests**
  * Added payload-size benchmarking for MCP and chat tools, producing CSV reports and logging representative payload shapes.

* **Refactor / Bug Fixes**
  * Reduced tool response payloads by omitting default/empty fields and trimming optional content.
  * Agent/tool JSON output is now compact (not pretty-printed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->