### PR TITLE
Implement Tool Call ID Tracking and Enhanced Chat History Support

### DIFF
--- a/changelogs/v2.2.6.md
+++ b/changelogs/v2.2.6.md
@@ -1,0 +1,14 @@
+## What's new
+
+### Features
+
+- **Chat Tool History Restoration**: Restored tool-calling memory to the completions Chat panel. Previously, the assistant would deny calling tools in previous turns because the message history payload sent to the LLM API only included raw `role` and `content` text fields. Cairn now preserves the unique `callId`, raw stringified JSON `arguments`, and execution `outputs` inside `ChatToolCallRecord` objects, and formats the conversation history with assistant `tool_calls` and corresponding `role: "tool"` responses.
+
+### Fixes
+
+- **Robust JSON Tool Arguments Parsing**: Resolved an issue where calling tools with no parameters (like `get_active_context` or `get_cairn_context`) would trigger `Malformed tool-call arguments JSON` parse errors and infinite retry loops if the model or gateway emitted empty or whitespace-only argument strings. The parsing logic now falls back to `"{}"` before invoking `JSON.parse`.
+- **Streaming Tool Chip Triggering**: Fixed a race condition inside the agent loop where the pending tool chip was not created if the tool name was not present in the first SSE chunk of the tool call. The loop now tracks whether `onToolPending` has been fired using a `streamCallIds` presence check rather than checking `isNew`.
+
+### Changes
+
+- **Preload and IPC Contracts Alignment**: Enhanced the Electron context bridge (`preload.ts`), chat completions handler (`chat.ts`), and tool execution loop (`chat-executor.ts`) to thread the unique tool `callId` and stringified `output` payload to the frontend.

--- a/electron/ipc/chat-executor.ts
+++ b/electron/ipc/chat-executor.ts
@@ -27,11 +27,12 @@ export async function executeTool(
   llmConfig: LLMConfig,
   name: string,
   args: ToolArgs,
-  emit?: (event: { tool: string; label: string; args: Record<string, unknown> }) => void,
+  emit?: (event: { tool: string; label: string; args: Record<string, unknown>; callId?: string }) => void,
   getWin?: () => BrowserWindow | null,
-  emitDone?: (event: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void,
+  emitDone?: (event: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string }; output?: string; callId?: string }) => void,
+  callId?: string,
 ): Promise<unknown> {
-  emit?.({ tool: name, label: TOOL_LABELS[name]?.(args) ?? name, args });
+  emit?.({ tool: name, label: TOOL_LABELS[name]?.(args) ?? name, args, callId });
   const snap = q.getFullSnapshot(db) as CairnSnapshot;
 
   const result = await (async () => {
@@ -276,7 +277,7 @@ export async function executeTool(
   }
 
   if (emitDone) {
-    emitDone({ tool: name, cairnRef });
+    emitDone({ tool: name, cairnRef, output: JSON.stringify(result), callId });
   }
 
   return result;

--- a/electron/ipc/chat.ts
+++ b/electron/ipc/chat.ts
@@ -80,12 +80,12 @@ async function runToolLoop(
   model: string,
   apiKey: string,
   messages: OpenAIMessage[],
-  emitToolCall: (e: { tool: string; label: string; args: Record<string, unknown> }) => void,
+  emitToolCall: (e: { tool: string; label: string; args: Record<string, unknown>; callId?: string }) => void,
   signal?: AbortSignal,
   getWin?: () => BrowserWindow | null,
   provider?: string,
   onUsage?: (pt: number, ct: number, rt?: number) => void,
-  emitToolCallDone?: (e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void,
+  emitToolCallDone?: (e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string }; output?: string; callId?: string }) => void,
   onToken?: (delta: string) => void,
   onThought?: (delta: string) => void,
 ): Promise<{ exhausted: true; content: string; reasoning: string } | { exhausted: false; content: string; reasoning: string }> {
@@ -280,12 +280,13 @@ async function runToolLoop(
       let args: Record<string, unknown>;
       let parseError: string | null = null;
       try {
-        args = JSON.parse(call.function.arguments) as Record<string, unknown>;
+        const rawArgs = call.function.arguments?.trim() || "{}";
+        args = JSON.parse(rawArgs) as Record<string, unknown>;
         traceTool("parse", {
           toolName: call.function.name,
           title: typeof args.title === "string" ? args.title : "",
           content: typeof args.content === "string" ? args.content : "",
-          rawArguments: call.function.arguments,
+          rawArguments: call.function.arguments || "",
         });
       } catch (err) {
         parseError = `Malformed tool-call arguments JSON from model: ${(err as Error).message}`;
@@ -296,8 +297,8 @@ async function runToolLoop(
       // with a descriptive error so the model can re-issue — never run
       // a tool with destructured args.
       if (parseError) {
-        emitToolCall({ tool: call.function.name, label: call.function.name, args: {} });
-        emitToolCallDone?.({ tool: call.function.name });
+        emitToolCall({ tool: call.function.name, label: call.function.name, args: {}, callId: call.id });
+        emitToolCallDone?.({ tool: call.function.name, callId: call.id });
         messages.push({
           role: "tool",
           tool_call_id: call.id,
@@ -308,7 +309,7 @@ async function runToolLoop(
 
       let result: unknown;
       try {
-        result = await executeTool(db, req, workspacePath, { baseUrl, model, apiKey, provider: provider as "openai" | "localllm" }, call.function.name, args, emitToolCall, getWin, emitToolCallDone);
+        result = await executeTool(db, req, workspacePath, { baseUrl, model, apiKey, provider: provider as "openai" | "localllm" }, call.function.name, args, emitToolCall, getWin, emitToolCallDone, call.id);
       } catch (toolErr) {
         result = { error: `Tool "${call.function.name}" failed: ${String(toolErr)}` };
       }
@@ -413,15 +414,21 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
 
     const messages: OpenAIMessage[] = [
       { role: "system", content: buildSystemPrompt(req) },
-      ...(req.history ?? []).map((m) => ({ role: m.role, content: m.content })),
+      ...(req.history ?? []).map((m) => {
+        const out: any = { role: m.role, content: m.content };
+        if (m.tool_calls) out.tool_calls = m.tool_calls;
+        if (m.tool_call_id) out.tool_call_id = m.tool_call_id;
+        if (m.name) out.name = m.name;
+        return out;
+      }),
       userMessage,
     ];
 
-    const emitToolCall = (e: { tool: string; label: string; args: Record<string, unknown> }) => {
+    const emitToolCall = (e: { tool: string; label: string; args: Record<string, unknown>; callId?: string }) => {
       send("chat:tool-call", e);
     };
 
-    const emitToolCallDone = (e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => {
+    const emitToolCallDone = (e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string }; output?: string; callId?: string }) => {
       send("chat:tool-call-done", e);
     };
 

--- a/electron/ipc/chat.ts
+++ b/electron/ipc/chat.ts
@@ -415,7 +415,7 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
     const messages: OpenAIMessage[] = [
       { role: "system", content: buildSystemPrompt(req) },
       ...(req.history ?? []).map((m) => {
-        const out: any = { role: m.role, content: m.content };
+        const out: OpenAIMessage = { role: m.role, content: m.content };
         if (m.tool_calls) out.tool_calls = m.tool_calls;
         if (m.tool_call_id) out.tool_call_id = m.tool_call_id;
         if (m.name) out.name = m.name;

--- a/electron/lib/llm.ts
+++ b/electron/lib/llm.ts
@@ -45,6 +45,7 @@ export interface LLMConfig {
 export type OpenAIMessage = {
   role: "system" | "user" | "assistant" | "tool";
   content: string | null;
+  name?: string;
   tool_call_id?: string;
   tool_calls?: Array<{
     id: string;

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -637,7 +637,7 @@ export async function runAgentLoop(
             if (tc.thought_signature) buf.thought_signature = tc.thought_signature;
 
             // Fire pending chip as soon as we see the tool name during streaming
-            if (isNew && buf.name) {
+            if (buf.name && !streamCallIds.has(idx)) {
               if (!toolsReadyFired) {
                 callbacks.onToolsReady();
                 toolsReadyFired = true;
@@ -701,12 +701,13 @@ export async function runAgentLoop(
       let args: ToolArgs;
       let parseError: string | null = null;
       try {
-        args = JSON.parse(tc.function.arguments) as ToolArgs;
+        const rawArgs = tc.function.arguments?.trim() || "{}";
+        args = JSON.parse(rawArgs) as ToolArgs;
         traceTool("parse", {
           toolName: tc.function.name,
           title: typeof (args as Record<string, unknown>).title === "string" ? (args as Record<string, unknown>).title as string : "",
           content: typeof (args as Record<string, unknown>).content === "string" ? (args as Record<string, unknown>).content as string : "",
-          rawArguments: tc.function.arguments,
+          rawArguments: tc.function.arguments || "",
         });
       } catch (err) {
         parseError = `malformed tool-call arguments JSON from model: ${(err as Error).message}`;

--- a/electron/lib/tools.ts
+++ b/electron/lib/tools.ts
@@ -86,23 +86,25 @@ export const TOOLS = (Object.entries(TOOL_SCHEMAS) as [ToolName, (typeof TOOL_SC
 void CHAT_ONLY_TOOLS;
 
 
+export interface ChatHistoryEntry {
+  role: "user" | "assistant" | "system" | "tool";
+  content: string | null;
+  tool_calls?: Array<{
+    id: string;
+    type: "function";
+    function: { name: string; arguments: string };
+    thought_signature?: string;
+  }>;
+  tool_call_id?: string;
+  name?: string;
+}
+
 export interface ChatRequest {
   message: string;
   threadId: string;
   projectId?: string;
   workspaceId?: string;
-  history?: Array<{
-    role: "user" | "assistant" | "system" | "tool";
-    content: string | null;
-    tool_calls?: Array<{
-      id: string;
-      type: "function";
-      function: { name: string; arguments: string };
-      thought_signature?: string;
-    }>;
-    tool_call_id?: string;
-    name?: string;
-  }>;
+  history?: ChatHistoryEntry[];
   config?: { baseUrl?: string; model?: string; apiKey?: string; maxSteps?: number; temperature?: number };
   systemPrompt?: string;
   images?: Array<{ name: string; dataUrl: string }>;

--- a/electron/lib/tools.ts
+++ b/electron/lib/tools.ts
@@ -91,7 +91,13 @@ export interface ChatRequest {
   threadId: string;
   projectId?: string;
   workspaceId?: string;
-  history?: Array<{ role: "user" | "assistant" | "system"; content: string }>;
+  history?: Array<{
+    role: "user" | "assistant" | "system" | "tool";
+    content: string | null;
+    tool_calls?: any[];
+    tool_call_id?: string;
+    name?: string;
+  }>;
   config?: { baseUrl?: string; model?: string; apiKey?: string; maxSteps?: number; temperature?: number };
   systemPrompt?: string;
   images?: Array<{ name: string; dataUrl: string }>;

--- a/electron/lib/tools.ts
+++ b/electron/lib/tools.ts
@@ -94,7 +94,12 @@ export interface ChatRequest {
   history?: Array<{
     role: "user" | "assistant" | "system" | "tool";
     content: string | null;
-    tool_calls?: any[];
+    tool_calls?: Array<{
+      id: string;
+      type: "function";
+      function: { name: string; arguments: string };
+      thought_signature?: string;
+    }>;
     tool_call_id?: string;
     name?: string;
   }>;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -145,15 +145,15 @@ const api = {
       ipcRenderer.on("chat:done", handler);
       return () => ipcRenderer.off("chat:done", handler);
     },
-    onToolCall: (cb: (e: { tool: string; label: string; args: Record<string, unknown> }) => void) => {
+    onToolCall: (cb: (e: { tool: string; label: string; args: Record<string, unknown>; callId?: string }) => void) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const handler = (_: any, e: { tool: string; label: string; args: Record<string, unknown> }) => cb(e);
+      const handler = (_: any, e: { tool: string; label: string; args: Record<string, unknown>; callId?: string }) => cb(e);
       ipcRenderer.on("chat:tool-call", handler);
       return () => ipcRenderer.off("chat:tool-call", handler);
     },
-    onToolCallDone: (cb: (e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => void) => {
+    onToolCallDone: (cb: (e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string }; output?: string; callId?: string }) => void) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const handler = (_: any, e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string } }) => cb(e);
+      const handler = (_: any, e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string }; output?: string; callId?: string }) => cb(e);
       ipcRenderer.on("chat:tool-call-done", handler);
       return () => ipcRenderer.off("chat:tool-call-done", handler);
     },

--- a/src/components/chat/chat-panel/index.tsx
+++ b/src/components/chat/chat-panel/index.tsx
@@ -410,7 +410,11 @@ export function ChatPanel({ prefill, onPrefillConsumed, popoutMode }: ChatPanelP
       const history: Array<{
         role: string;
         content: string | null;
-        tool_calls?: any[];
+        tool_calls?: Array<{
+          id: string;
+          type: "function";
+          function: { name: string; arguments: string };
+        }>;
         tool_call_id?: string;
         name?: string;
       }> = [];

--- a/src/components/chat/chat-panel/index.tsx
+++ b/src/components/chat/chat-panel/index.tsx
@@ -9,6 +9,8 @@ import { buildGraphContext } from "@/components/graph/graph-ai-utils";
 import { ipcAwaitResult } from "@/store/ipc";
 import { resolvePromptContext } from "@/lib/context-resolver";
 
+import type { ChatHistoryEntry } from "@/types";
+
 import { Tooltip } from "@/components/ui/tooltip";
 import { ChatMessageBubble } from "./ChatMessageBubble";
 import { SuggestedPrompts } from "./SuggestedPrompts";
@@ -407,17 +409,7 @@ export function ChatPanel({ prefill, onPrefillConsumed, popoutMode }: ChatPanelP
     }
 
     const formatChatHistory = (msgs: typeof messages) => {
-      const history: Array<{
-        role: string;
-        content: string | null;
-        tool_calls?: Array<{
-          id: string;
-          type: "function";
-          function: { name: string; arguments: string };
-        }>;
-        tool_call_id?: string;
-        name?: string;
-      }> = [];
+      const history: ChatHistoryEntry[] = [];
       msgs.slice(-40).forEach((m) => {
         if (m.role === "user") {
           history.push({

--- a/src/components/chat/chat-panel/index.tsx
+++ b/src/components/chat/chat-panel/index.tsx
@@ -406,11 +406,61 @@ export function ChatPanel({ prefill, onPrefillConsumed, popoutMode }: ChatPanelP
       systemPrompt = `## Context\n- **Date:** ${date}\n\n${GRAPH_SYSTEM_PROMPT}\n\n--- CURRENT GRAPH SNAPSHOT ---\n${graphContext}`;
     }
 
+    const formatChatHistory = (msgs: typeof messages) => {
+      const history: Array<{
+        role: string;
+        content: string | null;
+        tool_calls?: any[];
+        tool_call_id?: string;
+        name?: string;
+      }> = [];
+      msgs.slice(-40).forEach((m) => {
+        if (m.role === "user") {
+          history.push({
+            role: "user",
+            content: m.content || "",
+          });
+        } else if (m.role === "assistant") {
+          const toolCalls = m.toolCalls?.filter((tc) => tc.callId && tc.args);
+          if (toolCalls && toolCalls.length > 0) {
+            history.push({
+              role: "assistant",
+              content: m.content || null,
+              tool_calls: toolCalls.map((tc) => ({
+                id: tc.callId!,
+                type: "function" as const,
+                function: { name: tc.tool, arguments: tc.args! }
+              }))
+            });
+            toolCalls.forEach((tc) => {
+              history.push({
+                role: "tool",
+                tool_call_id: tc.callId!,
+                name: tc.tool,
+                content: tc.output || "{}"
+              });
+            });
+          } else {
+            history.push({
+              role: "assistant",
+              content: m.content || null,
+            });
+          }
+        } else if (m.role === "system") {
+          history.push({
+            role: "system",
+            content: m.content || "",
+          });
+        }
+      });
+      return history;
+    };
+
     sendStream({
       message: resolvedMessage, threadId,
       projectId: activeProjectId,
       workspaceId: activeWorkspaceId,
-      history: messages.slice(-40).map((m) => ({ role: m.role, content: m.content })),
+      history: formatChatHistory(messages),
       config: {
         provider:    aiConfig.provider    || "openai",
         baseUrl:     aiConfig.baseUrl     || undefined,

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -26,6 +26,9 @@ export interface ChatToolCall {
   /** "running" = currently executing; "done" = completed this turn */
   status: "running" | "done";
   cairnRef?: { type: "note" | "task"; id: string; title: string };
+  callId?: string;
+  args?: string;
+  output?: string;
 }
 
 export interface PendingQuestion {
@@ -39,7 +42,13 @@ export interface ChatStreamRequest {
   threadId: string;
   projectId: string | null | undefined;
   workspaceId: string | null | undefined;
-  history: Array<{ role: string; content: string }>;
+  history: Array<{
+    role: string;
+    content: string | null;
+    tool_calls?: any[];
+    tool_call_id?: string;
+    name?: string;
+  }>;
   config: {
     provider?: string;
     baseUrl?: string;
@@ -103,7 +112,13 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
           const updated = prev.map((tc) =>
             tc.status === "running" ? { ...tc, status: "done" as const } : tc
           );
-          const next = [...updated, { tool: e.tool, label: e.label, status: "running" as const }];
+          const next = [...updated, {
+            tool: e.tool,
+            label: e.label,
+            status: "running" as const,
+            callId: e.callId,
+            args: e.args ? JSON.stringify(e.args) : undefined
+          }];
           toolCallsRef.current = next;
           return next;
         });
@@ -116,7 +131,7 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
         if (lastIdx === -1) return prev;
         const idx = prev.length - 1 - lastIdx;
         const updated = [...prev];
-        updated[idx] = { ...updated[idx], cairnRef: e.cairnRef };
+        updated[idx] = { ...updated[idx], cairnRef: e.cairnRef, output: e.output };
         toolCallsRef.current = updated;
         return updated;
       });

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -18,7 +18,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useCairnStore } from "@/store";
-import type { SuggestedAction, TokenBreakdown } from "@/types";
+import type { SuggestedAction, TokenBreakdown, ChatHistoryEntry } from "@/types";
 
 export interface ChatToolCall {
   tool: string;
@@ -42,17 +42,7 @@ export interface ChatStreamRequest {
   threadId: string;
   projectId: string | null | undefined;
   workspaceId: string | null | undefined;
-  history: Array<{
-    role: string;
-    content: string | null;
-    tool_calls?: Array<{
-      id: string;
-      type: "function";
-      function: { name: string; arguments: string };
-    }>;
-    tool_call_id?: string;
-    name?: string;
-  }>;
+  history: ChatHistoryEntry[];
   config: {
     provider?: string;
     baseUrl?: string;
@@ -131,9 +121,17 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
 
     const unsubToolDone = electron.chat.onToolCallDone?.((e) => {
       setToolCalls((prev) => {
-        const lastIdx = [...prev].reverse().findIndex((tc) => tc.tool === e.tool);
-        if (lastIdx === -1) return prev;
-        const idx = prev.length - 1 - lastIdx;
+        let idx = -1;
+        if (e.callId) {
+          idx = prev.findIndex((tc) => tc.callId === e.callId);
+        }
+        if (idx === -1) {
+          const lastIdx = [...prev].reverse().findIndex((tc) => tc.tool === e.tool);
+          if (lastIdx !== -1) {
+            idx = prev.length - 1 - lastIdx;
+          }
+        }
+        if (idx === -1) return prev;
         const updated = [...prev];
         updated[idx] = { ...updated[idx], cairnRef: e.cairnRef, output: e.output };
         toolCallsRef.current = updated;

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -45,7 +45,11 @@ export interface ChatStreamRequest {
   history: Array<{
     role: string;
     content: string | null;
-    tool_calls?: any[];
+    tool_calls?: Array<{
+      id: string;
+      type: "function";
+      function: { name: string; arguments: string };
+    }>;
     tool_call_id?: string;
     name?: string;
   }>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -180,6 +180,9 @@ export interface ChatToolCallRecord {
   tool: string;
   label: string;
   cairnRef?: { type: "note" | "task"; id: ID; title: string };
+  callId?: string;
+  args?: string;      // JSON arguments string
+  output?: string;    // JSON output string
 }
 
 export type SuggestedAction =

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -191,6 +191,18 @@ export type SuggestedAction =
   | { type: "link_note_card"; noteId: string; noteTitle: string; cardId: string; cardTitle: string; reason: string }
   | { type: "add_tag";        nodeId: string; nodeTitle: string; nodeType: "note" | "card"; tagName: string; reason: string };
 
+export interface ChatHistoryEntry {
+  role: string;
+  content: string | null;
+  tool_calls?: Array<{
+    id: string;
+    type: "function";
+    function: { name: string; arguments: string };
+  }>;
+  tool_call_id?: string;
+  name?: string;
+}
+
 export interface ChatMessage {
   id: ID;
   threadId: ID;


### PR DESCRIPTION
What does this PR do?

This PR improves the reliability and traceability of tool execution within the chat system. Key changes include:
- **Tool Call IDs**: Added `callId` support to tool execution events (`chat:tool-call` and `chat:tool-call-done`), ensuring individual tool invocations are uniquely identifiable.
- **Enhanced Chat History**: Expanded `ChatRequest` history types to support `tool` roles, `tool_calls`, and `tool_call_id` fields, allowing the model to correctly maintain state across tool-use cycles.
- **Robustness**: Improved JSON parsing logic for tool arguments to handle empty or malformed strings gracefully and included tool output in the completion event.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Docs / changelog
- [ ] Tests

## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run test:e2e` passes
- [ ] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [ ] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts`
- [ ] New SQL goes in `electron/db/queries.ts` — single source of truth (imported by both Electron main process and MCP server); never construct a `Database` instance outside `db/client.ts` (Electron) or `mcp-server.ts` (MCP runtime)
- [ ] New `dependencies` or `devDependencies` added to `ROLE_MAP` in `scripts/generate-licenses.js` and `licenses.json` regenerated
- [ ] New MCP tools registered in `electron/mcp/tools/index.ts` dispatch + `electron/lib/tool-schemas.ts` Zod schema
- [ ] If you added/removed a `--external:<pkg>` flag in the `compile` script: updated the appropriate allowlist group (`RUNTIME_PROVIDED` / `OPTIONAL_TRANSITIVE` / `SUBPROCESS_ONLY` / `SHIPPED_NATIVE`) in `electron/bundle-guard.test.ts` and (if `SHIPPED_NATIVE`) shipped the package via `electron-builder.yml`

## Notes for reviewer

I've ensured that `callId` is propagated throughout the execution flow. The history handling was updated to properly map `tool_calls` and `tool_call_id` so that multi-turn model interactions that require tool results function as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat and streaming now preserve tool activity more completely, including unique tool call IDs, tool arguments, and tool outputs, so tool calls and results display more consistently in conversation history.

* **Bug Fixes**
  * Improved handling of empty or malformed tool arguments to prevent parse errors and retry loops.
  * Fixed a streaming race condition where the “tool pending” indicator could fail to appear.
  * Tool call history now round-trips more reliably across chat sessions and restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->