### PR TITLE
Update `ensure_note` to preserve content when content is omitted during updates

### DIFF
--- a/changelogs/v2.2.7.md
+++ b/changelogs/v2.2.7.md
@@ -4,6 +4,10 @@
 
 - **Bidirectional Link Removal**: Introduced the `unlink_note_from_task` tool to allow bidirectionally removing links between task cards and notes.
 - **Task Dependencies Visibility**: Added `blockingCardIds: string[]` to the output of `get_task` tool, letting the model discover which tasks are blocked by a given card without pulling the entire graph.
+- **Safe Note Renaming**: Added the `rename_note` tool to rename notes on disk and in the DB. The tool automatically rewrites inbound wikilinks (`[[Old Title]]` to `[[New Title]]`) in all other notes to keep links intact.
+- **Bulk Folder Moves**: Added the `bulk_move_notes` tool to move multiple notes to a subfolder in a single call, speeding up reorganization.
+- **Folder List Tree**: Added the `list_folders` tool to query and output all active folder paths used within a project's notes.
+- **Search Notes Advanced Parameters**: Added pagination (`offset`) and filtering (`updatedAfter`) parameters to `search_notes` to handle large workspaces efficiently and find recently updated notes.
 
 ### Fixes
 

--- a/changelogs/v2.2.7.md
+++ b/changelogs/v2.2.7.md
@@ -1,9 +1,15 @@
 ## What's new
 
+### Features
+
+- **Bidirectional Link Removal**: Introduced the `unlink_note_from_task` tool to allow bidirectionally removing links between task cards and notes.
+- **Task Dependencies Visibility**: Added `blockingCardIds: string[]` to the output of `get_task` tool, letting the model discover which tasks are blocked by a given card without pulling the entire graph.
+
 ### Fixes
 
 - **Note Content Preservation on Update**: Fixed a data loss bug in `ensure_note` where calling the tool to update metadata (such as moving a note to a subfolder, pinning, or tagging) without providing the `content` argument would overwrite the note's existing content with an empty string (`""`). The `ensure_note` tool now preserves the existing note content if the `content` argument is omitted (`undefined`).
 - **Template Literal Escaping in Prompt**: Fixed a syntax error in esbuild packaging where unescaped backticks around the `content` parameter description inside the system prompt builder closed the template literal string prematurely, preventing builds and typescript type checking from passing.
+- **Note-Task Linking File Sync**: Updated `link_note_to_task` to accept `workspacePath` and trigger `writeNoteFile` to keep the frontmatter of notes in the physical file system synchronized with link metadata updates in the database.
 
 ### Changes
 

--- a/changelogs/v2.2.7.md
+++ b/changelogs/v2.2.7.md
@@ -1,0 +1,10 @@
+## What's new
+
+### Fixes
+
+- **Note Content Preservation on Update**: Fixed a data loss bug in `ensure_note` where calling the tool to update metadata (such as moving a note to a subfolder, pinning, or tagging) without providing the `content` argument would overwrite the note's existing content with an empty string (`""`). The `ensure_note` tool now preserves the existing note content if the `content` argument is omitted (`undefined`).
+- **Template Literal Escaping in Prompt**: Fixed a syntax error in esbuild packaging where unescaped backticks around the `content` parameter description inside the system prompt builder closed the template literal string prematurely, preventing builds and typescript type checking from passing.
+
+### Changes
+
+- **AI Tools Schema Descriptions**: Enhanced the Zod schema and system prompt definitions for `ensure_note` to explicitly instruct the LLM that the `content` parameter is optional and that omitting it preserves the existing note body, enabling the model to perform metadata and folder-reorganization actions efficiently without a read-then-write cycle.

--- a/electron/ipc/chat-executor.test.ts
+++ b/electron/ipc/chat-executor.test.ts
@@ -538,6 +538,85 @@ describe("ensure_note", () => {
   });
 });
 
+describe("rename_note", () => {
+  it("renames a note and rewrites wikilinks in other notes", async () => {
+    const db = makeDb();
+    seed(db);
+    // Create note2 which links to note1
+    createNote(db, { id: "note2", projectId: "proj1", workspaceId: "ws1", title: "Note Two", content: "Links to [[My Note]]", contentText: "Links to [[My Note]]" });
+
+    // Rename note1 ("My Note") to "New Title"
+    const result = await exec(db, "rename_note", { noteId: "note1", newTitle: "New Title" }) as Record<string, unknown>;
+    expect(result.title).toBe("New Title");
+    expect(result.action).toBe("renamed");
+
+    // Verify note1 title changed
+    const note1 = await exec(db, "get_note", { noteId: "note1" }) as Record<string, unknown>;
+    expect(note1.title).toBe("New Title");
+
+    // Verify note2's wikilink rewritten to [[New Title]]
+    const note2 = await exec(db, "get_note", { noteId: "note2" }) as Record<string, unknown>;
+    expect(note2.content).toBe("Links to [[New Title]]");
+  });
+});
+
+describe("bulk_move_notes", () => {
+  it("moves multiple notes to a folder", async () => {
+    const db = makeDb();
+    seed(db);
+    createNote(db, { id: "note2", projectId: "proj1", workspaceId: "ws1", title: "Note Two", content: "hello", contentText: "hello" });
+
+    const result = await exec(db, "bulk_move_notes", { noteIds: ["note1", "note2"], folder: "Archive/Old" }) as Record<string, unknown>;
+    expect(result.moved).toBe(2);
+
+    const note1 = await exec(db, "get_note", { noteId: "note1" }) as Record<string, unknown>;
+    expect(note1.folder).toBe("Archive/Old");
+
+    const note2 = await exec(db, "get_note", { noteId: "note2" }) as Record<string, unknown>;
+    expect(note2.folder).toBe("Archive/Old");
+  });
+});
+
+describe("list_folders", () => {
+  it("returns unique folders inside a project", async () => {
+    const db = makeDb();
+    seed(db);
+    await exec(db, "ensure_note", { projectId: "proj1", title: "Folder A note", folder: "Folder A" });
+    await exec(db, "ensure_note", { projectId: "proj1", title: "Folder B note", folder: "Folder B" });
+    await exec(db, "ensure_note", { projectId: "proj1", title: "Folder A another note", folder: "Folder A" });
+
+    const result = await exec(db, "list_folders", { projectId: "proj1" }) as Record<string, unknown>;
+    expect(result.folders as string[]).toContain("Folder A");
+    expect(result.folders as string[]).toContain("Folder B");
+    expect((result.folders as string[])).toHaveLength(2);
+  });
+});
+
+describe("search_notes advanced parameters", () => {
+  it("supports offset pagination", async () => {
+    const db = makeDb();
+    seed(db);
+    createNote(db, { id: "note2", projectId: "proj1", workspaceId: "ws1", title: "Note Two", content: "hello", contentText: "hello" });
+    createNote(db, { id: "note3", projectId: "proj1", workspaceId: "ws1", title: "Note Three", content: "hello", contentText: "hello" });
+
+    const results = await exec(db, "search_notes", { query: "hello", limit: 2, offset: 1 }) as Array<Record<string, unknown>>;
+    expect(results).toHaveLength(2);
+  });
+
+  it("filters notes by updatedAfter", async () => {
+    const db = makeDb();
+    seed(db);
+    
+    createNote(db, { id: "note2", projectId: "proj1", workspaceId: "ws1", title: "Old Note", content: "hello", contentText: "hello" });
+    db.prepare("UPDATE notes SET updated_at = '2020-01-01T00:00:00.000Z' WHERE id = 'note2'").run();
+
+    const results = await exec(db, "search_notes", { query: "hello", updatedAfter: "2025-01-01T00:00:00.000Z" }) as Array<Record<string, unknown>>;
+    const ids = results.map(r => r.id);
+    expect(ids).toContain("note1");
+    expect(ids).not.toContain("note2");
+  });
+});
+
 // ── append_to_note ────────────────────────────────────────────────────────────
 
 describe("append_to_note", () => {

--- a/electron/ipc/chat-executor.test.ts
+++ b/electron/ipc/chat-executor.test.ts
@@ -145,6 +145,15 @@ describe("get_task", () => {
     const result = await exec(db, "get_task", { cardId: "nope" }) as Record<string, unknown>;
     expect(result).toHaveProperty("error");
   });
+
+  it("returns blockingCardIds when other cards are blocked by this task", async () => {
+    const db = makeDb();
+    seed(db);
+    createCard(db, { id: "card2", columnId: "col1", projectId: "proj1", workspaceId: "ws1", title: "Task Two", order: 1 });
+    db.prepare("UPDATE task_cards SET blocked_by_ids = '[\"card1\"]' WHERE id = 'card2'").run();
+    const result = await exec(db, "get_task", { cardId: "card1" }) as Record<string, unknown>;
+    expect(result.blockingCardIds).toContain("card2");
+  });
 });
 
 // ── get_note ──────────────────────────────────────────────────────────────────
@@ -330,6 +339,43 @@ describe("link_note_to_task", () => {
     seed(db);
     const result = await exec(db, "link_note_to_task", { noteId: "nope", cardId: "card1" }) as Record<string, unknown>;
     expect(result).toHaveProperty("error");
+  });
+});
+
+describe("unlink_note_from_task", () => {
+  it("unlinks note and card bidirectionally", async () => {
+    const db = makeDb();
+    seed(db);
+    // Link them first
+    await exec(db, "link_note_to_task", { noteId: "note1", cardId: "card1" });
+    
+    // Check they are linked in DB
+    const notePre = await exec(db, "get_note", { noteId: "note1" }) as Record<string, unknown>;
+    expect(notePre.linkedCardIds).toContain("card1");
+    
+    const taskPre = await exec(db, "get_task", { cardId: "card1" }) as Record<string, unknown>;
+    expect(taskPre.linkedNoteIds).toContain("note1");
+
+    // Unlink
+    const result = await exec(db, "unlink_note_from_task", { noteId: "note1", cardId: "card1" }) as Record<string, unknown>;
+    expect(result.unlinked).toBe(true);
+
+    // Verify unlinked
+    const notePost = await exec(db, "get_note", { noteId: "note1" }) as Record<string, unknown>;
+    expect(notePost.linkedCardIds).not.toContain("card1");
+    
+    const taskPost = await exec(db, "get_task", { cardId: "card1" }) as Record<string, unknown>;
+    expect(taskPost.linkedNoteIds).not.toContain("note1");
+  });
+
+  it("returns { error } for missing note or task", async () => {
+    const db = makeDb();
+    seed(db);
+    const result1 = await exec(db, "unlink_note_from_task", { noteId: "nope", cardId: "card1" }) as Record<string, unknown>;
+    expect(result1).toHaveProperty("error");
+
+    const result2 = await exec(db, "unlink_note_from_task", { noteId: "note1", cardId: "nope" }) as Record<string, unknown>;
+    expect(result2).toHaveProperty("error");
   });
 });
 

--- a/electron/ipc/chat-executor.test.ts
+++ b/electron/ipc/chat-executor.test.ts
@@ -436,6 +436,19 @@ describe("ensure_note", () => {
     expect(result.action).toBe("updated");
   });
 
+  it("preserves content on update when content argument is omitted", async () => {
+    const db = makeDb();
+    seed(db);
+    await exec(db, "ensure_note", { projectId: "proj1", title: "README", content: "initial content" });
+    const result = await exec(db, "ensure_note", { projectId: "proj1", title: "README", folder: "new_folder" }) as Record<string, unknown>;
+    expect(result.action).toBe("updated");
+    expect(result.folder).toBe("new_folder");
+    
+    const note = await exec(db, "get_note", { noteId: result.id }) as Record<string, unknown>;
+    expect(note.content).toBe("initial content");
+  });
+
+
   it("only one note exists after two ensure calls with same title", async () => {
     const db = makeDb();
     seed(db);

--- a/electron/ipc/chat-executor.test.ts
+++ b/electron/ipc/chat-executor.test.ts
@@ -598,9 +598,19 @@ describe("search_notes advanced parameters", () => {
     seed(db);
     createNote(db, { id: "note2", projectId: "proj1", workspaceId: "ws1", title: "Note Two", content: "hello", contentText: "hello" });
     createNote(db, { id: "note3", projectId: "proj1", workspaceId: "ws1", title: "Note Three", content: "hello", contentText: "hello" });
+    // Deterministic updated_at: note3 newest, note1 oldest
+    db.prepare("UPDATE notes SET updated_at = '2023-01-01T00:00:00.000Z' WHERE id = 'note1'").run();
+    db.prepare("UPDATE notes SET updated_at = '2024-01-01T00:00:00.000Z' WHERE id = 'note2'").run();
+    db.prepare("UPDATE notes SET updated_at = '2025-01-01T00:00:00.000Z' WHERE id = 'note3'").run();
 
-    const results = await exec(db, "search_notes", { query: "hello", limit: 2, offset: 1 }) as Array<Record<string, unknown>>;
-    expect(results).toHaveLength(2);
+    const page1 = await exec(db, "search_notes", { query: "hello", limit: 1, offset: 0 }) as Array<Record<string, unknown>>;
+    expect(page1.map((r) => r.id)).toEqual(["note3"]);
+
+    const page2 = await exec(db, "search_notes", { query: "hello", limit: 1, offset: 1 }) as Array<Record<string, unknown>>;
+    expect(page2.map((r) => r.id)).toEqual(["note2"]);
+
+    const page3 = await exec(db, "search_notes", { query: "hello", limit: 2, offset: 1 }) as Array<Record<string, unknown>>;
+    expect(page3.map((r) => r.id)).toEqual(["note2", "note1"]);
   });
 
   it("filters notes by updatedAfter", async () => {

--- a/electron/ipc/chat-executor.test.ts
+++ b/electron/ipc/chat-executor.test.ts
@@ -436,16 +436,24 @@ describe("ensure_note", () => {
     expect(result.action).toBe("updated");
   });
 
-  it("preserves content on update when content argument is omitted", async () => {
+  it("preserves content on update when content argument is omitted but clears it when content is empty string", async () => {
     const db = makeDb();
     seed(db);
+    // 1. Omitted content case
     await exec(db, "ensure_note", { projectId: "proj1", title: "README", content: "initial content" });
-    const result = await exec(db, "ensure_note", { projectId: "proj1", title: "README", folder: "new_folder" }) as Record<string, unknown>;
-    expect(result.action).toBe("updated");
-    expect(result.folder).toBe("new_folder");
+    const result1 = await exec(db, "ensure_note", { projectId: "proj1", title: "README", folder: "new_folder" }) as Record<string, unknown>;
+    expect(result1.action).toBe("updated");
+    expect(result1.folder).toBe("new_folder");
     
-    const note = await exec(db, "get_note", { noteId: result.id }) as Record<string, unknown>;
-    expect(note.content).toBe("initial content");
+    const note1 = await exec(db, "get_note", { noteId: result1.id }) as Record<string, unknown>;
+    expect(note1.content).toBe("initial content");
+
+    // 2. Empty string content case
+    const result2 = await exec(db, "ensure_note", { projectId: "proj1", title: "README", content: "" }) as Record<string, unknown>;
+    expect(result2.action).toBe("updated");
+
+    const note2 = await exec(db, "get_note", { noteId: result2.id }) as Record<string, unknown>;
+    expect(note2.content).toBe("");
   });
 
 

--- a/electron/ipc/chat-executor.ts
+++ b/electron/ipc/chat-executor.ts
@@ -121,6 +121,7 @@ export async function executeTool(
     case "delete_task":
     case "bulk_update_task_status":
     case "link_note_to_task":
+    case "unlink_note_from_task":
     case "create_task":
     case "list_ready_tasks":
     case "upsert_project":

--- a/electron/ipc/chat-executor.ts
+++ b/electron/ipc/chat-executor.ts
@@ -124,6 +124,8 @@ export async function executeTool(
     case "unlink_note_from_task":
     case "create_task":
     case "list_ready_tasks":
+    case "list_folders":
+    case "bulk_move_notes":
     case "upsert_project":
     case "delete_project":
     case "create_tag":
@@ -170,6 +172,16 @@ export async function executeTool(
       }
     }
     case "patch_note": {
+      const win = getWin?.() ?? null;
+      const noteId = args.noteId as string;
+      aiWriteLock.lock(noteId, win);
+      try {
+        return executeMcpTool(db, workspacePath, name, args);
+      } finally {
+        aiWriteLock.unlock(noteId, win);
+      }
+    }
+    case "rename_note": {
       const win = getWin?.() ?? null;
       const noteId = args.noteId as string;
       aiWriteLock.lock(noteId, win);
@@ -262,7 +274,7 @@ export async function executeTool(
     
     // For note tools, the result contains ID and title.
     const isNote = [
-      "get_note", "ensure_note", "patch_note", "append_to_note"
+      "get_note", "ensure_note", "patch_note", "append_to_note", "rename_note"
     ].includes(name);
     
     // For task tools, the result contains ID and title.

--- a/electron/lib/tool-schemas.ts
+++ b/electron/lib/tool-schemas.ts
@@ -60,9 +60,11 @@ export const TOOL_SCHEMAS = {
   search_notes: {
     description: "Search notes by text query. Empty query returns all notes.",
     schema: z.object({
-      query:     sStr,
-      projectId: sIdOpt,
-      limit:     z.number().optional().default(10),
+      query:        sStr,
+      projectId:    sIdOpt,
+      limit:        z.number().optional().default(10),
+      offset:       z.number().optional().default(0).describe("Pagination offset (default 0)"),
+      updatedAfter: z.string().optional().describe("ISO datetime string filter to find notes updated after this date"),
     }),
   },
 
@@ -118,6 +120,29 @@ export const TOOL_SCHEMAS = {
   delete_note: {
     description: "Permanently delete a note. Cannot be undone.",
     schema: z.object({ noteId: sId }),
+  },
+
+  rename_note: {
+    description: "Safely rename a note and update all incoming wikilink references in other notes to keep links intact.",
+    schema: z.object({
+      noteId:   sId,
+      newTitle: sStr.describe("The new title for the note"),
+    }),
+  },
+
+  bulk_move_notes: {
+    description: "Move multiple notes to a subfolder at once.",
+    schema: z.object({
+      noteIds: z.array(z.string()).describe("IDs of the notes to move"),
+      folder:  sStr.describe("Subfolder path. Empty = project root."),
+    }),
+  },
+
+  list_folders: {
+    description: "List all folders defined inside the notes of a project.",
+    schema: z.object({
+      projectId: sId,
+    }),
   },
 
   // ── Tasks ─────────────────────────────────────────────────────────────────────

--- a/electron/lib/tool-schemas.ts
+++ b/electron/lib/tool-schemas.ts
@@ -175,6 +175,14 @@ export const TOOL_SCHEMAS = {
     }),
   },
 
+  unlink_note_from_task: {
+    description: "Bidirectionally remove a link between a note and a task card.",
+    schema: z.object({
+      noteId: sId,
+      cardId: sId,
+    }),
+  },
+
   list_ready_tasks: {
     description: "Return only unblocked, active tasks — tasks with no pending blockers and not in a done column. Use this to find work that can start right now.",
     schema: z.object({

--- a/electron/lib/tool-schemas.ts
+++ b/electron/lib/tool-schemas.ts
@@ -84,11 +84,11 @@ export const TOOL_SCHEMAS = {
   // ── Notes ────────────────────────────────────────────────────────────────────
 
   ensure_note: {
-    description: "Create-or-update a note by title+projectId. Idempotent — safe to call repeatedly.",
+    description: "Create-or-update a note by title+projectId. Idempotent — safe to call repeatedly. Content is optional; if omitted on update, existing content is preserved.",
     schema: z.object({
       projectId: sId,
       title:     sStr,
-      content:   sStrOpt,
+      content:   sStrOpt.describe("Markdown content. If omitted on update, existing content is preserved."),
       tagIds:    sTagIds,
       tagNames:  sTagNames,
       isPinned:  sBoolOpt,

--- a/electron/lib/tool-schemas.ts
+++ b/electron/lib/tool-schemas.ts
@@ -63,8 +63,8 @@ export const TOOL_SCHEMAS = {
       query:        sStr,
       projectId:    sIdOpt,
       limit:        z.number().optional().default(10),
-      offset:       z.number().optional().default(0).describe("Pagination offset (default 0)"),
-      updatedAfter: z.string().optional().describe("ISO datetime string filter to find notes updated after this date"),
+      offset:       z.number().int().nonnegative().optional().default(0).describe("Pagination offset (default 0)"),
+      updatedAfter: z.iso.datetime({ offset: true }).optional().describe("ISO datetime string filter to find notes updated after this date"),
     }),
   },
 

--- a/electron/lib/tools.ts
+++ b/electron/lib/tools.ts
@@ -36,6 +36,7 @@ export const TOOL_LABELS: Record<string, (args: ToolArgs) => string> = {
   generate_prd:           (a) => `Generating PRD "${a.title}"`,
   spawn_tasks_from_note:  () => "Spawning tasks from note",
   link_note_to_task:      () => "Linking note to task",
+  unlink_note_from_task:   () => "Unlinking note from task",
   get_idea_flow:          () => "Reading Idea Flow",
   create_idea_flow_node:  (a) => `Adding ${(a.type as string) ?? "node"} to Idea Flow`,
   update_idea_flow_node:  () => "Updating Idea Flow node",
@@ -148,6 +149,7 @@ IDs (workspaceId, projectId, columnId) are stable for the app session. Call get_
 - Use update_task with \`columnId\` to move a task to a different column.
 - Use list_ready_tasks to find unblocked work; use search_tasks with an empty query to list all tasks.
 - Use update_task with \`blockedBy\` to add a blocker, \`unblockFrom\` to remove one. Blockers auto-clear when moved to done or archived.
+- Use \`link_note_to_task\` to link a note and a task card, and \`unlink_note_from_task\` to remove that connection.
 - You can pass \`tagNames\` (array of strings) to automatically resolve or create tags case-insensitively.
 
 ## Dashboards

--- a/electron/lib/tools.ts
+++ b/electron/lib/tools.ts
@@ -137,8 +137,8 @@ IDs (workspaceId, projectId, columnId) are stable for the app session. Call get_
 - Keep responses concise and actionable
 
 ## Notes
-- Use ensure_note to create or update notes — it is idempotent and safe to call repeatedly.
-- Use the optional \`folder\` parameter for subfolders, e.g. \`folder="Research/Papers"\`.
+- Use ensure_note to create or update notes — it is idempotent and safe to call repeatedly. Omitting the \`content\` parameter on update preserves the note's existing content.
+- Use the optional \`folder\` parameter for subfolders, e.g. \`folder="Research/Papers"\` (can be used with ensure_note to move notes without overwriting content).
 - Use patch_note for targeted edits, append_to_note to add content without replacing.
 - search_notes with an empty query returns all notes in a project.
 - search_notes_semantic uses local embeddings for natural-language queries — better than search_notes when concepts are described in different words. Requires embeddings enabled.

--- a/electron/lib/tools.ts
+++ b/electron/lib/tools.ts
@@ -32,6 +32,9 @@ export const TOOL_LABELS: Record<string, (args: ToolArgs) => string> = {
   upsert_project:         (a) => a.projectId ? `Updating project "${a.projectId}"` : `Creating project "${a.name}"`,
   delete_project:         (a) => `Deleting project "${a.projectId}"`,
   delete_note:            () => "Deleting note",
+  rename_note:            (a) => `Renaming note to "${a.newTitle}"`,
+  bulk_move_notes:        (a) => `Moving ${(a.noteIds as string[])?.length ?? 0} notes`,
+  list_folders:           () => "Listing subfolders",
   delete_task:            () => "Deleting task",
   generate_prd:           (a) => `Generating PRD "${a.title}"`,
   spawn_tasks_from_note:  () => "Spawning tasks from note",
@@ -139,9 +142,12 @@ IDs (workspaceId, projectId, columnId) are stable for the app session. Call get_
 
 ## Notes
 - Use ensure_note to create or update notes — it is idempotent and safe to call repeatedly. Omitting the \`content\` parameter on update preserves the note's existing content.
+- Use \`rename_note\` to safely change a note's title. This automatically renames the physical file and updates inbound wikilink references in other notes to keep links intact.
+- Use \`bulk_move_notes\` to move multiple notes to a subfolder at once.
+- Use \`list_folders\` to list all unique folder paths currently used in a project.
 - Use the optional \`folder\` parameter for subfolders, e.g. \`folder="Research/Papers"\` (can be used with ensure_note to move notes without overwriting content).
 - Use patch_note for targeted edits, append_to_note to add content without replacing.
-- search_notes with an empty query returns all notes in a project.
+- search_notes with an empty query returns all notes in a project. It supports \`offset\` for pagination and \`updatedAfter\` (ISO timestamp) to find recently updated notes.
 - search_notes_semantic uses local embeddings for natural-language queries — better than search_notes when concepts are described in different words. Requires embeddings enabled.
 - You can pass \`tagNames\` (array of strings) to automatically resolve or create tags case-insensitively, avoiding separate tag creation calls.
 

--- a/electron/mcp/tools/index.ts
+++ b/electron/mcp/tools/index.ts
@@ -3,7 +3,7 @@ import { getSnapshot } from "../db";
 import { getCairnContext, getProjectContextPack, DASHBOARD_CONSTANTS, IDEA_FLOW_RULES } from "./metadata";
 import { create_tag } from "./tags";
 import { upsert_project, delete_project } from "./projects";
-import { get_note, search_notes, ensure_note, append_to_note, patch_note, delete_note } from "./notes";
+import { get_note, search_notes, ensure_note, append_to_note, patch_note, delete_note, rename_note, bulk_move_notes, list_folders } from "./notes";
 import { get_task, search_tasks, create_task, bulk_update_task_status, link_note_to_task, unlink_note_from_task, delete_task, list_ready_tasks, update_task } from "./tasks";
 import { create_dashboard, update_dashboard } from "./dashboards";
 import {
@@ -100,6 +100,15 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
 
     case "patch_note":
       return patch_note(db, snap, workspacePath, args);
+
+    case "rename_note":
+      return rename_note(db, snap, workspacePath, args);
+
+    case "bulk_move_notes":
+      return bulk_move_notes(db, snap, workspacePath, args);
+
+    case "list_folders":
+      return list_folders(db, snap, args);
 
     case "get_idea_flow":
       return get_idea_flow(db, snap, args);

--- a/electron/mcp/tools/index.ts
+++ b/electron/mcp/tools/index.ts
@@ -4,7 +4,7 @@ import { getCairnContext, getProjectContextPack, DASHBOARD_CONSTANTS, IDEA_FLOW_
 import { create_tag } from "./tags";
 import { upsert_project, delete_project } from "./projects";
 import { get_note, search_notes, ensure_note, append_to_note, patch_note, delete_note } from "./notes";
-import { get_task, search_tasks, create_task, bulk_update_task_status, link_note_to_task, delete_task, list_ready_tasks, update_task } from "./tasks";
+import { get_task, search_tasks, create_task, bulk_update_task_status, link_note_to_task, unlink_note_from_task, delete_task, list_ready_tasks, update_task } from "./tasks";
 import { create_dashboard, update_dashboard } from "./dashboards";
 import {
   get_idea_flow,
@@ -60,7 +60,10 @@ export function executeTool(db: Database.Database, workspacePath: string, toolNa
       return bulk_update_task_status(db, snap, args);
 
     case "link_note_to_task":
-      return link_note_to_task(db, snap, args);
+      return link_note_to_task(db, snap, workspacePath, args);
+
+    case "unlink_note_from_task":
+      return unlink_note_from_task(db, snap, workspacePath, args);
 
     case "get_note":
       return get_note(db, snap, args);

--- a/electron/mcp/tools/notes.ts
+++ b/electron/mcp/tools/notes.ts
@@ -219,41 +219,53 @@ export function rename_note(db: Database.Database, snap: Snapshot, workspacePath
   if (!note) return { error: "Note not found" };
   const project = snap.projects.find((p) => p.id === note.projectId);
 
-  const updatedNote = db.transaction(() => {
-    // 1. Update the note itself in DB
-    const u = q.updateNote(db, noteId, { title: newTitle });
+  // Reject title collisions within the same project before updating.
+  const normalizedNew = normalizeNoteTitle(newTitle);
+  const collision = snap.notes.some(
+    (n) => n.id !== noteId && !n.archivedAt && n.projectId === note.projectId && normalizeNoteTitle(n.title as string) === normalizedNew
+  );
+  if (collision) return { error: `A note with the title "${newTitle}" already exists in this project` };
 
-    // 2. Rewrite wikilinks inside other notes in DB
-    const oldLink = `[[${note.title}]]`;
-    const newLink = `[[${newTitle}]]`;
-    for (const otherNote of snap.notes) {
-      if (otherNote.id === noteId) continue;
-      if (otherNote.content && otherNote.content.includes(oldLink)) {
-        const newContent = otherNote.content.split(oldLink).join(newLink);
-        q.updateNote(db, otherNote.id, { content: newContent, contentText: stripMarkdown(newContent) });
-        const otherProj = snap.projects.find((p) => p.id === otherNote.projectId);
-        writeNoteFile(workspacePath, {
-          id: otherNote.id,
-          projectId: otherNote.projectId,
-          workspaceId: otherNote.workspaceId as string,
-          title: otherNote.title as string,
-          content: newContent,
-          tagIds: otherNote.tagIds as string[],
-          linkedNoteIds: otherNote.linkedNoteIds as string[],
-          linkedCardIds: otherNote.linkedCardIds as string[],
-          isPinned: otherNote.isPinned as boolean,
-          folder: (otherNote.folder as string) ?? "",
-          createdAt: otherNote.createdAt as string,
-          updatedAt: new Date().toISOString(),
-          archivedAt: otherNote.archivedAt as string | undefined,
-          projectName: otherProj?.name ?? otherNote.projectId as string,
-        });
-      }
+  // Collect notes whose wikilinks need rewriting before the DB transaction.
+  const oldLink = `[[${note.title}]]`;
+  const newLink = `[[${newTitle}]]`;
+  const linkedNotes = snap.notes.filter(
+    (n) => n.id !== noteId && n.content && n.content.includes(oldLink)
+  );
+
+  const updatedNote = db.transaction(() => {
+    const u = q.updateNote(db, noteId, { title: newTitle });
+    for (const otherNote of linkedNotes) {
+      const newContent = otherNote.content.split(oldLink).join(newLink);
+      q.updateNote(db, otherNote.id, { content: newContent, contentText: stripMarkdown(newContent) });
     }
     return u;
   })();
 
-  // 3. Write note file to disk (writeNoteFile renames/moves the path dynamically if title changes)
+  // Write files to disk after the transaction commits — a failure here
+  // won't roll back SQLite while leaving files half-changed.
+  for (const otherNote of linkedNotes) {
+    const newContent = otherNote.content.split(oldLink).join(newLink);
+    const otherProj = snap.projects.find((p) => p.id === otherNote.projectId);
+    writeNoteFile(workspacePath, {
+      id: otherNote.id,
+      projectId: otherNote.projectId,
+      workspaceId: otherNote.workspaceId as string,
+      title: otherNote.title as string,
+      content: newContent,
+      tagIds: otherNote.tagIds as string[],
+      linkedNoteIds: otherNote.linkedNoteIds as string[],
+      linkedCardIds: otherNote.linkedCardIds as string[],
+      isPinned: otherNote.isPinned as boolean,
+      folder: (otherNote.folder as string) ?? "",
+      createdAt: otherNote.createdAt as string,
+      updatedAt: new Date().toISOString(),
+      archivedAt: otherNote.archivedAt as string | undefined,
+      projectName: otherProj?.name ?? otherNote.projectId as string,
+    });
+  }
+
+  // Write note file to disk (writeNoteFile renames/moves the path dynamically if title changes)
   writeNoteFile(workspacePath, {
     id: note.id,
     projectId: note.projectId,

--- a/electron/mcp/tools/notes.ts
+++ b/electron/mcp/tools/notes.ts
@@ -54,7 +54,7 @@ export function ensure_note(db: Database.Database, snap: Snapshot, workspacePath
     requestedTitle: typeof title === "string" ? title : "",
     matchedId: existing?.id ?? "none",
   });
-  const markdown = (content as string | undefined) ?? "";
+  const markdown = content !== undefined ? (content as string) : (existing?.content as string | undefined) ?? "";
 
   const resolvedFromNameIds = resolveTagNames(db, project.workspaceId, tagNames);
   let ensureResolvedTagIds = Array.isArray(ensureTagIds) ? ensureTagIds as string[] : undefined;

--- a/electron/mcp/tools/notes.ts
+++ b/electron/mcp/tools/notes.ts
@@ -54,8 +54,6 @@ export function ensure_note(db: Database.Database, snap: Snapshot, workspacePath
     requestedTitle: typeof title === "string" ? title : "",
     matchedId: existing?.id ?? "none",
   });
-  const markdown = content !== undefined ? (content as string) : (existing?.content as string | undefined) ?? "";
-
   const resolvedFromNameIds = resolveTagNames(db, project.workspaceId, tagNames);
   let ensureResolvedTagIds = Array.isArray(ensureTagIds) ? ensureTagIds as string[] : undefined;
   if (resolvedFromNameIds.length > 0) {
@@ -68,10 +66,10 @@ export function ensure_note(db: Database.Database, snap: Snapshot, workspacePath
   try {
     if (existing) {
       const updatedFolder = ensureFolder ?? (existing.folder as string) ?? "";
+      let updatedNote: any;
       db.transaction(() => {
-        q.updateNote(db, existing.id, {
-          content: markdown,
-          contentText: stripMarkdown(markdown),
+        updatedNote = q.updateNote(db, existing.id, {
+          ...(content !== undefined ? { content, contentText: stripMarkdown(content as string) } : {}),
           ...(ensureResolvedTagIds ? { tagIds: ensureResolvedTagIds } : {}),
           ...(ensureResolvedIsPinned !== undefined ? { isPinned: ensureResolvedIsPinned } : {}),
           ...(ensureFolder !== undefined ? { folder: ensureFolder } : {}),
@@ -80,19 +78,20 @@ export function ensure_note(db: Database.Database, snap: Snapshot, workspacePath
       })();
       writeNoteFile(workspacePath, {
         id: existing.id, projectId, workspaceId: existing.workspaceId as string,
-        title: existing.title as string, content: markdown,
-        tagIds: ensureResolvedTagIds ?? existing.tagIds as string[], linkedNoteIds: existing.linkedNoteIds as string[],
-        linkedCardIds: existing.linkedCardIds as string[], isPinned: ensureResolvedIsPinned ?? existing.isPinned as boolean,
-        folder: updatedFolder,
-        createdAt: existing.createdAt as string, updatedAt: new Date().toISOString(),
+        title: existing.title as string, content: updatedNote.content,
+        tagIds: updatedNote.tagIds, linkedNoteIds: updatedNote.linkedNoteIds,
+        linkedCardIds: updatedNote.linkedCardIds, isPinned: updatedNote.isPinned,
+        folder: updatedNote.folder,
+        createdAt: existing.createdAt as string, updatedAt: updatedNote.updatedAt,
         archivedAt: existing.archivedAt as string | undefined,
         projectName: project.name,
       });
-      return { id: existing.id, title, folder: updatedFolder, action: "updated", updatedAt: new Date().toISOString() };
+      return { id: existing.id, title, folder: updatedNote.folder, action: "updated", updatedAt: updatedNote.updatedAt };
     } else {
       const newTagIds = ensureResolvedTagIds ?? [];
       const newIsPinned = ensureResolvedIsPinned ?? false;
       const newFolder = ensureFolder ?? "";
+      const markdown = (content as string | undefined) ?? "";
       const note = db.transaction(() => {
         const n = q.createNote(db, {
           id: ensureNoteId,

--- a/electron/mcp/tools/notes.ts
+++ b/electron/mcp/tools/notes.ts
@@ -65,7 +65,6 @@ export function ensure_note(db: Database.Database, snap: Snapshot, workspacePath
   lockNote(db, ensureNoteId);
   try {
     if (existing) {
-      const updatedFolder = ensureFolder ?? (existing.folder as string) ?? "";
       let updatedNote: any;
       db.transaction(() => {
         updatedNote = q.updateNote(db, existing.id, {
@@ -211,4 +210,123 @@ export function delete_note(db: Database.Database, snap: Snapshot, workspacePath
   deleteNoteFile(workspacePath, delProj?.name ?? note.projectId as string, args.noteId as string);
   insertNotification(db, "delete_note", "Note deleted", `"${note.title}" was deleted`);
   return { deleted: true, id: args.noteId, title: note.title };
+}
+
+export function rename_note(db: Database.Database, snap: Snapshot, workspacePath: string, args: Record<string, any>) {
+  const { noteId, newTitle } = args;
+  if (!newTitle || typeof newTitle !== "string") return { error: "newTitle is required and must be a string" };
+  const note = snap.notes.find((n) => n.id === noteId);
+  if (!note) return { error: "Note not found" };
+  const project = snap.projects.find((p) => p.id === note.projectId);
+
+  const updatedNote = db.transaction(() => {
+    // 1. Update the note itself in DB
+    const u = q.updateNote(db, noteId, { title: newTitle });
+
+    // 2. Rewrite wikilinks inside other notes in DB
+    const oldLink = `[[${note.title}]]`;
+    const newLink = `[[${newTitle}]]`;
+    for (const otherNote of snap.notes) {
+      if (otherNote.id === noteId) continue;
+      if (otherNote.content && otherNote.content.includes(oldLink)) {
+        const newContent = otherNote.content.split(oldLink).join(newLink);
+        q.updateNote(db, otherNote.id, { content: newContent, contentText: stripMarkdown(newContent) });
+        const otherProj = snap.projects.find((p) => p.id === otherNote.projectId);
+        writeNoteFile(workspacePath, {
+          id: otherNote.id,
+          projectId: otherNote.projectId,
+          workspaceId: otherNote.workspaceId as string,
+          title: otherNote.title as string,
+          content: newContent,
+          tagIds: otherNote.tagIds as string[],
+          linkedNoteIds: otherNote.linkedNoteIds as string[],
+          linkedCardIds: otherNote.linkedCardIds as string[],
+          isPinned: otherNote.isPinned as boolean,
+          folder: (otherNote.folder as string) ?? "",
+          createdAt: otherNote.createdAt as string,
+          updatedAt: new Date().toISOString(),
+          archivedAt: otherNote.archivedAt as string | undefined,
+          projectName: otherProj?.name ?? otherNote.projectId as string,
+        });
+      }
+    }
+    return u;
+  })();
+
+  // 3. Write note file to disk (writeNoteFile renames/moves the path dynamically if title changes)
+  writeNoteFile(workspacePath, {
+    id: note.id,
+    projectId: note.projectId,
+    workspaceId: note.workspaceId as string,
+    title: newTitle,
+    content: updatedNote?.content ?? note.content as string,
+    tagIds: note.tagIds as string[],
+    linkedNoteIds: note.linkedNoteIds as string[],
+    linkedCardIds: note.linkedCardIds as string[],
+    isPinned: note.isPinned as boolean,
+    folder: (note.folder as string) ?? "",
+    createdAt: note.createdAt as string,
+    updatedAt: updatedNote?.updatedAt ?? new Date().toISOString(),
+    archivedAt: note.archivedAt as string | undefined,
+    projectName: project?.name ?? note.projectId as string,
+  });
+
+  insertNotification(db, "update_note", "Note renamed", `"${note.title}" renamed to "${newTitle}"`);
+  return { id: note.id, title: newTitle, action: "renamed", updatedAt: updatedNote?.updatedAt };
+}
+
+export function bulk_move_notes(db: Database.Database, snap: Snapshot, workspacePath: string, args: Record<string, any>) {
+  const { noteIds, folder } = args;
+  if (!Array.isArray(noteIds) || noteIds.length === 0) return { error: "noteIds must be a non-empty array" };
+  const targetFolder = typeof folder === "string" ? folder : "";
+  const results: Array<{ id: string; ok: boolean; error?: string }> = [];
+
+  for (const noteId of noteIds) {
+    const note = snap.notes.find((n) => n.id === noteId);
+    if (!note) {
+      results.push({ id: noteId, ok: false, error: "Note not found" });
+      continue;
+    }
+    lockNote(db, noteId);
+    try {
+      const project = snap.projects.find((p) => p.id === note.projectId);
+      const updatedNote = q.updateNote(db, noteId, { folder: targetFolder });
+      writeNoteFile(workspacePath, {
+        id: note.id,
+        projectId: note.projectId,
+        workspaceId: note.workspaceId as string,
+        title: note.title as string,
+        content: note.content as string,
+        tagIds: note.tagIds as string[],
+        linkedNoteIds: note.linkedNoteIds as string[],
+        linkedCardIds: note.linkedCardIds as string[],
+        isPinned: note.isPinned as boolean,
+        folder: targetFolder,
+        createdAt: note.createdAt as string,
+        updatedAt: updatedNote?.updatedAt ?? new Date().toISOString(),
+        archivedAt: note.archivedAt as string | undefined,
+        projectName: project?.name ?? note.projectId as string,
+      });
+      results.push({ id: noteId, ok: true });
+    } finally {
+      unlockNote(db, noteId);
+    }
+  }
+
+  const moved = results.filter((r) => r.ok).length;
+  const failed = results.filter((r) => !r.ok);
+  if (moved > 0) {
+    insertNotification(db, "bulk_move_notes", "Notes moved", `${moved} note${moved === 1 ? "" : "s"} moved to "${targetFolder || "root"}"`);
+  }
+  return { moved, failed, folder: targetFolder };
+}
+
+export function list_folders(db: Database.Database, snap: Snapshot, args: Record<string, any>) {
+  const { projectId } = args;
+  const project = snap.projects.find((p) => p.id === projectId);
+  if (!project) return { error: "Project not found" };
+
+  const rows = db.prepare("SELECT DISTINCT folder FROM notes WHERE project_id = ? AND archived_at IS NULL").all(projectId) as Array<{ folder: string }>;
+  const folders = Array.from(new Set(rows.map((r) => r.folder).filter((f) => typeof f === "string" && f.trim() !== "")));
+  return { projectId, folders };
 }

--- a/electron/mcp/tools/tasks.ts
+++ b/electron/mcp/tools/tasks.ts
@@ -7,7 +7,9 @@ import {
   Snapshot,
   getCardVersion,
   insertNotification,
+  lockNote,
   resolveTagNames,
+  unlockNote,
   writeNoteFile
 } from "../db";
 
@@ -93,22 +95,40 @@ export function bulk_update_task_status(db: Database.Database, snap: Snapshot, a
   return { moved, failed, targetColumnId, targetColumnName: col.name };
 }
 
-export function link_note_to_task(db: Database.Database, snap: Snapshot, workspacePath: string, args: Record<string, any>) {
+function applyNoteLinkChange(
+  db: Database.Database,
+  snap: Snapshot,
+  workspacePath: string,
+  args: { noteId: string; cardId: string },
+  transform: {
+    nextCardIds: (cur: string[]) => string[];
+    nextNoteIds: (cur: string[]) => string[];
+    notificationType: string;
+    notificationMsg: (noteTitle: string, cardTitle: string) => string;
+    resultKey: "linked" | "unlinked";
+  }
+) {
   const { noteId, cardId } = args;
   const note = snap.notes.find((n) => n.id === noteId);
   const card = snap.cards.find((c) => c.id === cardId);
   if (!note) return { error: "Note not found" };
   if (!card) return { error: "Card not found" };
-  const newCardIds = Array.from(new Set([...(note.linkedCardIds as string[]), cardId]));
-  const newNoteIds = Array.from(new Set([...(card.linkedNoteIds as string[]), noteId]));
-  const updatedNote = db.transaction(() => {
-    const u = q.updateNote(db, noteId as string, { linkedCardIds: newCardIds });
-    q.updateCard(db, cardId as string, { linkedNoteIds: newNoteIds });
-    return u;
-  })();
+  const newCardIds = transform.nextCardIds((note.linkedCardIds as string[]) ?? []);
+  const newNoteIds = transform.nextNoteIds((card.linkedNoteIds as string[]) ?? []);
+  lockNote(db, noteId);
+  let updatedNote: any;
+  try {
+    updatedNote = db.transaction(() => {
+      const u = q.updateNote(db, noteId, { linkedCardIds: newCardIds });
+      q.updateCard(db, cardId, { linkedNoteIds: newNoteIds });
+      return u;
+    })();
+  } finally {
+    unlockNote(db, noteId);
+  }
   const proj = snap.projects.find((p) => p.id === note.projectId);
   writeNoteFile(workspacePath, {
-    id: noteId as string, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
+    id: noteId, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
     title: note.title as string, content: updatedNote?.content ?? note.content as string,
     tagIds: note.tagIds as string[], linkedNoteIds: note.linkedNoteIds as string[],
     linkedCardIds: newCardIds, isPinned: note.isPinned as boolean,
@@ -117,36 +137,33 @@ export function link_note_to_task(db: Database.Database, snap: Snapshot, workspa
     projectName: proj?.name ?? note.projectId as string,
     folder: (note.folder as string) ?? "",
   });
-  insertNotification(db, "link_note_to_task", "Note linked to task", `"${note.title}" linked to "${card.title}"`);
-  return { noteId, cardId, linked: true };
+  insertNotification(
+    db,
+    transform.notificationType,
+    transform.notificationType === "link_note_to_task" ? "Note linked to task" : "Note unlinked from task",
+    transform.notificationMsg(note.title as string, card.title as string),
+  );
+  return { noteId, cardId, [transform.resultKey]: true };
+}
+
+export function link_note_to_task(db: Database.Database, snap: Snapshot, workspacePath: string, args: Record<string, any>) {
+  return applyNoteLinkChange(db, snap, workspacePath, args as { noteId: string; cardId: string }, {
+    nextCardIds: (cur) => Array.from(new Set([...cur, args.cardId as string])),
+    nextNoteIds: (cur) => Array.from(new Set([...cur, args.noteId as string])),
+    notificationType: "link_note_to_task",
+    notificationMsg: (noteTitle, cardTitle) => `"${noteTitle}" linked to "${cardTitle}"`,
+    resultKey: "linked",
+  });
 }
 
 export function unlink_note_from_task(db: Database.Database, snap: Snapshot, workspacePath: string, args: Record<string, any>) {
-  const { noteId, cardId } = args;
-  const note = snap.notes.find((n) => n.id === noteId);
-  const card = snap.cards.find((c) => c.id === cardId);
-  if (!note) return { error: "Note not found" };
-  if (!card) return { error: "Card not found" };
-  const newCardIds = (note.linkedCardIds as string[]).filter((id) => id !== cardId);
-  const newNoteIds = (card.linkedNoteIds as string[]).filter((id) => id !== noteId);
-  const updatedNote = db.transaction(() => {
-    const u = q.updateNote(db, noteId as string, { linkedCardIds: newCardIds });
-    q.updateCard(db, cardId as string, { linkedNoteIds: newNoteIds });
-    return u;
-  })();
-  const proj = snap.projects.find((p) => p.id === note.projectId);
-  writeNoteFile(workspacePath, {
-    id: noteId as string, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
-    title: note.title as string, content: updatedNote?.content ?? note.content as string,
-    tagIds: note.tagIds as string[], linkedNoteIds: note.linkedNoteIds as string[],
-    linkedCardIds: newCardIds, isPinned: note.isPinned as boolean,
-    createdAt: note.createdAt as string, updatedAt: updatedNote?.updatedAt ?? new Date().toISOString(),
-    archivedAt: note.archivedAt as string | undefined,
-    projectName: proj?.name ?? note.projectId as string,
-    folder: (note.folder as string) ?? "",
+  return applyNoteLinkChange(db, snap, workspacePath, args as { noteId: string; cardId: string }, {
+    nextCardIds: (cur) => cur.filter((id) => id !== args.cardId as string),
+    nextNoteIds: (cur) => cur.filter((id) => id !== args.noteId as string),
+    notificationType: "unlink_note_from_task",
+    notificationMsg: (noteTitle, cardTitle) => `"${noteTitle}" unlinked from "${cardTitle}"`,
+    resultKey: "unlinked",
   });
-  insertNotification(db, "unlink_note_from_task", "Note unlinked from task", `"${note.title}" unlinked from "${card.title}"`);
-  return { noteId, cardId, unlinked: true };
 }
 
 export function delete_task(db: Database.Database, snap: Snapshot, args: Record<string, any>) {

--- a/electron/mcp/tools/tasks.ts
+++ b/electron/mcp/tools/tasks.ts
@@ -7,18 +7,23 @@ import {
   Snapshot,
   getCardVersion,
   insertNotification,
-  resolveTagNames
+  resolveTagNames,
+  writeNoteFile
 } from "../db";
 
 export function get_task(db: Database.Database, snap: Snapshot, args: Record<string, any>) {
   const card = snap.cards.find((c) => c.id === args.cardId);
   if (!card) return { error: "Task not found" };
   const col = snap.columns.find((c) => c.id === card.columnId);
+  const blockingCardIds = snap.cards
+    .filter((c) => Array.isArray(c.blockedByIds) && c.blockedByIds.includes(card.id))
+    .map((c) => c.id);
   return {
     id: card.id, title: card.title, description: card.description,
     priority: card.priority, dueDate: card.dueDate,
     columnId: card.columnId, columnName: col?.name ?? "Unknown", columnType: col?.type ?? "custom",
     linkedNoteIds: card.linkedNoteIds, blockedByIds: card.blockedByIds ?? [],
+    blockingCardIds,
     projectId: card.projectId, createdAt: card.createdAt, updatedAt: card.updatedAt,
     version: getCardVersion(db, card.id) ?? 0,
   };
@@ -88,7 +93,7 @@ export function bulk_update_task_status(db: Database.Database, snap: Snapshot, a
   return { moved, failed, targetColumnId, targetColumnName: col.name };
 }
 
-export function link_note_to_task(db: Database.Database, snap: Snapshot, args: Record<string, any>) {
+export function link_note_to_task(db: Database.Database, snap: Snapshot, workspacePath: string, args: Record<string, any>) {
   const { noteId, cardId } = args;
   const note = snap.notes.find((n) => n.id === noteId);
   const card = snap.cards.find((c) => c.id === cardId);
@@ -96,12 +101,52 @@ export function link_note_to_task(db: Database.Database, snap: Snapshot, args: R
   if (!card) return { error: "Card not found" };
   const newCardIds = Array.from(new Set([...(note.linkedCardIds as string[]), cardId]));
   const newNoteIds = Array.from(new Set([...(card.linkedNoteIds as string[]), noteId]));
-  db.transaction(() => {
-    q.updateNote(db, noteId as string, { linkedCardIds: newCardIds });
+  const updatedNote = db.transaction(() => {
+    const u = q.updateNote(db, noteId as string, { linkedCardIds: newCardIds });
     q.updateCard(db, cardId as string, { linkedNoteIds: newNoteIds });
+    return u;
   })();
+  const proj = snap.projects.find((p) => p.id === note.projectId);
+  writeNoteFile(workspacePath, {
+    id: noteId as string, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
+    title: note.title as string, content: updatedNote?.content ?? note.content as string,
+    tagIds: note.tagIds as string[], linkedNoteIds: note.linkedNoteIds as string[],
+    linkedCardIds: newCardIds, isPinned: note.isPinned as boolean,
+    createdAt: note.createdAt as string, updatedAt: updatedNote?.updatedAt ?? new Date().toISOString(),
+    archivedAt: note.archivedAt as string | undefined,
+    projectName: proj?.name ?? note.projectId as string,
+    folder: (note.folder as string) ?? "",
+  });
   insertNotification(db, "link_note_to_task", "Note linked to task", `"${note.title}" linked to "${card.title}"`);
   return { noteId, cardId, linked: true };
+}
+
+export function unlink_note_from_task(db: Database.Database, snap: Snapshot, workspacePath: string, args: Record<string, any>) {
+  const { noteId, cardId } = args;
+  const note = snap.notes.find((n) => n.id === noteId);
+  const card = snap.cards.find((c) => c.id === cardId);
+  if (!note) return { error: "Note not found" };
+  if (!card) return { error: "Card not found" };
+  const newCardIds = (note.linkedCardIds as string[]).filter((id) => id !== cardId);
+  const newNoteIds = (card.linkedNoteIds as string[]).filter((id) => id !== noteId);
+  const updatedNote = db.transaction(() => {
+    const u = q.updateNote(db, noteId as string, { linkedCardIds: newCardIds });
+    q.updateCard(db, cardId as string, { linkedNoteIds: newNoteIds });
+    return u;
+  })();
+  const proj = snap.projects.find((p) => p.id === note.projectId);
+  writeNoteFile(workspacePath, {
+    id: noteId as string, projectId: note.projectId as string, workspaceId: note.workspaceId as string,
+    title: note.title as string, content: updatedNote?.content ?? note.content as string,
+    tagIds: note.tagIds as string[], linkedNoteIds: note.linkedNoteIds as string[],
+    linkedCardIds: newCardIds, isPinned: note.isPinned as boolean,
+    createdAt: note.createdAt as string, updatedAt: updatedNote?.updatedAt ?? new Date().toISOString(),
+    archivedAt: note.archivedAt as string | undefined,
+    projectName: proj?.name ?? note.projectId as string,
+    folder: (note.folder as string) ?? "",
+  });
+  insertNotification(db, "unlink_note_from_task", "Note unlinked from task", `"${note.title}" unlinked from "${card.title}"`);
+  return { noteId, cardId, unlinked: true };
 }
 
 export function delete_task(db: Database.Database, snap: Snapshot, args: Record<string, any>) {

--- a/electron/shared/read-tools-pure.ts
+++ b/electron/shared/read-tools-pure.ts
@@ -193,10 +193,11 @@ export function executeGetProjectContextPack(snap: CairnSnapshot, args: Args): u
 export function executeSearchNotes(snap: CairnSnapshot, args: Args): unknown {
   const { query, projectId, limit = 10, offset = 0, updatedAfter } = args;
   const qr = String(query).toLowerCase();
+  const updatedAfterMs = updatedAfter ? new Date(updatedAfter).getTime() : undefined;
   const matches = snap.notes.filter((n) => {
     if (n.archivedAt) return false;
     if (projectId && n.projectId !== projectId) return false;
-    if (updatedAfter && n.updatedAt < updatedAfter) return false;
+    if (updatedAfterMs !== undefined && new Date(n.updatedAt).getTime() < updatedAfterMs) return false;
     return n.title.toLowerCase().includes(qr) || n.contentText.toLowerCase().includes(qr);
   });
   // Sort by updatedAt DESC to ensure stable pagination ordering

--- a/electron/shared/read-tools-pure.ts
+++ b/electron/shared/read-tools-pure.ts
@@ -191,15 +191,18 @@ export function executeGetProjectContextPack(snap: CairnSnapshot, args: Args): u
 }
 
 export function executeSearchNotes(snap: CairnSnapshot, args: Args): unknown {
-  const { query, projectId, limit = 10 } = args;
+  const { query, projectId, limit = 10, offset = 0, updatedAfter } = args;
   const qr = String(query).toLowerCase();
-  return snap.notes
-    .filter((n) => {
-      if (n.archivedAt) return false;
-      if (projectId && n.projectId !== projectId) return false;
-      return n.title.toLowerCase().includes(qr) || n.contentText.toLowerCase().includes(qr);
-    })
-    .slice(0, limit)
+  const matches = snap.notes.filter((n) => {
+    if (n.archivedAt) return false;
+    if (projectId && n.projectId !== projectId) return false;
+    if (updatedAfter && n.updatedAt < updatedAfter) return false;
+    return n.title.toLowerCase().includes(qr) || n.contentText.toLowerCase().includes(qr);
+  });
+  // Sort by updatedAt DESC to ensure stable pagination ordering
+  matches.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+  return matches
+    .slice(offset, offset + limit)
     .map((n) => ({
       id: n.id,
       title: n.title,


### PR DESCRIPTION
What does this PR do?

This PR updates the `ensure_note` tool so that omitting the `content` argument during an update operation preserves the existing note content instead of defaulting to an empty string. Documentation and Zod schemas have been updated to reflect this behavior, and a new test case ensures this functionality remains intact.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Docs / changelog
- [ ] Tests

## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (runs `npm run compile` first so `electron/bundle-guard.test.ts` actually executes — `npm run test:bundle` to run just that)
- [x] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts`
- [ ] New SQL goes in `electron/db/queries.ts` — single source of truth (imported by both Electron main process and MCP server); never construct a `Database` instance outside `db/client.ts` (Electron) or `mcp-server.ts` (MCP runtime)
- [ ] New `dependencies` or `devDependencies` added to `ROLE_MAP` in `scripts/generate-licenses.js` and `licenses.json` regenerated
- [ ] New MCP tools registered in `electron/mcp/tools/index.ts` dispatch + `electron/lib/tool-schemas.ts` Zod schema
- [ ] If you added/removed a `--external:<pkg>` flag in the `compile` script: updated the appropriate allowlist group (`RUNTIME_PROVIDED` / `OPTIONAL_TRANSITIVE` / `SUBPROCESS_ONLY` / `SHIPPED_NATIVE`) in `electron/bundle-guard.test.ts` and (if `SHIPPED_NATIVE`) shipped the package via `electron-builder.yml`

## Notes for reviewer

The fix involves changing how the `markdown` variable is derived in `electron/mcp/tools/notes.ts`. It now performs an explicit check `content !== undefined` to distinguish between an intended update to empty content and an omitted parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **unlink note from task**.
  * `get_task` now returns **blockingCardIds**.
  * Added note tools: **rename note** (updates inbound wikilinks), **bulk move notes**, and **list folders**.
  * Enhanced **note search** with **offset pagination** and **updatedAfter** filtering.
* **Bug Fixes**
  * `ensure_note` now preserves existing note content when `content` is omitted (clears when `content` is `""`).
  * Fixed note renaming/moves so note text isn’t overwritten.
  * Resolved a system-prompt escaping issue that could break builds.
* **Tests**
  * Expanded coverage for unlinking, blocking, rename, bulk move, folder listing, and advanced search.
* **Documentation**
  * Updated tool guidance/schema and system prompt for new operations and `ensure_note.content` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->