### PR TITLE
v2.2.8: Bug fixes, Kanban UI improvements, and Diff Viewer performance

### DIFF
--- a/changelogs/v2.2.8.md
+++ b/changelogs/v2.2.8.md
@@ -1,0 +1,13 @@
+## What's new
+
+### Fixes
+
+- **Folder Preservation on Note Edits**: Fixed a bug where `patch_note` and `append_to_note` would move note files out of their current folder and into the project root. Both tools now pass the note's existing `folder` field to `writeNoteFile`, matching the behaviour of `ensure_note`, `rename_note`, and `bulk_move_notes`.
+- **Kanban Drag Cancel Cleanup**: Added an `onDragCancel` handler to the board's `DndContext`. Pressing Escape during a card or column drag now properly clears all drag state (`activeCard`, `activeColumn`, `overId`, `hoverZone`) and dismisses the action zone overlay, instead of leaving stale highlights behind.
+
+### Changes
+
+- **Redesigned Archive/Delete Drop Zones**: The action zone overlay that appears when dragging a card has been redesigned as two compact, button-style targets centered at the bottom of the viewport. The previous full-width banner at the top of the board caused content to shift on drag start; the new design is a fixed portal overlay that doesn't affect layout. Buttons match the app's `lg` button sizing (36px tall, rounded outer corners, solid colour at 85% opacity resting and full colour on hover).
+- **Kanban Card Height Fix**: Collapsed card descriptions now use `max-h-10 overflow-hidden` instead of `line-clamp-2`, which didn't reliably clip block-level markdown content. Expanded view increased to `max-h-80`. Paragraph margins from `prose-cairn` are zeroed inside cards to prevent excess vertical space.
+- **Kanban Drop Target Expansion**: Columns now stretch to the board's full height via `self-stretch` and `h-full`. During an active drag-over, the card drop zone minimum height bumps from 48px to 120px, making empty or near-empty columns easy drop targets without scrolling.
+- **Diff Viewer Performance**: The Agent View's Diff Viewer no longer blocks the UI thread when polling `git diff` every 5 seconds. `parseDiff` now runs on a `useDeferredValue`, so React keeps interactions responsive while the parse runs at lower priority. All diff sub-components (`FileDiff`, `UnifiedFile`, `SplitFile`, `HL`) are wrapped in `React.memo` so unchanged files skip re-rendering entirely. Split-view row building and addition/deletion counts are memoised per file.

--- a/electron/mcp/tools/notes.ts
+++ b/electron/mcp/tools/notes.ts
@@ -152,6 +152,7 @@ export function append_to_note(db: Database.Database, snap: Snapshot, workspaceP
       createdAt: note.createdAt as string, updatedAt: updated?.updatedAt ?? new Date().toISOString(),
       archivedAt: note.archivedAt as string | undefined,
       projectName: proj?.name ?? note.projectId as string,
+      folder: (note.folder as string) ?? "",
     });
     return { id: noteId, title: note.title, updatedAt: updated?.updatedAt, newLength: newContent.length };
   } finally {
@@ -195,6 +196,7 @@ export function patch_note(db: Database.Database, snap: Snapshot, workspacePath:
       createdAt: note.createdAt as string, updatedAt: updated?.updatedAt ?? new Date().toISOString(),
       archivedAt: note.archivedAt as string | undefined,
       projectName: proj?.name ?? note.projectId as string,
+      folder: (note.folder as string) ?? "",
     });
     return { id: noteId, title: note.title, updatedAt: updated?.updatedAt, replacements: all ? count : 1 };
   } finally {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -556,9 +556,9 @@ input[type="url"] {
 }
 .zone-archive.zone-active {
   background: var(--warning);
-  color: var(--surface);
+  color: #1a1a1a;
 }
 .zone-delete.zone-active {
   background: var(--danger);
-  color: var(--surface);
+  color: #fff;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -538,4 +538,27 @@ input[type="url"] {
 }
 
 
+/* ── Kanban drag drop zones ─────────────────────────────────────────────────── */
 
+.zone-archive {
+  color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 12%, transparent);
+}
+.zone-archive:hover {
+  background: color-mix(in srgb, var(--warning) 22%, transparent);
+}
+.zone-delete {
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+}
+.zone-delete:hover {
+  background: color-mix(in srgb, var(--danger) 22%, transparent);
+}
+.zone-archive.zone-active {
+  background: var(--warning);
+  color: var(--surface);
+}
+.zone-delete.zone-active {
+  background: var(--danger);
+  color: var(--surface);
+}

--- a/src/components/agent/DiffFile.tsx
+++ b/src/components/agent/DiffFile.tsx
@@ -68,7 +68,7 @@ function langFrom(filename: string): string | null {
 
 // ── Highlighted line ──────────────────────────────────────────────────────────
 
-function HL({ content, lang, palette }: { content: string; lang: string | null; palette: Palette }) {
+const HL = React.memo(function HL({ content, lang, palette }: { content: string; lang: string | null; palette: Palette }) {
   const tokens = useMemo(() => {
     if (!lang || !content) return null;
     try {
@@ -81,7 +81,7 @@ function HL({ content, lang, palette }: { content: string; lang: string | null; 
       {tokens ? tokens.map((n, i) => renderHast(n, palette, String(i))) : content}
     </code>
   );
-}
+});
 
 // ── View mode type ────────────────────────────────────────────────────────────
 
@@ -103,7 +103,7 @@ function ln(change: Change, side: "old" | "new"): number | "" {
 
 // ── Unified file view ─────────────────────────────────────────────────────────
 
-export function UnifiedFile({ file, palette, changesOnly, hunkTop }: { file: File; palette: Palette; changesOnly: boolean; hunkTop: number }) {
+export const UnifiedFile = React.memo(function UnifiedFile({ file, palette, changesOnly, hunkTop }: { file: File; palette: Palette; changesOnly: boolean; hunkTop: number }) {
   const filename = file.to ?? file.from ?? "unknown";
   const lang = langFrom(filename);
   return (
@@ -162,7 +162,7 @@ export function UnifiedFile({ file, palette, changesOnly, hunkTop }: { file: Fil
       })}
     </>
   );
-}
+});
 
 // ── Split file view ───────────────────────────────────────────────────────────
 
@@ -190,11 +190,12 @@ function buildSplitRows(changes: Change[]): SplitRow[] {
   return rows;
 }
 
-function SplitFile({ file, palette, hunkTop }: { file: File; palette: Palette; hunkTop: number }) {
+export const SplitFile = React.memo(function SplitFile({ file, palette, hunkTop }: { file: File; palette: Palette; hunkTop: number }) {
   const filename = file.to ?? file.from ?? "unknown";
   const lang = langFrom(filename);
   const addBg = "color-mix(in srgb, var(--success, #22c55e) 10%, transparent)";
   const delBg = "color-mix(in srgb, var(--danger) 10%, transparent)";
+  const splitRows = useMemo(() => file.chunks.map((chunk) => buildSplitRows(chunk.changes)), [file]);
   return (
     <>
       {file.chunks.map((chunk, ci) => (
@@ -205,7 +206,7 @@ function SplitFile({ file, palette, hunkTop }: { file: File; palette: Palette; h
           >
             {chunk.content}
           </div>
-          {buildSplitRows(chunk.changes).map((row, ri) => {
+          {splitRows[ci].map((row, ri) => {
             const oldContent = row.old ? row.old.content.slice(1) : "";
             const newContent = row.new ? row.new.content.slice(1) : "";
             const oldBg = row.old?.type === "del" ? delBg : undefined;
@@ -243,11 +244,11 @@ function SplitFile({ file, palette, hunkTop }: { file: File; palette: Palette; h
       ))}
     </>
   );
-}
+});
 
 // ── FileDiff — file header + collapsible content ──────────────────────────────
 
-export function FileDiff({ file, collapsed, onToggle, mode, palette }: {
+export const FileDiff = React.memo(function FileDiff({ file, collapsed, onToggle, mode, palette }: {
   file: File;
   collapsed: boolean;
   onToggle: () => void;
@@ -259,8 +260,8 @@ export function FileDiff({ file, collapsed, onToggle, mode, palette }: {
     ? `${file.from} → ${filename}`
     : filename;
 
-  const additions = file.chunks.reduce((s, c) => s + c.changes.filter((ch) => ch.type === "add").length, 0);
-  const deletions = file.chunks.reduce((s, c) => s + c.changes.filter((ch) => ch.type === "del").length, 0);
+  const additions = useMemo(() => file.chunks.reduce((s, c) => s + c.changes.filter((ch) => ch.type === "add").length, 0), [file]);
+  const deletions = useMemo(() => file.chunks.reduce((s, c) => s + c.changes.filter((ch) => ch.type === "del").length, 0), [file]);
 
   const headerRef = useRef<HTMLButtonElement>(null);
   const [hunkTop, setHunkTop] = useState(32);
@@ -299,4 +300,4 @@ export function FileDiff({ file, collapsed, onToggle, mode, palette }: {
       )}
     </div>
   );
-}
+});

--- a/src/components/agent/DiffFile.tsx
+++ b/src/components/agent/DiffFile.tsx
@@ -193,7 +193,7 @@ function buildSplitRows(changes: Change[]): SplitRow[] {
 export const SplitFile = React.memo(function SplitFile({ file, palette, hunkTop }: { file: File; palette: Palette; hunkTop: number }) {
   const filename = file.to ?? file.from ?? "unknown";
   const lang = langFrom(filename);
-  const addBg = "color-mix(in srgb, var(--success, #22c55e) 10%, transparent)";
+  const addBg = "color-mix(in srgb, var(--success) 10%, transparent)";
   const delBg = "color-mix(in srgb, var(--danger) 10%, transparent)";
   const splitRows = useMemo(() => file.chunks.map((chunk) => buildSplitRows(chunk.changes)), [file]);
   return (
@@ -248,10 +248,11 @@ export const SplitFile = React.memo(function SplitFile({ file, palette, hunkTop 
 
 // ── FileDiff — file header + collapsible content ──────────────────────────────
 
-export const FileDiff = React.memo(function FileDiff({ file, collapsed, onToggle, mode, palette }: {
+export const FileDiff = React.memo(function FileDiff({ file, fileKey, collapsed, onToggle, mode, palette }: {
   file: File;
+  fileKey: string;
   collapsed: boolean;
-  onToggle: () => void;
+  onToggle: (key: string) => void;
   mode: ViewMode;
   palette: Palette;
 }) {
@@ -278,7 +279,7 @@ export const FileDiff = React.memo(function FileDiff({ file, collapsed, onToggle
     <div className="border-b border-[var(--border)]">
       <button
         ref={headerRef}
-        onClick={onToggle}
+        onClick={() => onToggle(fileKey)}
         className="w-full flex items-center gap-2 px-3 py-1.5 bg-[var(--surface)] hover:bg-[var(--surface-2)] transition-colors sticky top-0 z-10 text-left border-b border-[var(--border-subtle)]"
       >
         {collapsed

--- a/src/components/agent/DiffViewer.tsx
+++ b/src/components/agent/DiffViewer.tsx
@@ -228,8 +228,9 @@ export function DiffViewer({ cwd }: DiffViewerProps) {
             <FileDiff
               key={fileKey}
               file={file}
+              fileKey={fileKey}
               collapsed={collapsed.has(fileKey)}
-              onToggle={() => toggleCollapse(fileKey)}
+              onToggle={toggleCollapse}
               mode={mode}
               palette={palette}
             />

--- a/src/components/agent/DiffViewer.tsx
+++ b/src/components/agent/DiffViewer.tsx
@@ -11,7 +11,7 @@
  *     changes  — unified but context lines hidden (adds/deletes only)
  */
 
-import { useMemo, useState, useEffect, useCallback, useRef } from "react";
+import { useMemo, useState, useEffect, useCallback, useRef, useDeferredValue } from "react";
 import parseDiff from "parse-diff";
 import { Copy, Check, RefreshCw, FolderGit2, ChevronRight, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -58,6 +58,10 @@ export function DiffViewer({ cwd }: DiffViewerProps) {
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const isMounted = useRef(true);
 
+  // Defers the diff text so that parseDiff + re-render runs at lower priority,
+  // keeping the UI responsive while typing, scrolling, or interacting.
+  const deferredDiffText = useDeferredValue(diffText);
+
   const fetchDiff = useCallback(async () => {
     if (!window.electron) return;
     setLoading(true);
@@ -83,9 +87,9 @@ export function DiffViewer({ cwd }: DiffViewerProps) {
   }, [fetchDiff]);
 
   const files = useMemo(() => {
-    if (!diffText) return [];
-    try { return parseDiff(diffText); } catch { return []; }
-  }, [diffText]);
+    if (!deferredDiffText) return [];
+    try { return parseDiff(deferredDiffText); } catch { return []; }
+  }, [deferredDiffText]);
 
   const toggleCollapse = useCallback((key: string) => {
     setCollapsed((prev) => {

--- a/src/components/kanban/board.tsx
+++ b/src/components/kanban/board.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { createPortal } from "react-dom";
 import {
   DndContext,
   DragOverlay,
@@ -33,32 +32,12 @@ import { KanbanCard } from "./card";
 import { CardDetailModal } from "./card-detail";
 import type { TaskCard, BoardColumn } from "@/types";
 
-const ZONE_H = 36;
-const ZONE_W = 128;
-const ZONE_GAP = 6;
+const TITLE_BAR_H = 36;
 
-function getZoneHit(clientX: number, clientY: number): "archive" | "delete" | null {
-  const zoneTop = window.innerHeight - ZONE_H - 12;
-  if (clientY < zoneTop || clientY > zoneTop + ZONE_H) return null;
-  const totalW = ZONE_W * 2 + ZONE_GAP;
-  const zoneLeft = (window.innerWidth - totalW) / 2;
-  const archiveLeft = zoneLeft;
-  const deleteLeft = zoneLeft + ZONE_W + ZONE_GAP;
-  if (clientX >= archiveLeft && clientX < archiveLeft + ZONE_W) return "archive";
-  if (clientX >= deleteLeft && clientX < deleteLeft + ZONE_W) return "delete";
+function getZoneHit(clientX: number, clientY: number, barTop: number, archiveRect: DOMRect | null, deleteRect: DOMRect | null): "archive" | "delete" | null {
+  if (archiveRect && clientX >= archiveRect.left && clientX <= archiveRect.right && clientY >= barTop && clientY <= barTop + TITLE_BAR_H) return "archive";
+  if (deleteRect && clientX >= deleteRect.left && clientX <= deleteRect.right && clientY >= barTop && clientY <= barTop + TITLE_BAR_H) return "delete";
   return null;
-}
-
-function pointerCoords(event: { activatorEvent: Event | null }): { x: number; y: number } | null {
-  const e = event.activatorEvent;
-  if (!e) return null;
-  if (e instanceof TouchEvent) {
-    const t = e.changedTouches[0] ?? e.touches[0];
-    if (!t) return null;
-    return { x: t.clientX, y: t.clientY };
-  }
-  const pe = e as PointerEvent | MouseEvent;
-  return { x: pe.clientX, y: pe.clientY };
 }
 
 export function KanbanBoard() {
@@ -105,7 +84,6 @@ export function KanbanBoard() {
   const [detailCardId, setDetailCardId]     = useState<string | null>(null);
   const [overId, setOverId]                 = useState<string | null>(null);
   const [deleteFlashing, setDeleteFlashing] = useState(false);
-  const [hoverZone, setHoverZone]           = useState<"archive" | "delete" | null>(null);
 
   // Board filter — ⌘F / Ctrl+F toggles and focuses
   const [boardFilter, setBoardFilter]       = useState("");
@@ -150,15 +128,34 @@ export function KanbanBoard() {
     else if (card) { setActiveCard(card); }
   }
 
-  function handleDragMove(event: DragMoveEvent) {
-    if (!activeCard) { setHoverZone(null); return; }
-    const origin = pointerCoords(event);
-    if (!origin) { return; }
-    const x = origin.x + event.delta.x;
-    const y = origin.y + event.delta.y;
-    const zone = getZoneHit(x, y);
-    setHoverZone(zone);
-    // Clear column/card drop highlight while hovering an action zone
+  const hoverZoneRef = useRef<"archive" | "delete" | null>(null);
+  const dragOverlayRef = useRef<HTMLDivElement | null>(null);
+
+  function applyZoneHighlight(zone: "archive" | "delete" | null) {
+    const a = archiveBtnRef.current;
+    const d = deleteBtnRef.current;
+    if (a) a.classList.toggle("zone-active", zone === "archive");
+    if (d) d.classList.toggle("zone-active", zone === "delete");
+    const ov = dragOverlayRef.current;
+    if (ov) {
+      ov.classList.toggle("ring-2", !!zone);
+      ov.classList.toggle("ring-[var(--warning)]", zone === "archive");
+      ov.classList.toggle("ring-[var(--danger)]", zone === "delete");
+    }
+  }
+
+  function handleDragMove(_event: DragMoveEvent) {
+    if (!activeCard) { return; }
+    const p = livePointer.current;
+    if (!p) return;
+    const barTop = titleBarRef.current?.getBoundingClientRect().top ?? 0;
+    const archive = archiveBtnRef.current?.getBoundingClientRect() ?? null;
+    const del = deleteBtnRef.current?.getBoundingClientRect() ?? null;
+    const zone = getZoneHit(p.x, p.y, barTop, archive, del);
+    if (zone !== hoverZoneRef.current) {
+      hoverZoneRef.current = zone;
+      applyZoneHighlight(zone);
+    }
     if (zone) setOverId(null);
   }
 
@@ -170,26 +167,33 @@ export function KanbanBoard() {
     setActiveCard(null);
     setActiveColumn(null);
     setOverId(null);
-    setHoverZone(null);
+    hoverZoneRef.current = null;
+    applyZoneHighlight(null);
+    livePointer.current = null;
   }
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
     const draggedCard = active.data.current?.card as TaskCard | undefined;
 
-    // Compute final pointer position before clearing state
-    const origin = pointerCoords(event);
-    const dropX = origin ? origin.x + event.delta.x : 0;
-    const dropY = origin ? origin.y + event.delta.y : 0;
+    // Use the last known live pointer position (tracked via window listener).
+    const drop = livePointer.current;
+    const dropX = drop?.x ?? 0;
+    const dropY = drop?.y ?? 0;
+    const barTop = titleBarRef.current?.getBoundingClientRect().top ?? 0;
+    const archive = archiveBtnRef.current?.getBoundingClientRect() ?? null;
+    const del = deleteBtnRef.current?.getBoundingClientRect() ?? null;
 
     setActiveCard(null);
     setActiveColumn(null);
     setOverId(null);
-    setHoverZone(null);
+    hoverZoneRef.current = null;
+    applyZoneHighlight(null);
+    livePointer.current = null;
 
     // ── Action zones ──────────────────────────────────────────────────────
     if (draggedCard) {
-      const zone = getZoneHit(dropX, dropY);
+      const zone = getZoneHit(dropX, dropY, barTop, archive, del);
       if (zone === "archive") {
         archiveCard(draggedCard.id);
         return;
@@ -256,6 +260,30 @@ export function KanbanBoard() {
   // Deep-link: scroll to column
   const columnRefs     = useRef<Record<string, HTMLDivElement | null>>({});
   const boardScrollRef = useRef<HTMLDivElement | null>(null);
+  const titleBarRef = useRef<HTMLDivElement | null>(null);
+  const archiveBtnRef = useRef<HTMLButtonElement | null>(null);
+  const deleteBtnRef = useRef<HTMLButtonElement | null>(null);
+  const livePointer = useRef<{ x: number; y: number } | null>(null);
+
+  // Track real pointer position via window listener during drag — dnd-kit's
+  // event.delta doesn't account for auto-scroll, so we can't rely on
+  // activatorEvent + delta for screen coordinates.
+  useEffect(() => {
+    if (!activeCard) { livePointer.current = null; return; }
+    function onPointerMove(e: PointerEvent) {
+      livePointer.current = { x: e.clientX, y: e.clientY };
+    }
+    function onTouchMove(e: TouchEvent) {
+      const t = e.touches[0];
+      if (t) livePointer.current = { x: t.clientX, y: t.clientY };
+    }
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("touchmove", onTouchMove);
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("touchmove", onTouchMove);
+    };
+  }, [activeCard]);
   const [highlightedColumnId, setHighlightedColumnId] = useState<string | null>(null);
 
   const scrollToColumn = useCallback((columnId: string) => {
@@ -288,73 +316,7 @@ export function KanbanBoard() {
     );
   }
 
-  // Portal action zones — rendered into document.body, positioned at the
-  // bottom of the viewport so content never shifts and the drop target is
-  // always visible without scrolling.
-  const actionZonesPortal = activeCard && typeof document !== "undefined"
-    ? createPortal(
-        <div
-          style={{
-            position: "fixed",
-            bottom: 12,
-            left: 0,
-            right: 0,
-            height: ZONE_H,
-            display: "flex",
-            justifyContent: "center",
-            gap: ZONE_GAP,
-            zIndex: 9999,
-            pointerEvents: "none",
-          }}
-        >
-          {/* Archive button */}
-          <div
-            style={{
-              width: ZONE_W,
-              height: ZONE_H,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              gap: 6,
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              borderRadius: "6px 0 0 6px",
-              background: hoverZone === "archive" ? "var(--warning)" : "color-mix(in srgb, var(--warning) 85%, transparent)",
-              color: "var(--surface)",
-              transition: "background 0.15s",
-            }}
-          >
-            <Archive size={14} />
-            Archive
-          </div>
-          {/* Delete button */}
-          <div
-            style={{
-              width: ZONE_W,
-              height: ZONE_H,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              gap: 6,
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              borderRadius: "0 6px 6px 0",
-              background: deleteFlashing
-                ? "var(--danger)"
-                : hoverZone === "delete"
-                ? "var(--danger)"
-                : "color-mix(in srgb, var(--danger) 85%, transparent)",
-              color: "var(--surface)",
-              transition: "background 0.15s",
-            }}
-          >
-            <Trash2 size={14} />
-            Delete
-          </div>
-        </div>,
-        document.body
-      )
-    : null;
+  // No more portal — action zones are rendered inline in the title bar.
 
   return (
     <>
@@ -369,7 +331,7 @@ export function KanbanBoard() {
       >
         <div className="flex-1 flex flex-col min-h-0 w-full overflow-hidden">
           {/* Board / Archive toggle bar */}
-          <div className="flex items-center gap-1 px-4 h-9 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0">
+          <div ref={titleBarRef} className="flex items-center gap-1 px-4 h-9 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0">
             <button
               onClick={() => setArchiveViewOpen(false)}
               className={cn(
@@ -406,6 +368,31 @@ export function KanbanBoard() {
                 ) : null;
               })()}
             </button>
+
+            {/* Drop zones — shown alongside toggle buttons during card drag */}
+            {activeCard && (
+              <div className="flex items-center gap-1 ml-auto">
+                <button
+                  ref={archiveBtnRef}
+                  type="button"
+                  className="zone-archive flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium transition-colors"
+                >
+                  <Archive size={11} />
+                  Archive
+                </button>
+                <button
+                  ref={deleteBtnRef}
+                  type="button"
+                  className={cn(
+                    "zone-delete flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium transition-colors",
+                    deleteFlashing && "zone-active"
+                  )}
+                >
+                  <Trash2 size={11} />
+                  Delete
+                </button>
+              </div>
+            )}
           </div>
 
           {/* Filter bar — shown when ⌘F is pressed */}
@@ -619,11 +606,12 @@ export function KanbanBoard() {
           </SortableContext>}
         </div>
 
-        {actionZonesPortal}
-
         <DragOverlay>
           {activeCard && (
-            <div className="rotate-2 opacity-90">
+            <div
+              ref={dragOverlayRef}
+              className="rotate-2 opacity-90 rounded-lg"
+            >
               <KanbanCard card={activeCard} isDragging onClick={() => {}} />
             </div>
           )}

--- a/src/components/kanban/board.tsx
+++ b/src/components/kanban/board.tsx
@@ -559,7 +559,7 @@ export function KanbanBoard() {
                     })
                   : allCards;
                 return (
-                  <div key={column.id} ref={(el) => { columnRefs.current[column.id] = el; }} className="flex-shrink-0">
+                  <div key={column.id} ref={(el) => { columnRefs.current[column.id] = el; }} className="flex-shrink-0 self-stretch">
                     <KanbanColumn
                       column={column}
                       cards={filteredCards}

--- a/src/components/kanban/board.tsx
+++ b/src/components/kanban/board.tsx
@@ -49,6 +49,18 @@ function getZoneHit(clientX: number, clientY: number): "archive" | "delete" | nu
   return null;
 }
 
+function pointerCoords(event: { activatorEvent: Event | null }): { x: number; y: number } | null {
+  const e = event.activatorEvent;
+  if (!e) return null;
+  if (e instanceof TouchEvent) {
+    const t = e.changedTouches[0] ?? e.touches[0];
+    if (!t) return null;
+    return { x: t.clientX, y: t.clientY };
+  }
+  const pe = e as PointerEvent | MouseEvent;
+  return { x: pe.clientX, y: pe.clientY };
+}
+
 export function KanbanBoard() {
   const {
     activeProjectId,
@@ -140,9 +152,10 @@ export function KanbanBoard() {
 
   function handleDragMove(event: DragMoveEvent) {
     if (!activeCard) { setHoverZone(null); return; }
-    const init = event.activatorEvent as PointerEvent;
-    const x = init.clientX + event.delta.x;
-    const y = init.clientY + event.delta.y;
+    const origin = pointerCoords(event);
+    if (!origin) { return; }
+    const x = origin.x + event.delta.x;
+    const y = origin.y + event.delta.y;
     const zone = getZoneHit(x, y);
     setHoverZone(zone);
     // Clear column/card drop highlight while hovering an action zone
@@ -165,9 +178,9 @@ export function KanbanBoard() {
     const draggedCard = active.data.current?.card as TaskCard | undefined;
 
     // Compute final pointer position before clearing state
-    const init  = event.activatorEvent as PointerEvent;
-    const dropX = init.clientX + event.delta.x;
-    const dropY = init.clientY + event.delta.y;
+    const origin = pointerCoords(event);
+    const dropX = origin ? origin.x + event.delta.x : 0;
+    const dropY = origin ? origin.y + event.delta.y : 0;
 
     setActiveCard(null);
     setActiveColumn(null);

--- a/src/components/kanban/board.tsx
+++ b/src/components/kanban/board.tsx
@@ -33,23 +33,20 @@ import { KanbanCard } from "./card";
 import { CardDetailModal } from "./card-detail";
 import type { TaskCard, BoardColumn } from "@/types";
 
-const ZONE_H = 56;
+const ZONE_H = 36;
+const ZONE_W = 128;
+const ZONE_GAP = 6;
 
-// ── Zone helpers — no component state deps, safe at module scope ──────────────
-
-function computeZoneRect(el: HTMLDivElement | null): { top: number; left: number; width: number } | null {
-  const r = el?.getBoundingClientRect();
-  if (!r) return null;
-  return { top: r.top, left: r.left, width: r.width };
-}
-
-function getZoneHit(clientX: number, clientY: number, rect: { top: number; left: number; width: number }): "archive" | "delete" | null {
-  const { top, left, width } = rect;
-  const bottom = top + ZONE_H;
-  const mid    = left + width / 2;
-  if (clientY < top || clientY > bottom) return null;
-  if (clientX < left || clientX > left + width) return null;
-  return clientX < mid ? "archive" : "delete";
+function getZoneHit(clientX: number, clientY: number): "archive" | "delete" | null {
+  const zoneTop = window.innerHeight - ZONE_H - 12;
+  if (clientY < zoneTop || clientY > zoneTop + ZONE_H) return null;
+  const totalW = ZONE_W * 2 + ZONE_GAP;
+  const zoneLeft = (window.innerWidth - totalW) / 2;
+  const archiveLeft = zoneLeft;
+  const deleteLeft = zoneLeft + ZONE_W + ZONE_GAP;
+  if (clientX >= archiveLeft && clientX < archiveLeft + ZONE_W) return "archive";
+  if (clientX >= deleteLeft && clientX < deleteLeft + ZONE_W) return "delete";
+  return null;
 }
 
 export function KanbanBoard() {
@@ -125,10 +122,6 @@ export function KanbanBoard() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  // Portal zone rects — computed from the board container when drag starts
-  const boardRef    = useRef<HTMLDivElement>(null);
-  const [zoneRect, setZoneRect] = useState<{ top: number; left: number; width: number } | null>(null);
-
   const columns = activeProjectId ? getProjectColumns(activeProjectId) : [];
 
   const sensors = useSensors(
@@ -141,16 +134,16 @@ export function KanbanBoard() {
   function handleDragStart(event: DragStartEvent) {
     const col  = event.active.data.current?.column as BoardColumn | undefined;
     const card = event.active.data.current?.card   as TaskCard    | undefined;
-    if (col)       { setActiveColumn(col); setZoneRect(null); }
-    else if (card) { setActiveCard(card);  setZoneRect(computeZoneRect(boardScrollRef.current)); }
+    if (col)       { setActiveColumn(col); }
+    else if (card) { setActiveCard(card); }
   }
 
   function handleDragMove(event: DragMoveEvent) {
-    if (!activeCard || !zoneRect) { setHoverZone(null); return; }
+    if (!activeCard) { setHoverZone(null); return; }
     const init = event.activatorEvent as PointerEvent;
     const x = init.clientX + event.delta.x;
     const y = init.clientY + event.delta.y;
-    const zone = getZoneHit(x, y, zoneRect);
+    const zone = getZoneHit(x, y);
     setHoverZone(zone);
     // Clear column/card drop highlight while hovering an action zone
     if (zone) setOverId(null);
@@ -158,6 +151,13 @@ export function KanbanBoard() {
 
   function handleDragOver(event: DragOverEvent) {
     setOverId(event.over?.id as string ?? null);
+  }
+
+  function handleDragCancel() {
+    setActiveCard(null);
+    setActiveColumn(null);
+    setOverId(null);
+    setHoverZone(null);
   }
 
   function handleDragEnd(event: DragEndEvent) {
@@ -168,17 +168,15 @@ export function KanbanBoard() {
     const init  = event.activatorEvent as PointerEvent;
     const dropX = init.clientX + event.delta.x;
     const dropY = init.clientY + event.delta.y;
-    const rect  = zoneRect;
 
     setActiveCard(null);
     setActiveColumn(null);
     setOverId(null);
     setHoverZone(null);
-    setZoneRect(null);
 
     // ── Action zones ──────────────────────────────────────────────────────
-    if (draggedCard && rect) {
-      const zone = getZoneHit(dropX, dropY, rect);
+    if (draggedCard) {
+      const zone = getZoneHit(dropX, dropY);
       if (zone === "archive") {
         archiveCard(draggedCard.id);
         return;
@@ -277,59 +275,64 @@ export function KanbanBoard() {
     );
   }
 
-  // Portal action zones — rendered into document.body, positioned over the board top edge
-  const actionZonesPortal = activeCard && zoneRect && typeof document !== "undefined"
+  // Portal action zones — rendered into document.body, positioned at the
+  // bottom of the viewport so content never shifts and the drop target is
+  // always visible without scrolling.
+  const actionZonesPortal = activeCard && typeof document !== "undefined"
     ? createPortal(
         <div
           style={{
             position: "fixed",
-            top: zoneRect.top,
-            left: zoneRect.left,
-            width: zoneRect.width,
+            bottom: 12,
+            left: 0,
+            right: 0,
             height: ZONE_H,
             display: "flex",
+            justifyContent: "center",
+            gap: ZONE_GAP,
             zIndex: 9999,
-            pointerEvents: "none", // visual only — drop detected via hit-test in handleDragEnd
+            pointerEvents: "none",
           }}
         >
-          {/* Archive half */}
+          {/* Archive button */}
           <div
             style={{
-              width: "50%",
+              width: ZONE_W,
+              height: ZONE_H,
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              gap: 8,
-              fontSize: 13,
+              gap: 6,
+              fontSize: "0.875rem",
               fontWeight: 500,
-              background: hoverZone === "archive" ? "color-mix(in srgb, var(--warning) 22%, transparent)" : "color-mix(in srgb, var(--warning) 8%, transparent)",
-              color: hoverZone === "archive" ? "var(--warning)" : "color-mix(in srgb, var(--warning) 50%, transparent)",
-              borderBottom: `1px solid color-mix(in srgb, var(--warning) ${hoverZone === "archive" ? "45%" : "20%"}, transparent)`,
-              transition: "background 0.15s, color 0.15s, border-color 0.15s",
+              borderRadius: "6px 0 0 6px",
+              background: hoverZone === "archive" ? "var(--warning)" : "color-mix(in srgb, var(--warning) 85%, transparent)",
+              color: "var(--surface)",
+              transition: "background 0.15s",
             }}
           >
             <Archive size={14} />
             Archive
           </div>
-          {/* Delete half */}
+          {/* Delete button */}
           <div
             style={{
-              width: "50%",
+              width: ZONE_W,
+              height: ZONE_H,
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              gap: 8,
-              fontSize: 13,
+              gap: 6,
+              fontSize: "0.875rem",
               fontWeight: 500,
+              borderRadius: "0 6px 6px 0",
               background: deleteFlashing
-                ? "color-mix(in srgb, var(--danger) 40%, transparent)"
+                ? "var(--danger)"
                 : hoverZone === "delete"
-                ? "color-mix(in srgb, var(--danger) 22%, transparent)"
-                : "color-mix(in srgb, var(--danger) 8%, transparent)",
-              color: hoverZone === "delete" || deleteFlashing ? "var(--danger)" : "color-mix(in srgb, var(--danger) 50%, transparent)",
-              borderBottom: `1px solid color-mix(in srgb, var(--danger) ${hoverZone === "delete" ? "45%" : "20%"}, transparent)`,
-              borderLeft: "1px solid color-mix(in srgb, var(--danger) 15%, transparent)",
-              transition: "background 0.15s, color 0.15s, border-color 0.15s",
+                ? "var(--danger)"
+                : "color-mix(in srgb, var(--danger) 85%, transparent)",
+              color: "var(--surface)",
+              transition: "background 0.15s",
             }}
           >
             <Trash2 size={14} />
@@ -349,8 +352,9 @@ export function KanbanBoard() {
         onDragMove={handleDragMove}
         onDragOver={handleDragOver}
         onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
       >
-        <div ref={boardRef} className="flex-1 flex flex-col min-h-0 w-full overflow-hidden">
+        <div className="flex-1 flex flex-col min-h-0 w-full overflow-hidden">
           {/* Board / Archive toggle bar */}
           <div className="flex items-center gap-1 px-4 h-9 border-b border-[var(--border)] bg-[var(--surface)] flex-shrink-0">
             <button
@@ -547,8 +551,7 @@ export function KanbanBoard() {
           {!archiveViewOpen && <SortableContext items={columns.map((c) => c.id)} strategy={horizontalListSortingStrategy}>
             <div
               ref={boardScrollRef}
-              className="flex-1 flex gap-3 overflow-x-auto p-5 min-h-0 transition-all duration-200"
-              style={{ paddingTop: activeCard ? ZONE_H + 20 : 20 }}
+              className="flex-1 flex gap-3 overflow-x-auto p-5 min-h-0"
             >
               {columns.map((column) => {
                 const allCards = getColumnCards(column.id);

--- a/src/components/kanban/board.tsx
+++ b/src/components/kanban/board.tsx
@@ -32,11 +32,11 @@ import { KanbanCard } from "./card";
 import { CardDetailModal } from "./card-detail";
 import type { TaskCard, BoardColumn } from "@/types";
 
-const TITLE_BAR_H = 36;
-
-function getZoneHit(clientX: number, clientY: number, barTop: number, archiveRect: DOMRect | null, deleteRect: DOMRect | null): "archive" | "delete" | null {
-  if (archiveRect && clientX >= archiveRect.left && clientX <= archiveRect.right && clientY >= barTop && clientY <= barTop + TITLE_BAR_H) return "archive";
-  if (deleteRect && clientX >= deleteRect.left && clientX <= deleteRect.right && clientY >= barTop && clientY <= barTop + TITLE_BAR_H) return "delete";
+function getZoneHit(clientX: number, clientY: number, barRect: DOMRect | null, archiveRect: DOMRect | null, deleteRect: DOMRect | null): "archive" | "delete" | null {
+  if (!barRect) return null;
+  if (clientY < barRect.top || clientY > barRect.bottom) return null;
+  if (archiveRect && clientX >= archiveRect.left && clientX <= archiveRect.right) return "archive";
+  if (deleteRect && clientX >= deleteRect.left && clientX <= deleteRect.right) return "delete";
   return null;
 }
 
@@ -148,10 +148,10 @@ export function KanbanBoard() {
     if (!activeCard) { return; }
     const p = livePointer.current;
     if (!p) return;
-    const barTop = titleBarRef.current?.getBoundingClientRect().top ?? 0;
+    const barRect = titleBarRef.current?.getBoundingClientRect() ?? null;
     const archive = archiveBtnRef.current?.getBoundingClientRect() ?? null;
     const del = deleteBtnRef.current?.getBoundingClientRect() ?? null;
-    const zone = getZoneHit(p.x, p.y, barTop, archive, del);
+    const zone = getZoneHit(p.x, p.y, barRect, archive, del);
     if (zone !== hoverZoneRef.current) {
       hoverZoneRef.current = zone;
       applyZoneHighlight(zone);
@@ -180,9 +180,40 @@ export function KanbanBoard() {
     const drop = livePointer.current;
     const dropX = drop?.x ?? 0;
     const dropY = drop?.y ?? 0;
-    const barTop = titleBarRef.current?.getBoundingClientRect().top ?? 0;
+    const barRect = titleBarRef.current?.getBoundingClientRect() ?? null;
     const archive = archiveBtnRef.current?.getBoundingClientRect() ?? null;
     const del = deleteBtnRef.current?.getBoundingClientRect() ?? null;
+
+    // Check action zones before clearing drag state — the delete flash
+    // needs activeCard to stay truthy so the zone buttons remain mounted.
+    if (draggedCard) {
+      const zone = getZoneHit(dropX, dropY, barRect, archive, del);
+      if (zone === "archive") {
+        setActiveCard(null);
+        setActiveColumn(null);
+        setOverId(null);
+        hoverZoneRef.current = null;
+        applyZoneHighlight(null);
+        livePointer.current = null;
+        archiveCard(draggedCard.id);
+        return;
+      }
+      if (zone === "delete") {
+        setDeleteFlashing(true);
+        applyZoneHighlight("delete");
+        setTimeout(() => {
+          setDeleteFlashing(false);
+          setActiveCard(null);
+          setActiveColumn(null);
+          setOverId(null);
+          hoverZoneRef.current = null;
+          applyZoneHighlight(null);
+          livePointer.current = null;
+          deleteCard(draggedCard.id);
+        }, 300);
+        return;
+      }
+    }
 
     setActiveCard(null);
     setActiveColumn(null);
@@ -190,23 +221,6 @@ export function KanbanBoard() {
     hoverZoneRef.current = null;
     applyZoneHighlight(null);
     livePointer.current = null;
-
-    // ── Action zones ──────────────────────────────────────────────────────
-    if (draggedCard) {
-      const zone = getZoneHit(dropX, dropY, barTop, archive, del);
-      if (zone === "archive") {
-        archiveCard(draggedCard.id);
-        return;
-      }
-      if (zone === "delete") {
-        setDeleteFlashing(true);
-        setTimeout(() => {
-          setDeleteFlashing(false);
-          deleteCard(draggedCard.id);
-        }, 300);
-        return;
-      }
-    }
 
     if (!over || active.id === over.id) return;
 

--- a/src/components/kanban/card.tsx
+++ b/src/components/kanban/card.tsx
@@ -109,7 +109,8 @@ export const KanbanCard = React.memo(function KanbanCard({ card, onClick, isDrag
                 ref={descRef}
                 className={cn(
                   "text-[0.786rem] text-[var(--text-tertiary)] leading-relaxed",
-                  expanded ? "max-h-48 overflow-y-auto pr-1" : "line-clamp-2"
+                  "[&_.prose-cairn]:!py-0 [&_.prose-cairn_p]:!my-0",
+                  expanded ? "max-h-80 overflow-y-auto pr-1" : "max-h-10 overflow-hidden"
                 )}
               >
                 <NoteMarkdownPreview content={description} className="!px-0 !py-0" />

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -204,7 +204,7 @@ export function KanbanColumn({
         ref={setSortableRef}
         style={style}
         className={cn(
-          "flex flex-col w-56 rounded-xl border flex-shrink-0 transition-colors duration-150",
+          "flex flex-col w-56 rounded-xl border flex-shrink-0 h-full transition-colors duration-150",
           isDragOver
             ? "border-[var(--accent)]/50 bg-[var(--accent-dim)]"
             : isHighlighted
@@ -323,7 +323,7 @@ export function KanbanColumn({
 
         {/* Cards */}
         <SortableContext items={cards.map((c) => c.id)} strategy={verticalListSortingStrategy}>
-          <div ref={setDropRef} className="flex-1 overflow-y-auto p-2 space-y-2 min-h-[48px]">
+          <div ref={setDropRef} className={cn("flex-1 overflow-y-auto p-2 space-y-2 min-h-[48px]", isDragOver && "min-h-[120px]")}>
             {cards.map((card) => (
               <KanbanCard key={card.id} card={card} onClick={() => onCardClick(card.id)} />
             ))}


### PR DESCRIPTION
What does this PR do?

This PR includes several stability and performance improvements:
- **Note Management**: Fixes a bug where `patch_note` and `append_to_note` would incorrectly move notes to the project root by failing to preserve their original folder path.
- **Kanban UX**: Refines the drag-and-drop experience by adding proper drag-cancel cleanup (Escape key support), redesigning action zones, and improving column/card responsiveness.
- **Diff Viewer Optimization**: Enhances Agent View performance by memoizing diff sub-components, caching row building, and offloading parsing to `useDeferredValue` to prevent UI thread blocking.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code quality

## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (runs `npm run compile` first so `electron/bundle-guard.test.ts` actually executes — `npm run test:bundle` to run just that)
- [x] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [ ] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [ ] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts`
- [ ] New SQL goes in `electron/db/queries.ts` — single source of truth (imported by both Electron main process and MCP server); never construct a `Database` instance outside `db/client.ts` (Electron) or `mcp-server.ts` (MCP runtime)
- [ ] New `dependencies` or `devDependencies` added to `ROLE_MAP` in `scripts/generate-licenses.js` and `licenses.json` regenerated
- [ ] New MCP tools registered in `electron/mcp/tools/index.ts` dispatch + `electron/lib/tool-schemas.ts` Zod schema
- [ ] If you added/removed a `--external:<pkg>` flag in the `compile` script: updated the appropriate allowlist group (`RUNTIME_PROVIDED` / `OPTIONAL_TRANSITIVE` / `SUBPROCESS_ONLY` / `SHIPPED_NATIVE`) in `electron/bundle-guard.test.ts` and (if `SHIPPED_NATIVE`) shipped the package via `electron-builder.yml`

## Notes for reviewer

The Diff Viewer updates use `React.memo` and `useMemo` hooks to prevent redundant re-renders of the diff file views during polling. The Kanban changes move away from the top-banner drag drop zones to a fixed-portal bottom overlay to avoid layout shift during drag operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refreshed Kanban drag-and-drop interactions with inline, title-bar Archive/Delete buttons and larger, more forgiving drop targets (reduced layout shifts).
* **Bug Fixes**
  * Notes now preserve folder metadata when edited or appended.
  * Improved drag cancellation behavior (including clearer highlight reset) and more consistent Kanban card/description expand/collapse sizing.
* **Performance**
  * Diff viewer responsiveness improved by deferring diff parsing, memoizing diff rendering, and safely handling parse failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->