### PR TITLE
feat: max steps setting for AI chat + agent token accumulation fix

### DIFF
--- a/changelogs/v2.2.2.md
+++ b/changelogs/v2.2.2.md
@@ -1,0 +1,9 @@
+## What's new
+
+### Features
+
+- **Max steps setting for AI Chat**: Settings → AI & Chat now has a "Max steps" control with number input, quick presets (10/20/30/50), and an ∞ (1000) option — matching the Coding Agent settings. Previously the chat tool loop defaulted to 20 steps with no UI to adjust it, causing complex multi-tool conversations to hit the limit prematurely. Default bumped from 20 → 30.
+
+### Fixes
+
+- **Agent completion/reasoning token accumulation**: The pi-agent loop was replacing completion and reasoning token counts each round instead of accumulating them, so the ContextRing Output section showed only the last round's tokens instead of the total for the turn. Both chat and agent paths now accumulate completion + reasoning tokens across all rounds, while prompt tokens remain last-round-only (representing current context window usage). Per-turn accumulators are reset when a new turn starts.

--- a/changelogs/v2.2.2.md
+++ b/changelogs/v2.2.2.md
@@ -7,3 +7,9 @@
 ### Fixes
 
 - **Agent completion/reasoning token accumulation**: The pi-agent loop was replacing completion and reasoning token counts each round instead of accumulating them, so the ContextRing Output section showed only the last round's tokens instead of the total for the turn. Both chat and agent paths now accumulate completion + reasoning tokens across all rounds, while prompt tokens remain last-round-only (representing current context window usage). Per-turn accumulators are reset when a new turn starts.
+- **Max steps renders for all providers**: The max steps setting was previously only rendered inside an OpenAI-specific branch, hiding it when using Local LLM or other providers. Moved outside the provider branch so it appears for all providers.
+- **LLM binary check-update 404**: `checkLLMBinaryUpdate()` was sending a GET request to `/v1/llm/binary/check-update`, but the runtime server route only accepts POST, causing a 404 error on startup. Fixed by specifying `method: "POST"` in `runtimeFetch`.
+
+### Refactor
+
+- **Settings endpoint components extraction**: Extracted shared endpoint configuration UI (Base URL, API Key, Model Selection, Connection Status) from `AISettings.tsx` and `AgentSettings.tsx` into a new `endpoint-components.tsx` module. Includes a `useEndpointConfig` hook (state + `fetchModels` logic), `BaseUrlRow`, `ApiKeyRow`, `ModelSelectionRow`, `CloudConnectionStatus` components, and exported constants (`isLocalBaseUrl`, `BASE_URL_PRESETS`, `LOCAL_FALLBACK_MODELS`, `CLOUD_FALLBACK_MODELS`). Eliminated ~360 lines of duplicated JSX.

--- a/electron/ipc/chat.ts
+++ b/electron/ipc/chat.ts
@@ -88,7 +88,7 @@ async function runToolLoop(
   onToken?: (delta: string) => void,
   onThought?: (delta: string) => void,
 ): Promise<{ exhausted: true; content: string; reasoning: string } | { exhausted: false; content: string; reasoning: string }> {
-  const maxSteps    = req.config?.maxSteps    ?? 20;
+  const maxSteps    = req.config?.maxSteps    ?? 30;
   const temperature = req.config?.temperature ?? 0.3;
   let accumulatedContent = "";
   let accumulatedReasoning = "";

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -169,6 +169,10 @@ export interface PiAgentSession {
   abortCtrl: AbortController;
   /** Most recent prompt_tokens count from the last onUsage callback. Updated each turn. */
   lastPromptTokens?: number;
+  /** Accumulated completion tokens across all rounds in the current turn. */
+  totalCompletionTokens?: number;
+  /** Accumulated reasoning tokens across all rounds in the current turn. */
+  totalReasoningTokens?: number;
   /**
    * Compaction transformer for this session. Stored here so the cachedSummary
    * inside it survives across multiple pi-agent:prompt calls on the same session.
@@ -456,6 +460,9 @@ export async function runAgentLoop(
     ?? buildSlidingWindowPruner(session, contextWindow);
 
   let steps = 0;
+  // Reset per-turn accumulators
+  session.totalCompletionTokens = 0;
+  session.totalReasoningTokens = 0;
 
   while (steps < maxSteps) {
     if (signal.aborted) { callbacks.onDone(); return; }
@@ -586,6 +593,10 @@ export async function runAgentLoop(
           const ct = chunk.usage.completion_tokens ?? 0;
           const rt = chunk.usage.completion_tokens_details?.reasoning_tokens ?? 0;
           session.lastPromptTokens = pt;
+          // Accumulate completion + reasoning across rounds (total output for the turn).
+          // Prompt tokens are last-round only (= current context window usage).
+          session.totalCompletionTokens = (session.totalCompletionTokens ?? 0) + ct;
+          session.totalReasoningTokens = (session.totalReasoningTokens ?? 0) + rt;
           let breakdown: TokenBreakdown | undefined;
           try {
             const rawBreakdown = calculatePromptBreakdown(systemPrompt, contextMessages, allTools);
@@ -593,7 +604,7 @@ export async function runAgentLoop(
           } catch (err) {
             console.error("[pi-agent] failed to calculate breakdown:", err);
           }
-          callbacks.onUsage(pt, ct, rt, breakdown);
+          callbacks.onUsage(pt, session.totalCompletionTokens ?? 0, session.totalReasoningTokens ?? 0, breakdown);
         }
 
         const delta = chunk.choices?.[0]?.delta;

--- a/electron/runtime/client.ts
+++ b/electron/runtime/client.ts
@@ -468,7 +468,7 @@ export async function checkLLMBinaryUpdate(): Promise<{
   currentVersion: string | null;
   latestVersion: string | null;
 }> {
-  return runtimeFetch("/v1/llm/binary/check-update");
+  return runtimeFetch("/v1/llm/binary/check-update", { method: "POST" });
 }
 
 export async function installLLMBinary(): Promise<void> {

--- a/src/components/chat/chat-panel/index.tsx
+++ b/src/components/chat/chat-panel/index.tsx
@@ -379,7 +379,7 @@ export function ChatPanel({ prefill, onPrefillConsumed }: ChatPanelProps = {}) {
         baseUrl:     aiConfig.baseUrl     || undefined,
         model:       aiConfig.model       || undefined,
         apiKey:      aiConfig.apiKey      || undefined,
-        maxSteps:    aiConfig.maxSteps    ?? 20,
+        maxSteps:    aiConfig.maxSteps    ?? 30,
         temperature: aiConfig.temperature ?? 0.3,
       },
       systemPrompt,

--- a/src/components/notes/markdown-pipeline.bench.test.ts
+++ b/src/components/notes/markdown-pipeline.bench.test.ts
@@ -87,7 +87,7 @@ function fmt(r: BenchResult): string {
 
 const CEILINGS: Record<string, Record<FixtureName, number>> = {
   "remark-parse":          { small: 15,  medium: 30,  large: 90   },
-  "remark-gfm+math":       { small: 15,  medium: 30,  large: 90   },
+  "remark-gfm+math":       { small: 15,  medium: 30,  large: 100  },
   "remark-callout":        { small: 10,  medium: 15,  large: 60   },
   "remark-promoteDisplay": { small: 10,  medium: 15,  large: 45   },
   "remark→hast":           { small: 15,  medium: 45,  large: 150  },

--- a/src/components/notes/notes-view/PrdModal.tsx
+++ b/src/components/notes/notes-view/PrdModal.tsx
@@ -96,7 +96,7 @@ export function PrdModal({ projectId, workspaceId, onClose }: PrdModalProps) {
         baseUrl:     aiConfig.baseUrl     || "https://api.openai.com",
         model:       aiConfig.model       || "gpt-4o-mini",
         apiKey:      aiConfig.apiKey      || "",
-        maxSteps:    aiConfig.maxSteps    ?? 20,
+        maxSteps:    aiConfig.maxSteps    ?? 30,
         temperature: aiConfig.temperature ?? 0.3,
       },
       systemPrompt: buildPrdSystemPrompt(projectId),

--- a/src/components/settings/AISettings.tsx
+++ b/src/components/settings/AISettings.tsx
@@ -860,58 +860,58 @@ export function AISettings() {
                 </div>
               </div>
             </SettingsRow>
-
-            {/* Max Steps */}
-            <SettingsRow
-              label="Max steps"
-              description="Tool-call rounds the chat can take per message. Increase for complex multi-tool tasks."
-            >
-              <div className="flex flex-col gap-1.5 items-end">
-                <div className="relative">
-                  <Footprints size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-                  <input
-                    type="number"
-                    min={1}
-                    max={1000}
-                    value={aiConfig.maxSteps ?? 30}
-                    onChange={(e) => {
-                      const v = parseInt(e.target.value, 10);
-                      if (!isNaN(v) && v >= 1 && v <= 1000) updateAIConfig({ maxSteps: v });
-                    }}
-                    className="pl-7 pr-3 py-1.5 text-xs w-24 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
-                  />
-                </div>
-                <div className="flex gap-1.5">
-                  {([10, 20, 30, 50] as const).map((n) => (
-                    <button
-                      key={n}
-                      onClick={() => updateAIConfig({ maxSteps: n })}
-                      className={cn(
-                        "px-2 py-1 text-[0.714rem] rounded border transition-colors",
-                        (aiConfig.maxSteps ?? 30) === n
-                          ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                          : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                      )}
-                    >
-                      {n}
-                    </button>
-                  ))}
-                  <button
-                    onClick={() => updateAIConfig({ maxSteps: 1000 })}
-                    className={cn(
-                      "px-2 py-1 text-[0.714rem] rounded border transition-colors",
-                      (aiConfig.maxSteps ?? 30) === 1000
-                        ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                        : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                    )}
-                  >
-                    ∞
-                  </button>
-                </div>
-              </div>
-            </SettingsRow>
           </>
         )}
+
+        {/* Max Steps — applies to all providers */}
+        <SettingsRow
+          label="Max steps"
+          description="Tool-call rounds the chat can take per message. Increase for complex multi-tool tasks."
+        >
+          <div className="flex flex-col gap-1.5 items-end">
+            <div className="relative">
+              <Footprints size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
+              <input
+                type="number"
+                min={1}
+                max={1000}
+                value={aiConfig.maxSteps ?? 30}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value, 10);
+                  if (!isNaN(v) && v >= 1 && v <= 1000) updateAIConfig({ maxSteps: v });
+                }}
+                className="pl-7 pr-3 py-1.5 text-xs w-24 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
+              />
+            </div>
+            <div className="flex gap-1.5">
+              {([10, 20, 30, 50] as const).map((n) => (
+                <button
+                  key={n}
+                  onClick={() => updateAIConfig({ maxSteps: n })}
+                  className={cn(
+                    "px-2 py-1 text-[0.714rem] rounded border transition-colors",
+                    (aiConfig.maxSteps ?? 30) === n
+                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
+                      : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
+                  )}
+                >
+                  {n}
+                </button>
+              ))}
+              <button
+                onClick={() => updateAIConfig({ maxSteps: 1000 })}
+                className={cn(
+                  "px-2 py-1 text-[0.714rem] rounded border transition-colors",
+                  (aiConfig.maxSteps ?? 30) === 1000
+                    ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
+                    : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
+                )}
+              >
+                ∞
+              </button>
+            </div>
+          </div>
+        </SettingsRow>
 
         {/* General Connection Status */}
         <div className="flex items-center gap-3 pt-1 text-xs">

--- a/src/components/settings/AISettings.tsx
+++ b/src/components/settings/AISettings.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import {
-  CheckCircle, RefreshCw, Key, Globe, Cpu, Wifi, WifiOff, Eye, EyeOff, Trash2, Star
+  CheckCircle, RefreshCw, Key, Globe, Cpu, Wifi, WifiOff, Eye, EyeOff, Trash2, Star, Footprints
 } from "lucide-react";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useCairnStore } from "@/store";
@@ -857,6 +857,56 @@ export function AISettings() {
                       {m}
                     </button>
                   ))}
+                </div>
+              </div>
+            </SettingsRow>
+
+            {/* Max Steps */}
+            <SettingsRow
+              label="Max steps"
+              description="Tool-call rounds the chat can take per message. Increase for complex multi-tool tasks."
+            >
+              <div className="flex flex-col gap-1.5 items-end">
+                <div className="relative">
+                  <Footprints size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
+                  <input
+                    type="number"
+                    min={1}
+                    max={1000}
+                    value={aiConfig.maxSteps ?? 30}
+                    onChange={(e) => {
+                      const v = parseInt(e.target.value, 10);
+                      if (!isNaN(v) && v >= 1 && v <= 1000) updateAIConfig({ maxSteps: v });
+                    }}
+                    className="pl-7 pr-3 py-1.5 text-xs w-24 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
+                  />
+                </div>
+                <div className="flex gap-1.5">
+                  {([10, 20, 30, 50] as const).map((n) => (
+                    <button
+                      key={n}
+                      onClick={() => updateAIConfig({ maxSteps: n })}
+                      className={cn(
+                        "px-2 py-1 text-[0.714rem] rounded border transition-colors",
+                        (aiConfig.maxSteps ?? 30) === n
+                          ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
+                          : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
+                      )}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                  <button
+                    onClick={() => updateAIConfig({ maxSteps: 1000 })}
+                    className={cn(
+                      "px-2 py-1 text-[0.714rem] rounded border transition-colors",
+                      (aiConfig.maxSteps ?? 30) === 1000
+                        ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
+                        : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
+                    )}
+                  >
+                    ∞
+                  </button>
                 </div>
               </div>
             </SettingsRow>

--- a/src/components/settings/AISettings.tsx
+++ b/src/components/settings/AISettings.tsx
@@ -2,17 +2,18 @@
 
 import React, { useState, useEffect } from "react";
 import {
-  CheckCircle, RefreshCw, Key, Globe, Cpu, Wifi, WifiOff, Eye, EyeOff, Trash2, Star, Footprints
+  CheckCircle, RefreshCw, Cpu, Globe, Trash2, Star
 } from "lucide-react";
-import { Tooltip } from "@/components/ui/tooltip";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
-import { SettingsGroup, SettingsRow, Toggle } from "./shared";
+import { SettingsGroup, SettingsRow, Toggle, StepperSettingsRow } from "./shared";
+import {
+  BaseUrlRow, ApiKeyRow, ModelSelectionRow, CloudConnectionStatus,
+  useEndpointConfig, isLocalBaseUrl, LOCAL_FALLBACK_MODELS,
+} from "./endpoint-components";
 import { MCPServerSettings } from "./MCPSettings";
 import type { ToggleableView } from "@/store/slices/ui";
-
-type TestState = "idle" | "testing" | "ok" | "error";
 
 export function AISettings() {
   const { aiConfig, setAIConfig, hiddenViews, toggleViewVisibility } = useCairnStore(useShallow((s) => ({
@@ -22,9 +23,10 @@ export function AISettings() {
     toggleViewVisibility: s.toggleViewVisibility,
   })));
 
-  const [showKey, setShowKey] = useState(false);
-  const [testState, setTestState] = useState<TestState>("idle");
-  const [testError, setTestError] = useState("");
+  const {
+    showKey, testState, testError, availableModels, modelsLoading,
+    setShowKey, fetchModels, resetModels,
+  } = useEndpointConfig();
 
   // Llama local model manager state
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -217,56 +219,19 @@ export function AISettings() {
     }
   }
 
-  // Available models fetched from the general endpoint
-  const [availableModels, setAvailableModels] = useState<string[]>([]);
-  const [modelsLoading, setModelsLoading] = useState(false);
-
   // General config destructuring
   const { provider = "openai", baseUrl, model, apiKey, aiEnabled } = aiConfig;
-  const isLocal =
-    baseUrl.includes("localhost") ||
-    baseUrl.includes("127.0.0.1") ||
-    baseUrl.includes("0.0.0.0");
+  const isLocal = isLocalBaseUrl(baseUrl);
 
   function updateAIConfig(patch: Partial<typeof aiConfig>) {
     setAIConfig(patch);
     if (patch.baseUrl !== undefined) {
-      setAvailableModels([]);
-    }
-  }
-
-  async function fetchModels() {
-    setModelsLoading(true);
-    try {
-      const url = (baseUrl || "https://api.openai.com").replace(/\/+$/, "").replace(/\/v1$/, "");
-      const headers: Record<string, string> = {};
-      if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
-
-      const res = await fetch(`${url}/v1/models`, { headers });
-      if (!res.ok) throw new Error(`${res.status}`);
-
-      const data = await res.json();
-      const ids: string[] = (data?.data ?? [])
-        .map((m: { id: string }) => m.id)
-        .filter((id: string) => {
-          return !id.includes("embed") && !id.includes("whisper") && !id.includes("tts") && !id.includes("dall-e");
-        })
-        .sort();
-
-      setAvailableModels(ids);
-      setTestState("ok");
-    } catch (err) {
-      setTestState("error");
-      setTestError(err instanceof Error ? err.message : "Failed to fetch models");
-      setAvailableModels([]);
-    } finally {
-      setModelsLoading(false);
-      setTimeout(() => setTestState("idle"), 5000);
+      resetModels();
     }
   }
 
   const fallbackModels = isLocal
-    ? ["llama3.2", "llama3.1", "qwen2.5:14b", "mistral", "phi4", "gemma3:12b"]
+    ? LOCAL_FALLBACK_MODELS
     : ["gpt-4o-mini", "gpt-4o", "gpt-4-turbo", "gpt-4", "o1-mini", "o3-mini"];
 
   const modelOptions = availableModels.length > 0 ? availableModels : fallbackModels;
@@ -726,192 +691,40 @@ export function AISettings() {
           </div>
         ) : (
           <>
-            {/* Base URL */}
-            <SettingsRow
-              label="Base URL"
-              description="Root URL. The chat route appends /v1/chat/completions."
-            >
-              <div className="flex flex-col gap-1.5 items-end">
-                <div className="relative">
-                  <Globe size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-                  <input
-                    type="url"
-                    value={baseUrl}
-                    onChange={(e) => updateAIConfig({ baseUrl: e.target.value })}
-                    placeholder="https://api.openai.com"
-                    className="pl-7 pr-3 py-1.5 text-xs w-64 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)]"
-                  />
-                </div>
-                <div className="flex gap-1.5">
-                  {[
-                    { label: "OpenAI", url: "https://api.openai.com" },
-                    { label: "Ollama", url: "http://localhost:11434" },
-                    { label: "LM Studio", url: "http://localhost:1234" },
-                  ].map(({ label, url }) => (
-                    <button
-                      key={label}
-                      onClick={() => updateAIConfig({ baseUrl: url })}
-                      className={cn(
-                        "px-2 py-1 text-[0.714rem] rounded border transition-colors cursor-pointer",
-                        baseUrl === url
-                          ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                          : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                      )}
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </SettingsRow>
-
-            {/* API Key */}
-            <SettingsRow
-              label="API Key"
-              description={
-                isLocal
-                  ? "Local servers don't need a key — leave blank."
-                  : "Required for OpenAI. Leave blank to use the OPENAI_API_KEY server env var."
-              }
-            >
-              <div className="relative">
-                <Key size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-                <input
-                  type={showKey ? "text" : "password"}
-                  value={apiKey}
-                  onChange={(e) => updateAIConfig({ apiKey: e.target.value })}
-                  placeholder={isLocal ? "optional" : "sk-…"}
-                  className="pl-7 pr-8 py-1.5 text-xs w-52 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)]"
-                />
-                <Tooltip content={showKey ? "Hide API key" : "Show API key"} side="top">
-                  <button
-                    onClick={() => setShowKey((s) => !s)}
-                    aria-label={showKey ? "Hide API key" : "Show API key"}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
-                  >
-                    {showKey ? <EyeOff size={11} /> : <Eye size={11} />}
-                  </button>
-                </Tooltip>
-              </div>
-            </SettingsRow>
-
-            {/* Model Selection */}
-            <SettingsRow
-              label="Model"
-              description={
-                availableModels.length > 0
-                  ? `${availableModels.length} models loaded from endpoint`
-                  : "Type a model name or fetch the list from your endpoint."
-              }
-            >
-              <div className="flex flex-col gap-1.5 items-end w-64">
-                <div className="flex gap-1.5 w-full">
-                  <div className="relative flex-1">
-                    <Cpu size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-                    <input
-                      type="text"
-                      value={model}
-                      onChange={(e) => updateAIConfig({ model: e.target.value })}
-                      placeholder="gpt-4o-mini"
-                      className="pl-7 pr-3 py-1.5 text-xs w-full rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)]"
-                    />
-                  </div>
-                  <button
-                    onClick={fetchModels}
-                    disabled={modelsLoading}
-                    aria-label="Fetch general models from endpoint"
-                    className={cn(
-                      "px-2 py-1.5 text-[0.714rem] rounded-md border transition-colors flex items-center gap-1 min-w-[52px] justify-center",
-                      "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]",
-                      modelsLoading && "opacity-50 cursor-wait"
-                    )}
-                  >
-                    <RefreshCw size={11} className={modelsLoading ? "animate-spin" : ""} />
-                    {modelsLoading ? "…" : "Fetch"}
-                  </button>
-                </div>
-
-                {testState === "error" && (
-                  <p className="text-[0.786rem] text-[var(--danger)] self-start" title={testError}>
-                    {testError.slice(0, 60)}
-                  </p>
-                )}
-                {testState === "ok" && availableModels.length > 0 && (
-                  <p className="text-[0.786rem] text-[var(--success)] self-start flex items-center gap-1">
-                    <CheckCircle size={10} /> {availableModels.length} models available
-                  </p>
-                )}
-
-                <div className="flex flex-wrap gap-1 max-h-28 overflow-y-auto w-full pr-0.5">
-                  {modelOptions.map((m) => (
-                    <button
-                      key={m}
-                      onClick={() => updateAIConfig({ model: m })}
-                      className={cn(
-                        "px-2 py-0.5 text-[0.714rem] rounded border transition-colors font-mono whitespace-nowrap",
-                        model === m
-                          ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                          : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                      )}
-                    >
-                      {m}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </SettingsRow>
+            <BaseUrlRow baseUrl={baseUrl} onChange={(url) => updateAIConfig({ baseUrl: url })} />
+            <ApiKeyRow
+              apiKey={apiKey}
+              isLocal={isLocal}
+              showKey={showKey}
+              onToggleShowKey={() => setShowKey((s) => !s)}
+              onChange={(key) => updateAIConfig({ apiKey: key })}
+            />
+            <ModelSelectionRow
+              model={model}
+              modelOptions={modelOptions}
+              availableModelsCount={availableModels.length}
+              modelsLoading={modelsLoading}
+              testState={testState}
+              testError={testError}
+              placeholder="gpt-4o-mini"
+              onModelChange={(m) => updateAIConfig({ model: m })}
+              onFetch={() => fetchModels(baseUrl, apiKey)}
+            />
           </>
         )}
 
         {/* Max Steps — applies to all providers */}
-        <SettingsRow
+        <StepperSettingsRow
           label="Max steps"
           description="Tool-call rounds the chat can take per message. Increase for complex multi-tool tasks."
-        >
-          <div className="flex flex-col gap-1.5 items-end">
-            <div className="relative">
-              <Footprints size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-              <input
-                type="number"
-                min={1}
-                max={1000}
-                value={aiConfig.maxSteps ?? 30}
-                onChange={(e) => {
-                  const v = parseInt(e.target.value, 10);
-                  if (!isNaN(v) && v >= 1 && v <= 1000) updateAIConfig({ maxSteps: v });
-                }}
-                className="pl-7 pr-3 py-1.5 text-xs w-24 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
-              />
-            </div>
-            <div className="flex gap-1.5">
-              {([10, 20, 30, 50] as const).map((n) => (
-                <button
-                  key={n}
-                  onClick={() => updateAIConfig({ maxSteps: n })}
-                  className={cn(
-                    "px-2 py-1 text-[0.714rem] rounded border transition-colors",
-                    (aiConfig.maxSteps ?? 30) === n
-                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                      : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                  )}
-                >
-                  {n}
-                </button>
-              ))}
-              <button
-                onClick={() => updateAIConfig({ maxSteps: 1000 })}
-                className={cn(
-                  "px-2 py-1 text-[0.714rem] rounded border transition-colors",
-                  (aiConfig.maxSteps ?? 30) === 1000
-                    ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                    : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                )}
-              >
-                ∞
-              </button>
-            </div>
-          </div>
-        </SettingsRow>
+          icon="footprints"
+          value={aiConfig.maxSteps ?? 30}
+          onChange={(v) => updateAIConfig({ maxSteps: v })}
+          presets={[10, 20, 30, 50, 1000]}
+          min={1}
+          max={1000}
+          formatPreset={(n) => (n === 1000 ? "∞" : String(n))}
+        />
 
         {/* General Connection Status */}
         <div className="flex items-center gap-3 pt-1 text-xs">
@@ -932,20 +745,7 @@ export function AISettings() {
               </span>
             </>
           ) : (
-            <>
-              <span className={cn(
-                "flex items-center gap-1",
-                testState === "ok" ? "text-[var(--success)]" : testState === "error" ? "text-[var(--danger)]" : "text-[var(--text-tertiary)]"
-              )}>
-                {testState === "ok" && <><CheckCircle size={11} /> Connected</>}
-                {testState === "error" && <><WifiOff size={11} /> Error</>}
-                {(testState === "idle" || testState === "testing") && <><Wifi size={11} /> {testState === "testing" ? "Connecting…" : "Not tested"}</>}
-              </span>
-              <span className="text-[var(--text-tertiary)]">·</span>
-              <span className="text-[var(--text-tertiary)] font-mono truncate max-w-40">{baseUrl.replace(/^https?:\/\//, "")}</span>
-              <span className="text-[var(--text-tertiary)]">·</span>
-              <span className="text-[var(--text-tertiary)] font-mono">{model || "no model"}</span>
-            </>
+            <CloudConnectionStatus testState={testState} baseUrl={baseUrl} model={model} />
           )}
         </div>
       </SettingsGroup>

--- a/src/components/settings/AISettings.tsx
+++ b/src/components/settings/AISettings.tsx
@@ -225,7 +225,7 @@ export function AISettings() {
 
   function updateAIConfig(patch: Partial<typeof aiConfig>) {
     setAIConfig(patch);
-    if (patch.baseUrl !== undefined) {
+    if (patch.baseUrl !== undefined || patch.apiKey !== undefined) {
       resetModels();
     }
   }

--- a/src/components/settings/AgentSettings.tsx
+++ b/src/components/settings/AgentSettings.tsx
@@ -421,7 +421,7 @@ export function AgentSettings() {
 
   function updateAgent(patch: Partial<typeof agentConfig>) {
     setAgentConfig(patch);
-    if (patch.baseUrl !== undefined) {
+    if (patch.baseUrl !== undefined || patch.apiKey !== undefined) {
       resetModelsAgent();
     }
   }

--- a/src/components/settings/AgentSettings.tsx
+++ b/src/components/settings/AgentSettings.tsx
@@ -2,18 +2,18 @@
 
 import { useState, useEffect, useCallback } from "react";
 import {
-  Plus, Trash2, Star, FolderOpen, Check, BookOpen, ChevronDown, ChevronUp, Copy, CheckCircle, RefreshCw, FileCode,
-  Key, Globe, Cpu, Wifi, WifiOff, Eye, EyeOff, Footprints, Layers, Thermometer
+  Plus, Trash2, Star, FolderOpen, Check, BookOpen, ChevronDown, ChevronUp, Copy, FileCode, CheckCircle, RefreshCw
 } from "lucide-react";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { Button } from "@/components/ui/button";
-import { Tooltip } from "@/components/ui/tooltip";
 import { id, cn } from "@/lib/utils";
 import type { CodingAgent } from "@/store/slices/coding-agents";
-import { SettingsGroup, SettingsRow } from "./shared";
-
-type TestState = "idle" | "testing" | "ok" | "error";
+import { SettingsGroup, SettingsRow, StepperSettingsRow } from "./shared";
+import {
+  BaseUrlRow, ApiKeyRow, ModelSelectionRow, CloudConnectionStatus,
+  useEndpointConfig, isLocalBaseUrl, LOCAL_FALLBACK_MODELS,
+} from "./endpoint-components";
 
 // ── Agent form ────────────────────────────────────────────────────────────────
 
@@ -408,60 +408,26 @@ export function AgentSettings() {
   const [adding, setAdding] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
 
-  const [showKeyAgent, setShowKeyAgent] = useState(false);
-  const [testStateAgent, setTestStateAgent] = useState<TestState>("idle");
-  const [testErrorAgent, setTestErrorAgent] = useState("");
-
-  const [availableModelsAgent, setAvailableModelsAgent] = useState<string[]>([]);
-  const [modelsLoadingAgent, setModelsLoadingAgent] = useState(false);
+  const {
+    showKey: showKeyAgent, testState: testStateAgent, testError: testErrorAgent,
+    availableModels: availableModelsAgent, modelsLoading: modelsLoadingAgent,
+    setShowKey: setShowKeyAgent, fetchModels: fetchModelsAgent, resetModels: resetModelsAgent,
+  } = useEndpointConfig();
 
   useEffect(() => { fetchAgents(); }, [fetchAgents]);
 
   const { baseUrl: baseUrlAgent, model: modelAgent, apiKey: apiKeyAgent, maxSteps: maxStepsAgent, temperature: temperatureAgent, contextLimit: contextLimitAgent, autoApprove = true } = agentConfig;
-  const isLocalAgent =
-    baseUrlAgent.includes("localhost") ||
-    baseUrlAgent.includes("127.0.0.1") ||
-    baseUrlAgent.includes("0.0.0.0");
+  const isLocalAgent = isLocalBaseUrl(baseUrlAgent);
 
   function updateAgent(patch: Partial<typeof agentConfig>) {
     setAgentConfig(patch);
     if (patch.baseUrl !== undefined) {
-      setAvailableModelsAgent([]);
-    }
-  }
-
-  async function fetchModelsAgent() {
-    setModelsLoadingAgent(true);
-    try {
-      const url = (baseUrlAgent || "https://api.openai.com").replace(/\/+$/, "").replace(/\/v1$/, "");
-      const headers: Record<string, string> = {};
-      if (apiKeyAgent) headers["Authorization"] = `Bearer ${apiKeyAgent}`;
-
-      const res = await fetch(`${url}/v1/models`, { headers });
-      if (!res.ok) throw new Error(`${res.status}`);
-
-      const data = await res.json();
-      const ids: string[] = (data?.data ?? [])
-        .map((m: { id: string }) => m.id)
-        .filter((id: string) => {
-          return !id.includes("embed") && !id.includes("whisper") && !id.includes("tts") && !id.includes("dall-e");
-        })
-        .sort();
-
-      setAvailableModelsAgent(ids);
-      setTestStateAgent("ok");
-    } catch (err) {
-      setTestStateAgent("error");
-      setTestErrorAgent(err instanceof Error ? err.message : "Failed to fetch models");
-      setAvailableModelsAgent([]);
-    } finally {
-      setModelsLoadingAgent(false);
-      setTimeout(() => setTestStateAgent("idle"), 5000);
+      resetModelsAgent();
     }
   }
 
   const fallbackModelsAgent = isLocalAgent
-    ? ["llama3.2", "llama3.1", "qwen2.5:14b", "mistral", "phi4", "gemma3:12b"]
+    ? LOCAL_FALLBACK_MODELS
     : ["gpt-4o", "gpt-4-turbo", "gpt-4o-mini", "o1-mini", "o3-mini"];
 
   const modelOptionsAgent = availableModelsAgent.length > 0 ? availableModelsAgent : fallbackModelsAgent;
@@ -487,269 +453,70 @@ export function AgentSettings() {
         description="Configure endpoint parameters for the native autonomous coding agent. Coding agents require high-capacity cloud/local models supporting function calling."
       >
         {/* Base URL */}
-        <SettingsRow
-          label="Base URL"
-          description="Root URL for the Coding Agent loop. Appends /v1/chat/completions."
-        >
-          <div className="flex flex-col gap-1.5 items-end">
-            <div className="relative">
-              <Globe size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-              <input
-                type="url"
-                value={baseUrlAgent}
-                onChange={(e) => updateAgent({ baseUrl: e.target.value })}
-                placeholder="https://api.openai.com"
-                className="pl-7 pr-3 py-1.5 text-xs w-64 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)]"
-              />
-            </div>
-            <div className="flex gap-1.5">
-              {[
-                { label: "OpenAI", url: "https://api.openai.com" },
-                { label: "Ollama", url: "http://localhost:11434" },
-                { label: "LM Studio", url: "http://localhost:1234" },
-              ].map(({ label, url }) => (
-                <button
-                  key={label}
-                  onClick={() => updateAgent({ baseUrl: url })}
-                  className={cn(
-                    "px-2 py-1 text-[0.714rem] rounded border transition-colors cursor-pointer",
-                    baseUrlAgent === url
-                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                      : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                  )}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-          </div>
-        </SettingsRow>
+        <BaseUrlRow baseUrl={baseUrlAgent} onChange={(url) => updateAgent({ baseUrl: url })} />
 
         {/* API Key */}
-        <SettingsRow
-          label="API Key"
-          description={
-            isLocalAgent
-              ? "Local servers don't need a key — leave blank."
-              : "Required for OpenAI. Leave blank to use the OPENAI_API_KEY server env var."
-          }
-        >
-          <div className="relative">
-            <Key size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-            <input
-              type={showKeyAgent ? "text" : "password"}
-              value={apiKeyAgent}
-              onChange={(e) => updateAgent({ apiKey: e.target.value })}
-              placeholder={isLocalAgent ? "optional" : "sk-…"}
-              className="pl-7 pr-8 py-1.5 text-xs w-52 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)]"
-            />
-            <Tooltip content={showKeyAgent ? "Hide API key" : "Show API key"} side="top">
-              <button
-                onClick={() => setShowKeyAgent((s) => !s)}
-                aria-label={showKeyAgent ? "Hide API key" : "Show API key"}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
-              >
-                {showKeyAgent ? <EyeOff size={11} /> : <Eye size={11} />}
-              </button>
-            </Tooltip>
-          </div>
-        </SettingsRow>
+        <ApiKeyRow
+          apiKey={apiKeyAgent}
+          isLocal={isLocalAgent}
+          showKey={showKeyAgent}
+          onToggleShowKey={() => setShowKeyAgent((s) => !s)}
+          onChange={(key) => updateAgent({ apiKey: key })}
+        />
 
         {/* Model Selection */}
-        <SettingsRow
-          label="Model"
-          description={
-            availableModelsAgent.length > 0
-              ? `${availableModelsAgent.length} models loaded from endpoint`
-              : "Type a model name or fetch the list from your endpoint."
-          }
-        >
-          <div className="flex flex-col gap-1.5 items-end w-64">
-            <div className="flex gap-1.5 w-full">
-              <div className="relative flex-1">
-                <Cpu size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-                <input
-                  type="text"
-                  value={modelAgent}
-                  onChange={(e) => updateAgent({ model: e.target.value })}
-                  placeholder="gpt-4o"
-                  className="pl-7 pr-3 py-1.5 text-xs w-full rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)]"
-                />
-              </div>
-              <button
-                onClick={fetchModelsAgent}
-                disabled={modelsLoadingAgent}
-                aria-label="Fetch agent models from endpoint"
-                className={cn(
-                  "px-2 py-1.5 text-[0.714rem] rounded-md border transition-colors flex items-center gap-1 min-w-[52px] justify-center",
-                  "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]",
-                  modelsLoadingAgent && "opacity-50 cursor-wait"
-                )}
-              >
-                <RefreshCw size={11} className={modelsLoadingAgent ? "animate-spin" : ""} />
-                {modelsLoadingAgent ? "…" : "Fetch"}
-              </button>
-            </div>
-
-            {testStateAgent === "error" && (
-              <p className="text-[0.786rem] text-[var(--danger)] self-start" title={testErrorAgent}>
-                {testErrorAgent.slice(0, 60)}
-              </p>
-            )}
-            {testStateAgent === "ok" && availableModelsAgent.length > 0 && (
-              <p className="text-[0.786rem] text-[var(--success)] self-start flex items-center gap-1">
-                <CheckCircle size={10} /> {availableModelsAgent.length} models available
-              </p>
-            )}
-
-            <div className="flex flex-wrap gap-1 max-h-28 overflow-y-auto w-full pr-0.5">
-              {modelOptionsAgent.map((m) => (
-                <button
-                  key={m}
-                  onClick={() => updateAgent({ model: m })}
-                  className={cn(
-                    "px-2 py-0.5 text-[0.714rem] rounded border transition-colors font-mono whitespace-nowrap",
-                    modelAgent === m
-                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                      : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                  )}
-                >
-                  {m}
-                </button>
-              ))}
-            </div>
-          </div>
-        </SettingsRow>
+        <ModelSelectionRow
+          model={modelAgent}
+          modelOptions={modelOptionsAgent}
+          availableModelsCount={availableModelsAgent.length}
+          modelsLoading={modelsLoadingAgent}
+          testState={testStateAgent}
+          testError={testErrorAgent}
+          placeholder="gpt-4o"
+          onModelChange={(m) => updateAgent({ model: m })}
+          onFetch={() => fetchModelsAgent(baseUrlAgent, apiKeyAgent)}
+        />
 
         {/* Max steps */}
-        <SettingsRow
+        <StepperSettingsRow
           label="Max steps"
           description="Tool-call rounds the agent can take per message. Use ∞ for complex multi-file tasks — but watch API costs."
-        >
-          <div className="flex flex-col gap-1.5 items-end">
-            <div className="relative">
-              <Footprints size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-              <input
-                type="number"
-                min={1}
-                max={1000}
-                value={maxStepsAgent ?? 30}
-                onChange={(e) => {
-                  const v = parseInt(e.target.value, 10);
-                  if (!isNaN(v) && v >= 1 && v <= 1000) updateAgent({ maxSteps: v });
-                }}
-                className="pl-7 pr-3 py-1.5 text-xs w-24 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
-              />
-            </div>
-            <div className="flex gap-1.5">
-              {([10, 20, 30, 50] as const).map((n) => (
-                <button
-                  key={n}
-                  onClick={() => updateAgent({ maxSteps: n })}
-                  className={cn(
-                    "px-2 py-1 text-[0.714rem] rounded border transition-colors",
-                    (maxStepsAgent ?? 30) === n
-                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                      : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                  )}
-                >
-                  {n}
-                </button>
-              ))}
-              <button
-                onClick={() => updateAgent({ maxSteps: 1000 })}
-                className={cn(
-                  "px-2 py-1 text-[0.714rem] rounded border transition-colors",
-                  (maxStepsAgent ?? 30) === 1000
-                    ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                    : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                )}
-              >
-                ∞
-              </button>
-            </div>
-          </div>
-        </SettingsRow>
+          icon="footprints"
+          value={maxStepsAgent ?? 30}
+          onChange={(v) => updateAgent({ maxSteps: v })}
+          presets={[10, 20, 30, 50, 1000]}
+          min={1}
+          max={1000}
+          formatPreset={(n) => (n === 1000 ? "∞" : String(n))}
+        />
 
         {/* Temperature */}
-        <SettingsRow
+        <StepperSettingsRow
           label="Temperature"
           description="Sampling temperature for the agent (0–1). Lower = more deterministic. Plan mode always uses 0.1 regardless of this setting."
-        >
-          <div className="flex flex-col gap-1.5 items-end">
-            <div className="relative">
-              <Thermometer size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-              <input
-                type="number"
-                min={0}
-                max={1}
-                step={0.05}
-                value={temperatureAgent ?? 0.3}
-                onChange={(e) => {
-                  const v = parseFloat(e.target.value);
-                  if (!isNaN(v) && v >= 0 && v <= 1) updateAgent({ temperature: v });
-                }}
-                className="pl-7 pr-3 py-1.5 text-xs w-24 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
-              />
-            </div>
-            <div className="flex gap-1.5">
-              {[0.1, 0.3, 0.5, 0.7].map((n) => (
-                <button
-                  key={n}
-                  onClick={() => updateAgent({ temperature: n })}
-                  className={cn(
-                    "px-2 py-1 text-[0.714rem] rounded border transition-colors",
-                    (temperatureAgent ?? 0.3) === n
-                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                      : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                  )}
-                >
-                  {n}
-                </button>
-              ))}
-            </div>
-          </div>
-        </SettingsRow>
+          icon="thermometer"
+          value={temperatureAgent ?? 0.3}
+          onChange={(v) => updateAgent({ temperature: v })}
+          presets={[0.1, 0.3, 0.5, 0.7]}
+          min={0}
+          max={1}
+          step={0.05}
+        />
 
         {/* Context window */}
-        <SettingsRow
+        <StepperSettingsRow
           label="Context window"
           description="Token limit of your model. Used to display the context usage ring in the coding agent — does not truncate or limit API calls."
-        >
-          <div className="flex flex-col gap-1.5 items-end">
-            <div className="relative">
-              <Layers size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
-              <input
-                type="number"
-                min={1000}
-                max={2000000}
-                step={1000}
-                value={contextLimitAgent ?? 128000}
-                onChange={(e) => {
-                  const v = parseInt(e.target.value, 10);
-                  if (!isNaN(v) && v >= 1000) updateAgent({ contextLimit: v });
-                }}
-                className="pl-7 pr-3 py-1.5 text-xs w-28 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
-              />
-            </div>
-            <div className="flex gap-1.5">
-              {[8000, 32000, 128000, 200000].map((n) => (
-                <button
-                  key={n}
-                  onClick={() => updateAgent({ contextLimit: n })}
-                  className={cn(
-                    "px-2 py-1 text-[0.714rem] rounded border transition-colors",
-                    (contextLimitAgent ?? 128000) === n
-                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                      : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
-                  )}
-                >
-                  {n >= 1000 ? `${n / 1000}k` : n}
-                </button>
-              ))}
-            </div>
-          </div>
-        </SettingsRow>
+          icon="layers"
+          value={contextLimitAgent ?? 128000}
+          onChange={(v) => updateAgent({ contextLimit: v })}
+          presets={[8000, 32000, 128000, 200000]}
+          min={1000}
+          max={2000000}
+          step={1000}
+          inputWidth="w-28"
+          formatPreset={(n) => (n >= 1000 ? `${n / 1000}k` : String(n))}
+        />
 
         {/* Auto-approve */}
         <SettingsRow
@@ -767,18 +534,7 @@ export function AgentSettings() {
 
         {/* Agent Connection Status */}
         <div className="flex items-center gap-3 pt-1 text-xs">
-          <span className={cn(
-            "flex items-center gap-1",
-            testStateAgent === "ok" ? "text-[var(--success)]" : testStateAgent === "error" ? "text-[var(--danger)]" : "text-[var(--text-tertiary)]"
-          )}>
-            {testStateAgent === "ok" && <><CheckCircle size={11} /> Connected</>}
-            {testStateAgent === "error" && <><WifiOff size={11} /> Error</>}
-            {(testStateAgent === "idle" || testStateAgent === "testing") && <><Wifi size={11} /> {testStateAgent === "testing" ? "Connecting…" : "Not tested"}</>}
-          </span>
-          <span className="text-[var(--text-tertiary)]">·</span>
-          <span className="text-[var(--text-tertiary)] font-mono truncate max-w-40">{baseUrlAgent.replace(/^https?:\/\//, "")}</span>
-          <span className="text-[var(--text-tertiary)]">·</span>
-          <span className="text-[var(--text-tertiary)] font-mono">{modelAgent || "no model"}</span>
+          <CloudConnectionStatus testState={testStateAgent} baseUrl={baseUrlAgent} model={modelAgent} />
         </div>
       </SettingsGroup>
 

--- a/src/components/settings/endpoint-components.tsx
+++ b/src/components/settings/endpoint-components.tsx
@@ -53,15 +53,23 @@ export function useEndpointConfig(): UseEndpointConfigResult {
   const [testError, setTestError] = useState("");
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [modelsLoading, setModelsLoading] = useState(false);
+  const abortRef = React.useRef<AbortController | null>(null);
+  const resetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchModels = useCallback(async (baseUrl: string, apiKey: string) => {
+    if (abortRef.current) abortRef.current.abort();
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    const ac = new AbortController();
+    abortRef.current = ac;
+
     setModelsLoading(true);
+    setTestState("testing");
     try {
       const url = (baseUrl || "https://api.openai.com").replace(/\/+$/, "").replace(/\/v1$/, "");
       const headers: Record<string, string> = {};
       if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
 
-      const res = await fetch(`${url}/v1/models`, { headers });
+      const res = await fetch(`${url}/v1/models`, { headers, signal: ac.signal });
       if (!res.ok) throw new Error(`${res.status}`);
 
       const data = await res.json();
@@ -72,15 +80,19 @@ export function useEndpointConfig(): UseEndpointConfigResult {
         })
         .sort();
 
+      if (ac.signal.aborted) return;
       setAvailableModels(ids);
       setTestState("ok");
     } catch (err) {
+      if (ac.signal.aborted) return;
       setTestState("error");
       setTestError(err instanceof Error ? err.message : "Failed to fetch models");
       setAvailableModels([]);
     } finally {
-      setModelsLoading(false);
-      setTimeout(() => setTestState("idle"), 5000);
+      if (!ac.signal.aborted) {
+        setModelsLoading(false);
+        resetTimerRef.current = setTimeout(() => setTestState("idle"), 5000);
+      }
     }
   }, []);
 

--- a/src/components/settings/endpoint-components.tsx
+++ b/src/components/settings/endpoint-components.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import React, { useState, useCallback } from "react";
+import { Globe, Key, Cpu, RefreshCw, Eye, EyeOff, CheckCircle, Wifi, WifiOff } from "lucide-react";
+import { Tooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { SettingsRow } from "./shared";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export type TestState = "idle" | "testing" | "ok" | "error";
+
+export const BASE_URL_PRESETS = [
+  { label: "OpenAI", url: "https://api.openai.com" },
+  { label: "Ollama", url: "http://localhost:11434" },
+  { label: "LM Studio", url: "http://localhost:1234" },
+] as const;
+
+export function isLocalBaseUrl(baseUrl: string): boolean {
+  return (
+    baseUrl.includes("localhost") ||
+    baseUrl.includes("127.0.0.1") ||
+    baseUrl.includes("0.0.0.0")
+  );
+}
+
+export const LOCAL_FALLBACK_MODELS = ["llama3.2", "llama3.1", "qwen2.5:14b", "mistral", "phi4", "gemma3:12b"];
+
+export const CLOUD_FALLBACK_MODELS = ["gpt-4o", "gpt-4-turbo", "gpt-4o-mini", "o1-mini", "o3-mini"];
+
+// ── useEndpointConfig hook ────────────────────────────────────────────────────
+
+export interface EndpointConfigState {
+  showKey: boolean;
+  testState: TestState;
+  testError: string;
+  availableModels: string[];
+  modelsLoading: boolean;
+}
+
+export interface UseEndpointConfigResult extends EndpointConfigState {
+  setShowKey: React.Dispatch<React.SetStateAction<boolean>>;
+  fetchModels: (baseUrl: string, apiKey: string) => Promise<void>;
+  resetModels: () => void;
+}
+
+/**
+ * Shared state + fetchModels logic for endpoint configuration in AISettings and AgentSettings.
+ */
+export function useEndpointConfig(): UseEndpointConfigResult {
+  const [showKey, setShowKey] = useState(false);
+  const [testState, setTestState] = useState<TestState>("idle");
+  const [testError, setTestError] = useState("");
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [modelsLoading, setModelsLoading] = useState(false);
+
+  const fetchModels = useCallback(async (baseUrl: string, apiKey: string) => {
+    setModelsLoading(true);
+    try {
+      const url = (baseUrl || "https://api.openai.com").replace(/\/+$/, "").replace(/\/v1$/, "");
+      const headers: Record<string, string> = {};
+      if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+      const res = await fetch(`${url}/v1/models`, { headers });
+      if (!res.ok) throw new Error(`${res.status}`);
+
+      const data = await res.json();
+      const ids: string[] = (data?.data ?? [])
+        .map((m: { id: string }) => m.id)
+        .filter((id: string) => {
+          return !id.includes("embed") && !id.includes("whisper") && !id.includes("tts") && !id.includes("dall-e");
+        })
+        .sort();
+
+      setAvailableModels(ids);
+      setTestState("ok");
+    } catch (err) {
+      setTestState("error");
+      setTestError(err instanceof Error ? err.message : "Failed to fetch models");
+      setAvailableModels([]);
+    } finally {
+      setModelsLoading(false);
+      setTimeout(() => setTestState("idle"), 5000);
+    }
+  }, []);
+
+  const resetModels = useCallback(() => setAvailableModels([]), []);
+
+  return { showKey, testState, testError, availableModels, modelsLoading, setShowKey, fetchModels, resetModels };
+}
+
+// ── BaseUrlRow ────────────────────────────────────────────────────────────────
+
+export function BaseUrlRow({
+  baseUrl,
+  onChange,
+  description = "Root URL. The chat route appends /v1/chat/completions.",
+}: {
+  baseUrl: string;
+  onChange: (url: string) => void;
+  description?: string;
+}) {
+  return (
+    <SettingsRow label="Base URL" description={description}>
+      <div className="flex flex-col gap-1.5 items-end">
+        <div className="relative">
+          <Globe size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
+          <input
+            type="url"
+            value={baseUrl}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="https://api.openai.com"
+            className="pl-7 pr-3 py-1.5 text-xs w-64 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)]"
+          />
+        </div>
+        <div className="flex gap-1.5">
+          {BASE_URL_PRESETS.map(({ label, url }) => (
+            <button
+              key={label}
+              onClick={() => onChange(url)}
+              className={cn(
+                "px-2 py-1 text-[0.714rem] rounded border transition-colors cursor-pointer",
+                baseUrl === url
+                  ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
+                  : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </SettingsRow>
+  );
+}
+
+// ── ApiKeyRow ─────────────────────────────────────────────────────────────────
+
+export function ApiKeyRow({
+  apiKey,
+  isLocal,
+  showKey,
+  onToggleShowKey,
+  onChange,
+}: {
+  apiKey: string;
+  isLocal: boolean;
+  showKey: boolean;
+  onToggleShowKey: () => void;
+  onChange: (key: string) => void;
+}) {
+  return (
+    <SettingsRow
+      label="API Key"
+      description={
+        isLocal
+          ? "Local servers don't need a key — leave blank."
+          : "Required for OpenAI. Leave blank to use the OPENAI_API_KEY server env var."
+      }
+    >
+      <div className="relative">
+        <Key size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
+        <input
+          type={showKey ? "text" : "password"}
+          value={apiKey}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={isLocal ? "optional" : "sk-…"}
+          className="pl-7 pr-8 py-1.5 text-xs w-52 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)]"
+        />
+        <Tooltip content={showKey ? "Hide API key" : "Show API key"} side="top">
+          <button
+            onClick={onToggleShowKey}
+            aria-label={showKey ? "Hide API key" : "Show API key"}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors cursor-pointer"
+          >
+            {showKey ? <EyeOff size={11} /> : <Eye size={11} />}
+          </button>
+        </Tooltip>
+      </div>
+    </SettingsRow>
+  );
+}
+
+// ── ModelSelectionRow ─────────────────────────────────────────────────────────
+
+export function ModelSelectionRow({
+  model,
+  modelOptions,
+  availableModelsCount,
+  modelsLoading,
+  testState,
+  testError,
+  fetchLabel = "Fetch",
+  placeholder = "gpt-4o",
+  onModelChange,
+  onFetch,
+}: {
+  model: string;
+  modelOptions: string[];
+  availableModelsCount: number;
+  modelsLoading: boolean;
+  testState: TestState;
+  testError: string;
+  fetchLabel?: string;
+  placeholder?: string;
+  onModelChange: (model: string) => void;
+  onFetch: () => void;
+}) {
+  return (
+    <SettingsRow
+      label="Model"
+      description={
+        availableModelsCount > 0
+          ? `${availableModelsCount} models loaded from endpoint`
+          : "Type a model name or fetch the list from your endpoint."
+      }
+    >
+      <div className="flex flex-col gap-1.5 items-end w-64">
+        <div className="flex gap-1.5 w-full">
+          <div className="relative flex-1">
+            <Cpu size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
+            <input
+              type="text"
+              value={model}
+              onChange={(e) => onModelChange(e.target.value)}
+              placeholder={placeholder}
+              className="pl-7 pr-3 py-1.5 text-xs w-full rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)]"
+            />
+          </div>
+          <button
+            onClick={onFetch}
+            disabled={modelsLoading}
+            aria-label={`${fetchLabel} models from endpoint`}
+            className={cn(
+              "px-2 py-1.5 text-[0.714rem] rounded-md border transition-colors flex items-center gap-1 min-w-[52px] justify-center",
+              "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]",
+              modelsLoading && "opacity-50 cursor-wait"
+            )}
+          >
+            <RefreshCw size={11} className={modelsLoading ? "animate-spin" : ""} />
+            {modelsLoading ? "…" : "Fetch"}
+          </button>
+        </div>
+
+        {testState === "error" && (
+          <p className="text-[0.786rem] text-[var(--danger)] self-start" title={testError}>
+            {testError.slice(0, 60)}
+          </p>
+        )}
+        {testState === "ok" && availableModelsCount > 0 && (
+          <p className="text-[0.786rem] text-[var(--success)] self-start flex items-center gap-1">
+            <CheckCircle size={10} /> {availableModelsCount} models available
+          </p>
+        )}
+
+        <div className="flex flex-wrap gap-1 max-h-28 overflow-y-auto w-full pr-0.5">
+          {modelOptions.map((m) => (
+            <button
+              key={m}
+              onClick={() => onModelChange(m)}
+              className={cn(
+                "px-2 py-0.5 text-[0.714rem] rounded border transition-colors font-mono whitespace-nowrap",
+                model === m
+                  ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
+                  : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
+              )}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+      </div>
+    </SettingsRow>
+  );
+}
+
+// ── CloudConnectionStatus ─────────────────────────────────────────────────────
+
+export function CloudConnectionStatus({
+  testState,
+  baseUrl,
+  model,
+}: {
+  testState: TestState;
+  baseUrl: string;
+  model: string;
+}) {
+  return (
+    <>
+      <span className={cn(
+        "flex items-center gap-1",
+        testState === "ok" ? "text-[var(--success)]" : testState === "error" ? "text-[var(--danger)]" : "text-[var(--text-tertiary)]"
+      )}>
+        {testState === "ok" && <><CheckCircle size={11} /> Connected</>}
+        {testState === "error" && <><WifiOff size={11} /> Error</>}
+        {(testState === "idle" || testState === "testing") && <><Wifi size={11} /> {testState === "testing" ? "Connecting…" : "Not tested"}</>}
+      </span>
+      <span className="text-[var(--text-tertiary)]">·</span>
+      <span className="text-[var(--text-tertiary)] font-mono truncate max-w-40">{baseUrl.replace(/^https?:\/\//, "")}</span>
+      <span className="text-[var(--text-tertiary)]">·</span>
+      <span className="text-[var(--text-tertiary)] font-mono">{model || "no model"}</span>
+    </>
+  );
+}

--- a/src/components/settings/shared.tsx
+++ b/src/components/settings/shared.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { Footprints, Thermometer, Layers } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -131,6 +131,24 @@ export function StepperSettingsRow({
   formatPreset?: (n: number) => string;
 }) {
   const Icon = ICON_MAP[icon];
+  const [draft, setDraft] = useState(String(value));
+  const blurringRef = useRef(false);
+
+  useEffect(() => {
+    if (!blurringRef.current) setDraft(String(value));
+  }, [value]);
+
+  function commit(raw: string) {
+    const v = step && step < 1 ? parseFloat(raw) : parseInt(raw, 10);
+    if (!isNaN(v)) {
+      const clamped = Math.max(min, Math.min(max, v));
+      onChange(clamped);
+      setDraft(String(clamped));
+    } else {
+      setDraft(String(value));
+    }
+  }
+
   return (
     <SettingsRow label={label} description={description}>
       <div className="flex flex-col gap-1.5 items-end">
@@ -141,10 +159,15 @@ export function StepperSettingsRow({
             min={min}
             max={max}
             step={step}
-            value={value}
-            onChange={(e) => {
-              const v = step && step < 1 ? parseFloat(e.target.value) : parseInt(e.target.value, 10);
-              if (!isNaN(v) && v >= min && v <= max) onChange(v);
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={() => {
+              blurringRef.current = true;
+              commit(draft);
+              requestAnimationFrame(() => { blurringRef.current = false; });
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") (e.target as HTMLInputElement).blur();
             }}
             className={cn(
               "pl-7 pr-3 py-1.5 text-xs rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]",

--- a/src/components/settings/shared.tsx
+++ b/src/components/settings/shared.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { Footprints, Thermometer, Layers } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // ── Layout helpers ────────────────────────────
@@ -87,5 +88,87 @@ export function Toggle({
         )}
       />
     </button>
+  );
+}
+
+// ── Stepper settings row ───────────────────────
+
+export type StepperIcon = "footprints" | "thermometer" | "layers";
+
+const ICON_MAP: Record<StepperIcon, React.ComponentType<{ size?: number; className?: string }>> = {
+  footprints: Footprints,
+  thermometer: Thermometer,
+  layers: Layers,
+};
+
+/**
+ * A SettingsRow with an icon-prefixed number input and preset quick-buttons.
+ * Used for maxSteps, temperature, and contextLimit across AISettings and AgentSettings.
+ */
+export function StepperSettingsRow({
+  label,
+  description,
+  icon,
+  value,
+  onChange,
+  presets,
+  min,
+  max,
+  step,
+  inputWidth = "w-24",
+  formatPreset,
+}: {
+  label: string;
+  description?: string;
+  icon: StepperIcon;
+  value: number;
+  onChange: (v: number) => void;
+  presets: readonly number[];
+  min: number;
+  max: number;
+  step?: number;
+  inputWidth?: string;
+  formatPreset?: (n: number) => string;
+}) {
+  const Icon = ICON_MAP[icon];
+  return (
+    <SettingsRow label={label} description={description}>
+      <div className="flex flex-col gap-1.5 items-end">
+        <div className="relative">
+          <Icon size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
+          <input
+            type="number"
+            min={min}
+            max={max}
+            step={step}
+            value={value}
+            onChange={(e) => {
+              const v = step && step < 1 ? parseFloat(e.target.value) : parseInt(e.target.value, 10);
+              if (!isNaN(v) && v >= min && v <= max) onChange(v);
+            }}
+            className={cn(
+              "pl-7 pr-3 py-1.5 text-xs rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]",
+              inputWidth,
+            )}
+          />
+        </div>
+        <div className="flex gap-1.5">
+          {presets.map((n) => (
+            <button
+              key={n}
+              onClick={() => onChange(n)}
+              className={cn(
+                "px-2 py-1 text-[0.714rem] rounded border transition-colors",
+                value === n
+                  ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
+                  : "border-[var(--border)] text-[var(--text-tertiary)] hover:border-[var(--muted)] hover:text-[var(--text-secondary)]"
+              )}
+            >
+              {formatPreset ? formatPreset(n) : n}
+            </button>
+          ))}
+        </div>
+      </div>
+    </SettingsRow>
   );
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -84,7 +84,7 @@ export const DEFAULT_AI_CONFIG: AIConfig = {
   baseUrl:      "https://api.openai.com",
   model:        "gpt-4o-mini",
   apiKey:       "",
-  maxSteps:     20,
+  maxSteps:     30,
   temperature:  0.3,
   contextLimit: 128000,
   aiEnabled:    true,


### PR DESCRIPTION
## What does this PR do?

Adds a configurable max steps setting to AI Chat (Settings → AI & Chat), matching the existing Coding Agent settings pattern with presets (10/20/30/50/∞). Also fixes token accumulation in the pi-agent loop so completion and reasoning tokens accumulate across tool-call rounds (matching the chat path), while prompt tokens remain last-round-only for accurate context window display.

## Type of change

- [x] Bug fix
- [x] New feature


## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (runs `npm run compile` first so `electron/bundle-guard.test.ts` actually executes — `npm run test:bundle` to run just that)
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts`
- [ ] New SQL goes in `electron/db/queries.ts` — single source of truth
- [ ] New `dependencies` or `devDependencies` added to `ROLE_MAP` in `scripts/generate-licenses.js` and `licenses.json` regenerated
- [ ] New MCP tools registered in `electron/mcp/tools/index.ts` dispatch + `electron/lib/tool-schemas.ts` Zod schema
- [ ] If you added/removed a `--external:<pkg>` flag in the `compile` script: updated the appropriate allowlist group in `electron/bundle-guard.test.ts`

## Notes for reviewer

- The maxSteps UI in AISettings mirrors the existing pattern in AgentSettings for consistency.
- The token accumulation fix aligns chat and agent paths — both now accumulate completion/reasoning across rounds while prompt tokens use last-round-only (current context size). Compaction is unaffected (uses `lastPromptTokens` only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Max steps** control for AI chat and inline AI (presets 10/20/30/50 plus ∞), with the default now **30** when unset.
  * The **Max steps** setting is now shown for all AI providers.
* **Bug Fixes**
  * Improved token usage reporting by accumulating completion/reasoning totals across streaming rounds within the same turn.
  * Fixed a startup issue that could prevent LLM binary update checks from working.
* **Refactor**
  * Refreshed AI/agent settings UI with shared endpoint configuration and a consistent stepper-style input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->