### PR TITLE
Notes: fix cross-project move, add right-click menu (desktop) + move-to-project & fixes (mobile)

### DIFF
--- a/changelogs/v2.4.10.md
+++ b/changelogs/v2.4.10.md
@@ -1,0 +1,12 @@
+## What's new
+
+Moving a note between projects now sticks, and notes get a right-click menu.
+
+### New
+
+- **Right-click a note for its actions.** The note actions menu (Pin/Unpin, Reveal, Archive, Move to folder, Move to project, Delete) now also opens on right-click anywhere on a note row — you no longer have to hover and hit the small ⋯ button. Archived notes get a right-click menu too (Restore / Delete permanently).
+
+### Fixes
+
+- **Project icons in the "Move to project" list.** The move-to-project picker showed some projects' icon as a raw word (e.g. "Briefcase", "Rocket") instead of the actual icon, because it rendered the stored icon *name* as text. It now draws the proper icon, matching the sidebar and everywhere else.
+- **Moving a note to another project now persists.** Moving a note from one project to another appeared to work, but the note would re-appear in its original project a moment later. The move was never written to the database — the note-update path had no way to change a note's project — so the note's `.md` file was also left behind in the old project's folder, and the next refresh, file re-scan, or device sync brought the note back where it started. Moving a note now correctly updates its project (and owning workspace), relocates its `.md` file into the new project's folder (removing the old copy), and refreshes its links and search index for the new location. Undo/redo of a move now persists too.

--- a/electron/db/queries.test.ts
+++ b/electron/db/queries.test.ts
@@ -208,7 +208,7 @@ describe("moveNoteToProject", () => {
   });
 
   it("persists the new project_id and workspace_id (regression: updateNote drops them)", () => {
-    const moved = moveNoteToProject(db, "note1", "proj2", "ws2");
+    const moved = moveNoteToProject(db, "note1", "proj2");
     expect(moved.projectId).toBe("proj2");
     expect(moved.workspaceId).toBe("ws2");
 
@@ -218,8 +218,22 @@ describe("moveNoteToProject", () => {
     expect(reloaded?.workspaceId).toBe("ws2");
   });
 
+  it("resolves the destination workspace from the target project, not a caller arg", () => {
+    // proj2 belongs to ws2 (see beforeEach) — the note's workspace must follow
+    // the project regardless of what any caller might have wanted.
+    const moved = moveNoteToProject(db, "note1", "proj2");
+    expect(moved.workspaceId).toBe("ws2");
+  });
+
+  it("rejects a move to a non-existent project (note stays put)", () => {
+    expect(() => moveNoteToProject(db, "note1", "nope")).toThrow();
+    const reloaded = getNoteById(db, "note1");
+    expect(reloaded?.projectId).toBe("proj1");
+    expect(reloaded?.workspaceId).toBe("ws1");
+  });
+
   it("does NOT re-surface under the old project after the move", () => {
-    moveNoteToProject(db, "note1", "proj2", "ws2");
+    moveNoteToProject(db, "note1", "proj2");
     const inOldProject = searchNotes(db, { query: "Movable Note", projectId: "proj1" });
     expect(inOldProject.find((n) => n.id === "note1")).toBeUndefined();
     const inNewProject = searchNotes(db, { query: "Movable Note", projectId: "proj2" });
@@ -228,9 +242,11 @@ describe("moveNoteToProject", () => {
 
   it("bumps version and updated_at", async () => {
     const before = getNoteById(db, "note1");
+    // Small delay so the ISO timestamp is strictly later (same-ms writes would tie).
     await new Promise((r) => setTimeout(r, 5));
-    const moved = moveNoteToProject(db, "note1", "proj2", "ws2");
-    expect(moved.updatedAt >= (before?.updatedAt ?? "")).toBe(true);
+    const moved = moveNoteToProject(db, "note1", "proj2");
+    expect(moved.version).toBeGreaterThan(before?.version ?? -1);
+    expect(moved.updatedAt > (before?.updatedAt ?? "")).toBe(true);
   });
 });
 

--- a/electron/db/queries.test.ts
+++ b/electron/db/queries.test.ts
@@ -19,6 +19,7 @@ import {
   updateNote,
   deleteNote,
   getNoteById,
+  moveNoteToProject,
   createColumn,
   createCard,
   updateCard,
@@ -184,6 +185,52 @@ describe("updateNote", () => {
 
     const results = searchNotes(db, { query: "Original Title" });
     expect(results.find((n) => n.id === "note1")).toBeUndefined();
+  });
+});
+
+describe("moveNoteToProject", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = makeDb();
+    seedWorkspace(db);
+    seedProject(db);
+    // A second project in a different workspace to move into.
+    createWorkspace(db, { id: "ws2", name: "Other Workspace" });
+    createProject(db, { id: "proj2", workspaceId: "ws2", name: "Other Project" });
+    createNote(db, {
+      id: "note1",
+      projectId: "proj1",
+      workspaceId: "ws1",
+      title: "Movable Note",
+      content: "content",
+    });
+  });
+
+  it("persists the new project_id and workspace_id (regression: updateNote drops them)", () => {
+    const moved = moveNoteToProject(db, "note1", "proj2", "ws2");
+    expect(moved.projectId).toBe("proj2");
+    expect(moved.workspaceId).toBe("ws2");
+
+    // Re-read from the DB — the move must be durable, not just on the return value.
+    const reloaded = getNoteById(db, "note1");
+    expect(reloaded?.projectId).toBe("proj2");
+    expect(reloaded?.workspaceId).toBe("ws2");
+  });
+
+  it("does NOT re-surface under the old project after the move", () => {
+    moveNoteToProject(db, "note1", "proj2", "ws2");
+    const inOldProject = searchNotes(db, { query: "Movable Note", projectId: "proj1" });
+    expect(inOldProject.find((n) => n.id === "note1")).toBeUndefined();
+    const inNewProject = searchNotes(db, { query: "Movable Note", projectId: "proj2" });
+    expect(inNewProject.find((n) => n.id === "note1")).toBeDefined();
+  });
+
+  it("bumps version and updated_at", async () => {
+    const before = getNoteById(db, "note1");
+    await new Promise((r) => setTimeout(r, 5));
+    const moved = moveNoteToProject(db, "note1", "proj2", "ws2");
+    expect(moved.updatedAt >= (before?.updatedAt ?? "")).toBe(true);
   });
 });
 

--- a/electron/db/queries.ts
+++ b/electron/db/queries.ts
@@ -264,6 +264,24 @@ export function moveNoteFolder(db: Database.Database, id: string, folder: string
 }
 
 /**
+ * Move a note to a different project (and its owning workspace).
+ * Uses a direct SET rather than updateNote()'s COALESCE list, which has no
+ * project_id/workspace_id columns at all — so a project move sent through
+ * updateNote() was silently dropped, leaving the row (and its .md file) in the
+ * old project and letting a DB refresh / file-watcher re-import / sync reconcile
+ * resurface the note where it started. Callers must also move the .md file
+ * (delete the old project's copy, write into the new one) — see the
+ * db:note:moveToProject IPC handler.
+ */
+export function moveNoteToProject(db: Database.Database, id: string, projectId: string, workspaceId: string) {
+  const now = ts();
+  db.prepare(
+    "UPDATE notes SET project_id = ?, workspace_id = ?, updated_at = ?, version = version + 1 WHERE id = ?",
+  ).run(projectId, workspaceId, now, id);
+  return toNote(db.prepare("SELECT * FROM notes WHERE id = ?").get(id));
+}
+
+/**
  * Explicitly clear archived_at for a note (cannot use COALESCE for NULL clears).
  */
 export function restoreNote(db: Database.Database, id: string) {

--- a/electron/db/queries.ts
+++ b/electron/db/queries.ts
@@ -272,12 +272,20 @@ export function moveNoteFolder(db: Database.Database, id: string, folder: string
  * resurface the note where it started. Callers must also move the .md file
  * (delete the old project's copy, write into the new one) — see the
  * db:note:moveToProject IPC handler.
+ *
+ * The destination workspace is resolved from the target project itself (not
+ * trusted from the caller) so the note can never land in a project/workspace
+ * mismatch; a missing target project is rejected.
  */
-export function moveNoteToProject(db: Database.Database, id: string, projectId: string, workspaceId: string) {
+export function moveNoteToProject(db: Database.Database, id: string, projectId: string) {
+  const project = db.prepare("SELECT workspace_id FROM projects WHERE id = ?").get(projectId) as
+    | { workspace_id: string }
+    | undefined;
+  if (!project) throw new Error(`Target project not found: ${projectId}`);
   const now = ts();
   db.prepare(
     "UPDATE notes SET project_id = ?, workspace_id = ?, updated_at = ?, version = version + 1 WHERE id = ?",
-  ).run(projectId, workspaceId, now, id);
+  ).run(projectId, project.workspace_id, now, id);
   return toNote(db.prepare("SELECT * FROM notes WHERE id = ?").get(id));
 }
 

--- a/electron/ipc/db-handlers.ts
+++ b/electron/ipc/db-handlers.ts
@@ -236,6 +236,53 @@ export function registerDbHandlers(ctx: DbContext): void {
     return note;
   }));
 
+  registerIpcHandle(
+    "db:note:moveToProject",
+    (_e, { id, projectId, workspaceId }: { id: string; projectId: string; workspaceId: string }) =>
+      handle(() => {
+        // Moving a note between projects was previously routed through
+        // updateNote(), whose UPDATE has no project_id/workspace_id columns — so
+        // the move was silently dropped and the note re-surfaced in the old
+        // project (via a DB refresh, file-watcher re-import, or sync reconcile).
+        // Persist the move with a dedicated direct-SET query, and — crucially —
+        // relocate the .md file: writeNoteFile only unlinks a stale file it finds
+        // *within the target project's* folder, so the old project's copy must be
+        // deleted explicitly or the file-watcher will re-import it into the old
+        // project.
+        const before = q.getNoteById(ctx.db, id);
+        if (!before) throw new Error(`Note not found: ${id}`);
+        const oldProjectName = getProjectName(ctx.db, before.projectId);
+
+        suppressNextChange(id);
+        const note = q.moveNoteToProject(ctx.db, id, projectId, workspaceId);
+
+        if (note.type !== "dashboard") {
+          // Remove the note's file from the OLD project folder (its id-matched
+          // copy), then write it fresh under the NEW project folder.
+          if (oldProjectName !== getProjectName(ctx.db, projectId)) {
+            deleteNoteFile(ctx.workspacePath, oldProjectName, id);
+          }
+          writeNoteFile(ctx.workspacePath, { ...note, projectName: getProjectName(ctx.db, note.projectId) });
+        }
+
+        // Membership changed → auto/semantic relationships and the embedding
+        // index are scoped by workspace, so recompute for the new workspace.
+        invalidateRelationshipCache(ctx.db, id);
+        if (note.workspaceId) {
+          computeAutoRelationships(ctx.db, note.workspaceId, [id]);
+          void reindexSingleNoteEmbedding(ctx, id, note.workspaceId).then((didReindex) => {
+            if (!didReindex) return;
+            try {
+              computeSemanticRelationships(ctx.db, note.workspaceId, [id]);
+            } catch (e) {
+              console.warn("[embeddings] semantic recompute skipped:", e instanceof Error ? e.message : e);
+            }
+          }).catch(() => { /* already warned */ });
+        }
+        return note;
+      }),
+  );
+
   registerIpcHandle("db:note:delete", (_e, { id }) => handle(() => {
     const note = q.getNoteById(ctx.db, id);
     if (note) {

--- a/electron/ipc/db-handlers.ts
+++ b/electron/ipc/db-handlers.ts
@@ -238,7 +238,7 @@ export function registerDbHandlers(ctx: DbContext): void {
 
   registerIpcHandle(
     "db:note:moveToProject",
-    (_e, { id, projectId, workspaceId }: { id: string; projectId: string; workspaceId: string }) =>
+    (_e, { id, projectId }: { id: string; projectId: string; workspaceId?: string }) =>
       handle(() => {
         // Moving a note between projects was previously routed through
         // updateNote(), whose UPDATE has no project_id/workspace_id columns — so
@@ -251,18 +251,34 @@ export function registerDbHandlers(ctx: DbContext): void {
         // project.
         const before = q.getNoteById(ctx.db, id);
         if (!before) throw new Error(`Note not found: ${id}`);
-        const oldProjectName = getProjectName(ctx.db, before.projectId);
+        const oldProjectId = before.projectId;
+        const oldProjectName = getProjectName(ctx.db, oldProjectId);
 
+        // moveNoteToProject rejects a missing target project (and resolves the
+        // authoritative workspace itself), so the DB move is validated before we
+        // touch any files.
         suppressNextChange(id);
-        const note = q.moveNoteToProject(ctx.db, id, projectId, workspaceId);
+        const note = q.moveNoteToProject(ctx.db, id, projectId);
 
-        if (note.type !== "dashboard") {
-          // Remove the note's file from the OLD project folder (its id-matched
-          // copy), then write it fresh under the NEW project folder.
-          if (oldProjectName !== getProjectName(ctx.db, projectId)) {
-            deleteNoteFile(ctx.workspacePath, oldProjectName, id);
+        if (note.type !== "dashboard" && oldProjectName !== getProjectName(ctx.db, projectId)) {
+          // Failure-safe relocation: write the note into the NEW project folder
+          // FIRST, then remove the old copy. If the write throws, roll the DB
+          // row back to the old project so ownership and the on-disk file stay
+          // consistent (the old file is still present and authoritative).
+          try {
+            writeNoteFile(ctx.workspacePath, { ...note, projectName: getProjectName(ctx.db, note.projectId) });
+          } catch (e) {
+            q.moveNoteToProject(ctx.db, id, oldProjectId);
+            throw e;
           }
-          writeNoteFile(ctx.workspacePath, { ...note, projectName: getProjectName(ctx.db, note.projectId) });
+          // New file is in place; deleting the stale old copy is best-effort
+          // (a failure here only leaves a duplicate that the watcher would
+          // re-import into the old project — non-fatal, and the DB move stands).
+          try {
+            deleteNoteFile(ctx.workspacePath, oldProjectName, id);
+          } catch (e) {
+            console.warn("[notes] failed to remove old-project file after move:", e instanceof Error ? e.message : e);
+          }
         }
 
         // Membership changed → auto/semantic relationships and the embedding

--- a/electron/ipc/registry.test.ts
+++ b/electron/ipc/registry.test.ts
@@ -32,6 +32,7 @@ describe("isWriteChannel", () => {
       "db:note:update",
       "db:note:delete",
       "db:note:moveToFolder",
+      "db:note:moveToProject",
       "db:card:addBlocker",
       "db:card:removeBlocker",
       "db:cards:archive-done",

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -125,8 +125,10 @@ const api = {
     update:       (id: string, patch: unknown) => invoke("db:note:update", { id, patch }),
     delete:       (id: string) => invoke("db:note:delete", { id }),
     moveToFolder: (id: string, folder: string) => invoke("db:note:moveToFolder", { id, folder }),
-    moveToProject: (id: string, projectId: string, workspaceId: string) =>
-      invoke("db:note:moveToProject", { id, projectId, workspaceId }),
+    // workspaceId is derived from the target project by the handler; accepted for
+    // backwards-compatible call sites but no longer required.
+    moveToProject: (id: string, projectId: string, _workspaceId?: string) =>
+      invoke("db:note:moveToProject", { id, projectId }),
   },
 
   // ── Board columns ─────────────────────────────

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -125,6 +125,8 @@ const api = {
     update:       (id: string, patch: unknown) => invoke("db:note:update", { id, patch }),
     delete:       (id: string) => invoke("db:note:delete", { id }),
     moveToFolder: (id: string, folder: string) => invoke("db:note:moveToFolder", { id, folder }),
+    moveToProject: (id: string, projectId: string, workspaceId: string) =>
+      invoke("db:note:moveToProject", { id, projectId, workspaceId }),
   },
 
   // ── Board columns ─────────────────────────────

--- a/mobile/app/(tabs)/chat/index.tsx
+++ b/mobile/app/(tabs)/chat/index.tsx
@@ -11,6 +11,8 @@ import {
   Alert,
   ActionSheetIOS,
   Platform,
+  AppState,
+  type AppStateStatus,
 } from "react-native";
 import Animated, { useSharedValue, withTiming, useAnimatedStyle, interpolate } from "react-native-reanimated";
 import { KeyboardStickyView, KeyboardController, KeyboardChatScrollView, KeyboardGestureArea, useReanimatedKeyboardAnimation } from "react-native-keyboard-controller";
@@ -55,6 +57,7 @@ const NOTE_TOOLS: Record<string, "args" | "result"> = {
   append_to_note: "args",
   patch_note: "args",
   rename_note: "args",
+  move_note_to_project: "args",
 };
 /** Tools whose result points at a CARD. */
 const CARD_TOOLS: Record<string, "args" | "result"> = {
@@ -127,6 +130,21 @@ export default function ChatScreen() {
   // the Chat tab (it's session state otherwise, lost on unmount).
   const [usage, setUsage] = useState<ChatUsage | null>(() => loadLastChatUsage());
   const scrollRef = useRef<ComponentRef<typeof KeyboardChatScrollView>>(null);
+  // Resume-repaint key. iOS composites its cached UIKit snapshot over the live
+  // hierarchy when the app returns from background; the composer's native Liquid
+  // Glass layer (GlassBar → GlassView) samples a backdrop that stays stale until
+  // the next paint, leaving translucent vertical "ghost bands" over the
+  // transformed scroll content (tool chips + avatar column) until the user
+  // interacts. Bumping this key on the "active" transition remounts that content
+  // so the stale backdrop is invalidated immediately. Only glass builds are
+  // affected, so it's a no-op remount elsewhere.
+  const [resumeKey, setResumeKey] = useState(0);
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (next: AppStateStatus) => {
+      if (next === "active") setResumeKey((k) => k + 1);
+    });
+    return () => sub.remove();
+  }, []);
   // Whether the user is at/near the bottom of the transcript. Auto-follow on
   // content growth only when true, so expanding a past message's reasoning block
   // (or other layout changes while scrolled up) doesn't yank the view to the end.
@@ -402,6 +420,7 @@ export default function ChatScreen() {
           style={StyleSheet.absoluteFill}
         >
           <KeyboardChatScrollView
+            key={resumeKey}
             ref={scrollRef}
             style={StyleSheet.absoluteFill}
             contentContainerStyle={[styles.list, messages.length === 0 && styles.listEmpty]}

--- a/mobile/app/(tabs)/chat/index.tsx
+++ b/mobile/app/(tabs)/chat/index.tsx
@@ -136,10 +136,12 @@ export default function ChatScreen() {
   // the next paint, leaving translucent vertical "ghost bands" over the
   // transformed scroll content (tool chips + avatar column) until the user
   // interacts. Bumping this key on the "active" transition remounts that content
-  // so the stale backdrop is invalidated immediately. Only glass builds are
-  // affected, so it's a no-op remount elsewhere.
+  // so the stale backdrop is invalidated immediately. iOS-only — the artifact is
+  // specific to the native glass layer, and remounting on Android would only
+  // throw away scroll state for no benefit.
   const [resumeKey, setResumeKey] = useState(0);
   useEffect(() => {
+    if (Platform.OS !== "ios") return;
     const sub = AppState.addEventListener("change", (next: AppStateStatus) => {
       if (next === "active") setResumeKey((k) => k + 1);
     });

--- a/mobile/changelogs/v0.1.3.md
+++ b/mobile/changelogs/v0.1.3.md
@@ -4,6 +4,7 @@ Polish for the workspace switcher and Knowledge Graph controls.
 
 ### New
 
+- **Long-press a note to move, pin, or delete it**: Press and hold any note in a project's Notes list to open a quick actions menu — **Pin/Unpin**, **Move to project**, **Move to folder**, or **Delete** — mirroring the note menu on desktop. "Move to project" and "Move to folder" open a picker of your other projects / this project's folders. This is the first way to move a note between projects on mobile (there was previously no manual way to do it at all).
 - **Project Overview on mobile**: Opening a project now starts on a new **Overview** tab (alongside Notes and Board) that gives you an at-a-glance snapshot — a completion ring, note / open-task / overdue counts, a breakdown of tasks by column and by priority, what's due soon, your pinned and recent notes, and a recent-activity feed. Tapping anything jumps straight to it. This mirrors the desktop project Overview.
 - **Drag to reschedule on the calendar**: Long-press a task on the calendar and drag it onto another day to change its due date — the same lift-and-drop gesture as the board. There's also a new **Unscheduled** tray at the bottom listing tasks with no due date: drag one onto a day to schedule it, or drag a dated task into the tray to clear its due date. Available on both the workspace and per-project calendars.
 
@@ -16,6 +17,8 @@ Polish for the workspace switcher and Knowledge Graph controls.
 
 ### Fixes
 
+- **The assistant can dig much deeper before giving up**: Chat could previously stop after only 8 steps with "I couldn't finish that in a reasonable number of steps." — too few for the assistant's introspective research, which often chains many single reads (open a note, search, read a section, follow a link…). It now allows up to 30 steps, matching the desktop app, so multi-step research and edits complete instead of cutting off early. The message shown if it ever does hit the limit is clearer, and notes any changes already made were saved.
+- **No more ghost bands after reopening Chat**: Returning to the Chat screen after the app had been backgrounded could briefly show faint vertical bands over the messages (an iOS snapshot artifact from the frosted composer). Chat now repaints on resume so they no longer appear.
 - **Reschedule overdue tasks by dragging**: Overdue chips in the calendar's overdue tray can now be long-pressed and dragged onto a day (or into the Unscheduled tray) to reschedule or clear their due date — same as tasks in the grid.
 - **Consistent calendar header**: The Today and Month/Week controls now sit in the top navigation bar on the per-project calendar too, matching the Calendar tab — the calendar looks the same however you open it.
 - **Chat attachment icon stays put**: The image-attachment button in the chat composer no longer jumps up out of place after you tap it while the keyboard is open — it's now a plain button (opening a native photo action sheet) that rides the keyboard exactly like the send button, instead of a native menu control that anchored to the screen and drifted when its menu opened.
@@ -37,7 +40,7 @@ Polish for the workspace switcher and Knowledge Graph controls.
 
 - **Open notes and tasks straight from chat**: Chat is now far more reliable at jumping to what it mentions. When the assistant creates or touches a note or task, its little tool chip is now tappable and takes you straight there. `[[Wikilinks]]` in replies now open **tasks** too (not just notes), and both are matched to the exact item at the moment they're shown — so taps no longer occasionally open the wrong item or quietly do nothing.
 
-- **The assistant can now manage tasks and organise notes**: Chat gained several tools it was missing — it can open a task's full detail, edit a task (including moving it to another column, changing priority, due date or assignee), rename a note (fixing links to it automatically), move notes into folders, list a project's folders, and delete a note or task. Previously it could only read and create/append to notes and tasks.
+- **The assistant can now manage tasks and organise notes**: Chat gained several tools it was missing — it can open a task's full detail, edit a task (including moving it to another column, changing priority, due date or assignee), rename a note (fixing links to it automatically), move notes into folders, **move a note to another project**, list a project's folders, and delete a note or task. Previously it could only read and create/append to notes and tasks.
 
 ### Under the hood
 

--- a/mobile/src/chat/agent.ts
+++ b/mobile/src/chat/agent.ts
@@ -20,7 +20,12 @@ import {
 } from "./providers/types";
 import { toolsForAgent, TOOL_MAP } from "./tools";
 
-const MAX_TURNS = 8;
+// Max model round-trips per user turn. Each turn is one model call; a turn that
+// requests tools runs them all, then loops for the model's follow-up (which sees
+// the outputs). Introspective research chains many single-tool reads (get note →
+// search → get note range → …), so this must be generous — matched to the
+// desktop default (DEFAULT_AGENT_CONFIG.maxSteps in src/lib/constants.ts).
+const MAX_TURNS = 30;
 
 export interface AgentEvent {
   type: "text-delta" | "reasoning-delta" | "tool" | "final" | "error";
@@ -236,7 +241,7 @@ export async function runAgent(
     }
   }
 
-  const msg = finalText || "I couldn't finish that in a reasonable number of steps.";
+  const msg = finalText || `I reached the maximum of ${MAX_TURNS} steps. Any changes made have been saved — try a more focused request.`;
   onEvent?.({ type: "final", text: msg, reasoning: reasoning || undefined, usage });
   return msg;
 }

--- a/mobile/src/chat/agent.ts
+++ b/mobile/src/chat/agent.ts
@@ -241,7 +241,12 @@ export async function runAgent(
     }
   }
 
-  const msg = finalText || `I reached the maximum of ${MAX_TURNS} steps. Any changes made have been saved — try a more focused request.`;
+  // Reaching here means every turn requested tools and we ran out of turns. The
+  // limit MUST be reported even if an earlier turn produced partial text — a
+  // bare `finalText || …` would silently swallow the notice and pass the
+  // half-finished answer off as complete.
+  const limitNote = `I reached the maximum of ${MAX_TURNS} steps. Any changes made have been saved — try a more focused request.`;
+  const msg = finalText ? `${finalText}\n\n${limitNote}` : limitNote;
   onEvent?.({ type: "final", text: msg, reasoning: reasoning || undefined, usage });
   return msg;
 }

--- a/mobile/src/chat/tools.ts
+++ b/mobile/src/chat/tools.ts
@@ -174,6 +174,14 @@ export const TOOLS: ToolDef[] = [
     run: (a) => ({ moved: q.moveNotesToFolder(Array.isArray(a.note_ids) ? a.note_ids.map(str) : [], str(a.folder)) }),
   },
   {
+    name: "move_note_to_project",
+    description:
+      "Move a note to a different project (call get_cairn_context for project ids). The note's owning workspace is updated automatically. Returns the new project_id/workspace_id, or an error.",
+    params: '{ "id": string, "project_id": string }',
+    jsonSchema: obj({ id: S, project_id: S }, ["id", "project_id"]),
+    run: (a) => q.moveNoteToProject(str(a.id), str(a.project_id)),
+  },
+  {
     name: "list_folders",
     description: "List all folder paths used by a project's notes.",
     params: '{ "project_id": string }',

--- a/mobile/src/chat/tools.ts
+++ b/mobile/src/chat/tools.ts
@@ -179,7 +179,12 @@ export const TOOLS: ToolDef[] = [
       "Move a note to a different project (call get_cairn_context for project ids). The note's owning workspace is updated automatically. Returns the new project_id/workspace_id, or an error.",
     params: '{ "id": string, "project_id": string }',
     jsonSchema: obj({ id: S, project_id: S }, ["id", "project_id"]),
-    run: (a) => q.moveNoteToProject(str(a.id), str(a.project_id)),
+    run: (a) => {
+      const res = q.moveNoteToProject(str(a.id), str(a.project_id));
+      // Adapt the query's camelCase result to the snake_case field names this
+      // tool documents (and the rest of the tool surface uses); pass errors through.
+      return "error" in res ? res : { project_id: res.projectId, workspace_id: res.workspaceId };
+    },
   },
   {
     name: "list_folders",

--- a/mobile/src/components/NotePickerSheet.tsx
+++ b/mobile/src/components/NotePickerSheet.tsx
@@ -65,8 +65,11 @@ export function NotePickerSheet({
             const on = item.value === selectedValue;
             return (
               <Pressable
-                style={[styles.row, on && { backgroundColor: withAlpha(t.accent, 0.1) }]}
-                onPress={() => onSelect(item.value)}
+                style={[styles.row, on && { backgroundColor: withAlpha(t.accent, 0.1), opacity: 0.6 }]}
+                // The current project/folder is where the note already lives —
+                // selecting it is a no-op, so disable it (and show it as such).
+                disabled={on}
+                onPress={() => { if (!on) onSelect(item.value); }}
               >
                 {variant === "folder" ? (
                   on ? (

--- a/mobile/src/components/NotePickerSheet.tsx
+++ b/mobile/src/components/NotePickerSheet.tsx
@@ -1,0 +1,110 @@
+import { useMemo } from "react";
+import { View, Text, Pressable, FlatList, StyleSheet } from "react-native";
+import { Check, Folder, FolderOpen } from "lucide-react-native";
+import { useTheme, withAlpha, type as typeScale, type Theme } from "@/theme";
+import { ProjectIcon } from "./ProjectIcon";
+import { BottomSheet, BottomSheetHeader } from "./BottomSheet";
+
+/** One selectable option in the picker. */
+export interface PickerOption {
+  /** The value returned via onSelect (project id, or folder path). */
+  value: string;
+  /** Row label. */
+  label: string;
+  /**
+   * For the "project" variant: the project's Lucide icon NAME (e.g. "Rocket") —
+   * NOT an emoji. Rendered via ProjectIcon so it matches the icon shown
+   * everywhere else. Ignored by the other variants.
+   */
+  icon?: string | null;
+}
+
+/**
+ * A bottom-anchored single-select sheet used by the note long-press menu to
+ * pick a target — either another project ("Move to project") or a folder
+ * ("Move to folder"). Selecting a row commits immediately (single-select, no
+ * Done button) and closes; this mirrors the desktop MoveNoteModal / folder
+ * picker, which also commit on tap.
+ */
+export function NotePickerSheet({
+  visible,
+  title,
+  options,
+  selectedValue,
+  emptyText,
+  variant = "plain",
+  onSelect,
+  onClose,
+}: {
+  visible: boolean;
+  title: string;
+  options: PickerOption[];
+  /** Current value — shown with a check and skipped-as-target styling. */
+  selectedValue?: string;
+  emptyText: string;
+  /** "folder" shows a folder glyph; "project" renders each option's Lucide icon; "plain" shows no leading glyph. */
+  variant?: "plain" | "folder" | "project";
+  onSelect: (value: string) => void;
+  onClose: () => void;
+}) {
+  const t = useTheme();
+  const styles = useMemo(() => makeStyles(t), [t]);
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose} maxHeight="70%">
+      <BottomSheetHeader title={title} onCancel={onClose} />
+
+      {options.length === 0 ? (
+        <Text style={styles.empty}>{emptyText}</Text>
+      ) : (
+        <FlatList
+          data={options}
+          keyExtractor={(o) => o.value}
+          style={styles.list}
+          renderItem={({ item }) => {
+            const on = item.value === selectedValue;
+            return (
+              <Pressable
+                style={[styles.row, on && { backgroundColor: withAlpha(t.accent, 0.1) }]}
+                onPress={() => onSelect(item.value)}
+              >
+                {variant === "folder" ? (
+                  on ? (
+                    <FolderOpen size={16} color={t.accent} />
+                  ) : (
+                    <Folder size={16} color={t.textTertiary} />
+                  )
+                ) : variant === "project" ? (
+                  <ProjectIcon name={item.icon} size={16} color={on ? t.accent : t.textSecondary} />
+                ) : (
+                  <View style={styles.iconSlot} />
+                )}
+                <Text style={styles.name} numberOfLines={1}>
+                  {item.label}
+                </Text>
+                {on && <Check size={18} color={t.accent} />}
+              </Pressable>
+            );
+          }}
+        />
+      )}
+    </BottomSheet>
+  );
+}
+
+function makeStyles(t: Theme) {
+  return StyleSheet.create({
+    list: { paddingHorizontal: 10, paddingBottom: 6 },
+    row: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+      paddingVertical: 12,
+      paddingHorizontal: 12,
+      borderRadius: 10,
+    },
+    iconSlot: { width: 16 },
+    name: { flex: 1, ...typeScale.body, color: t.textPrimary },
+    empty: { color: t.textTertiary, textAlign: "center", padding: 28, ...typeScale.caption },
+  });
+}

--- a/mobile/src/db/queries.ts
+++ b/mobile/src/db/queries.ts
@@ -1039,6 +1039,36 @@ export function moveNotesToFolder(noteIds: string[], folder: string): number {
   return res.changes ?? 0;
 }
 
+/**
+ * Move a note to a different project (and its owning workspace).
+ *
+ * Mobile is DB-only (no .md files), so this is a plain UPDATE of project_id +
+ * workspace_id — no file relocation like the desktop equivalent. Writing both
+ * columns matters: notes are scoped by project_id everywhere (lists, search,
+ * graph), and the sync engine carries them in the row's full snapshot, so a
+ * partial move (project without workspace) would desync. Returns the new
+ * project/workspace, or an error if the target project doesn't exist.
+ */
+export function moveNoteToProject(
+  noteId: string,
+  targetProjectId: string,
+): { error: string } | { projectId: string; workspaceId: string } {
+  const note = getNote(noteId);
+  if (!note) return { error: "Note not found" };
+  const workspaceId = workspaceIdForProject(targetProjectId);
+  if (!workspaceId) return { error: "Target project not found" };
+  const now = new Date().toISOString();
+  getDb().runSync(
+    `UPDATE notes SET project_id = ?, workspace_id = ?, updated_at = ?, version = version + 1 WHERE id = ?`,
+    targetProjectId,
+    workspaceId,
+    now,
+    noteId,
+  );
+  notifyLocalWrite();
+  return { projectId: targetProjectId, workspaceId };
+}
+
 /** Pin or unpin a note. Plain UPDATE so the capture triggers publish it. */
 export function pinNote(id: string, pinned: boolean): void {
   const now = new Date().toISOString();

--- a/mobile/src/screens/ProjectScreen.tsx
+++ b/mobile/src/screens/ProjectScreen.tsx
@@ -186,8 +186,14 @@ export function ProjectScreen({ nested = false }: { nested?: boolean }) {
   const onPickProject = useCallback((projectId: string) => {
     if (actionNote) {
       const res = moveNoteToProject(actionNote.id, projectId);
-      if ("error" in res) haptics.error();
-      else haptics.success();
+      if ("error" in res) {
+        // Surface the failure and keep the picker open (state intact) so the
+        // user can retry or pick a different target — don't silently swallow it.
+        haptics.error();
+        Alert.alert("Couldn't move note", res.error);
+        return;
+      }
+      haptics.success();
     }
     setPicker(null);
     setActionNote(null);

--- a/mobile/src/screens/ProjectScreen.tsx
+++ b/mobile/src/screens/ProjectScreen.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useMemo, useState } from "react";
-import { View, Text, ScrollView, FlatList, Pressable, StyleSheet, type ListRenderItem } from "react-native";
+import { View, Text, ScrollView, FlatList, Pressable, StyleSheet, ActionSheetIOS, Alert, Platform, type ListRenderItem } from "react-native";
 import { useLocalSearchParams, useRouter, Stack, type Href } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ChevronDown, ChevronRight, Folder, FolderOpen, FileText, Pin } from "lucide-react-native";
@@ -9,7 +9,13 @@ import {
   listNotes,
   listColumns,
   listCards,
+  listProjects,
+  listFolders,
   moveCardToColumn,
+  moveNoteToProject,
+  moveNotesToFolder,
+  pinNote,
+  softDeleteNote,
   tagsByRow,
   tagsForNotes,
   noteTagIds,
@@ -22,8 +28,9 @@ import {
 import { TagChips } from "@/components/TagChips";
 import { PressableScale } from "@/components/PressableScale";
 import { SearchField } from "@/components/SearchField";
+import { NotePickerSheet, type PickerOption } from "@/components/NotePickerSheet";
 import { ICON_ADD, ICON_CALENDAR } from "@/components/toolbar-icons";
-import { toolbarPress } from "@/haptics";
+import { haptics, toolbarPress } from "@/haptics";
 import { DraggableBoard } from "@/components/DraggableBoard";
 import { OverviewTab } from "@/components/overview/OverviewTab";
 import { EmptyState } from "@/components/EmptyState";
@@ -73,6 +80,10 @@ export function ProjectScreen({ nested = false }: { nested?: boolean }) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [filter, setFilter] = useState("");
   const [activeTagId, setActiveTagId] = useState<string | null>(null);
+  // The note currently targeted by the long-press action menu, and which
+  // move-picker sheet (if any) is open for it. `null` = no menu/sheet.
+  const [actionNote, setActionNote] = useState<NoteRow | null>(null);
+  const [picker, setPicker] = useState<null | "project" | "folder">(null);
 
   // Onward-navigation targets. Kept as typed Href builders so the nested vs.
   // root path families both satisfy typed routes.
@@ -103,6 +114,118 @@ export function ProjectScreen({ nested = false }: { nested?: boolean }) {
   // actually skip re-rendering when unrelated state (filter text, collapse)
   // changes. Passing a fresh `() => push(...)` per row would defeat React.memo.
   const openNote = useCallback((nid: string) => router.push(noteHref(nid)), [router, noteHref]);
+
+  // ── Long-press note actions ────────────────────────────────────────────────
+  // A per-note contextual menu mirroring the desktop note ⋯ menu (Pin/Unpin,
+  // Move to project, Move to folder, Delete). Presented as a native action
+  // sheet (iOS) / Alert action list (Android) on long-press; the two "Move"
+  // actions open a themed BottomSheet picker (NotePickerSheet). Kept as stable
+  // callbacks so the memoised NoteRowItem rows don't re-render.
+
+  const togglePin = useCallback((note: NoteRow) => {
+    pinNote(note.id, !note.is_pinned);
+    haptics.success();
+    load();
+  }, [load]);
+
+  const confirmDelete = useCallback((note: NoteRow) => {
+    haptics.warning();
+    Alert.alert(
+      "Delete note?",
+      `"${note.title || "Untitled"}" will be deleted. This syncs to your other devices.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: () => {
+            softDeleteNote(note.id);
+            load();
+          },
+        },
+      ],
+    );
+  }, [load]);
+
+  const showNoteActions = useCallback((note: NoteRow) => {
+    haptics.selection();
+    const pinLabel = note.is_pinned ? "Unpin" : "Pin";
+    const run = (choice: "pin" | "project" | "folder" | "delete") => {
+      if (choice === "pin") togglePin(note);
+      else if (choice === "project") { setActionNote(note); setPicker("project"); }
+      else if (choice === "folder") { setActionNote(note); setPicker("folder"); }
+      else if (choice === "delete") confirmDelete(note);
+    };
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title: note.title || "Untitled",
+          options: [pinLabel, "Move to project", "Move to folder", "Delete", "Cancel"],
+          destructiveButtonIndex: 3,
+          cancelButtonIndex: 4,
+        },
+        (i) => {
+          if (i === 0) run("pin");
+          else if (i === 1) run("project");
+          else if (i === 2) run("folder");
+          else if (i === 3) run("delete");
+        },
+      );
+    } else {
+      Alert.alert(note.title || "Untitled", undefined, [
+        { text: pinLabel, onPress: () => run("pin") },
+        { text: "Move to project", onPress: () => run("project") },
+        { text: "Move to folder", onPress: () => run("folder") },
+        { text: "Delete", style: "destructive", onPress: () => run("delete") },
+        { text: "Cancel", style: "cancel" },
+      ]);
+    }
+  }, [togglePin, confirmDelete]);
+
+  // Commit a picker selection, then close the menu + sheet and refresh the list.
+  const onPickProject = useCallback((projectId: string) => {
+    if (actionNote) {
+      const res = moveNoteToProject(actionNote.id, projectId);
+      if ("error" in res) haptics.error();
+      else haptics.success();
+    }
+    setPicker(null);
+    setActionNote(null);
+    load();
+  }, [actionNote, load]);
+
+  const onPickFolder = useCallback((folder: string) => {
+    if (actionNote) {
+      moveNotesToFolder([actionNote.id], folder);
+      haptics.success();
+    }
+    setPicker(null);
+    setActionNote(null);
+    load();
+  }, [actionNote, load]);
+
+  const closePicker = useCallback(() => { setPicker(null); setActionNote(null); }, []);
+
+  // Picker option lists, computed only while the relevant sheet is open. The
+  // project list excludes the current project; the folder list is prefixed with
+  // an explicit "Root" (folder="") option, matching the desktop folder picker.
+  const projectOptions = useMemo<PickerOption[]>(
+    () =>
+      picker === "project"
+        ? listProjects()
+            .filter((p) => p.id !== id)
+            .map((p) => ({ value: p.id, label: p.name, icon: p.icon }))
+        : [],
+    [picker, id],
+  );
+  const folderOptions = useMemo<PickerOption[]>(() => {
+    if (picker !== "folder" || !id) return [];
+    const opts: PickerOption[] = [{ value: "", label: "Root" }];
+    for (const f of listFolders(id)) {
+      if (f) opts.push({ value: f, label: f });
+    }
+    return opts;
+  }, [picker, id]);
 
   const tree = useMemo(() => buildFolderTree(notes), [notes]);
   const styles = useMemo(() => makeStyles(t), [t]);
@@ -157,9 +280,9 @@ export function ProjectScreen({ nested = false }: { nested?: boolean }) {
       item.kind === "folder" ? (
         <FolderRow node={item.node} depth={item.depth} collapsed={!!collapsed[item.node.path]} onToggle={toggle} t={t} />
       ) : (
-        <NoteRowItem note={item.note} depth={item.depth} tags={tagMap.get(item.note.id)} onOpen={openNote} t={t} />
+        <NoteRowItem note={item.note} depth={item.depth} tags={tagMap.get(item.note.id)} onOpen={openNote} onLongPress={showNoteActions} t={t} />
       ),
-    [collapsed, toggle, t, tagMap, openNote],
+    [collapsed, toggle, t, tagMap, openNote, showNoteActions],
   );
 
   const onAdd = () => {
@@ -270,6 +393,29 @@ export function ProjectScreen({ nested = false }: { nested?: boolean }) {
           onAddCard={(colId) => router.push({ pathname: "/card/new", params: { project: id, column: colId } })}
         />
       )}
+
+      {/* Long-press move pickers. Options are read lazily (only while the sheet
+          is open) so they reflect the current DB without polling. */}
+      <NotePickerSheet
+        visible={picker === "project"}
+        title="Move to project"
+        variant="project"
+        options={projectOptions}
+        selectedValue={id}
+        emptyText="No other projects in this workspace."
+        onSelect={onPickProject}
+        onClose={closePicker}
+      />
+      <NotePickerSheet
+        visible={picker === "folder"}
+        title="Move to folder"
+        variant="folder"
+        options={folderOptions}
+        selectedValue={actionNote?.folder ?? ""}
+        emptyText="No folders in this project yet."
+        onSelect={onPickFolder}
+        onClose={closePicker}
+      />
     </View>
   );
 }
@@ -342,30 +488,35 @@ const NoteRowItem = memo(function NoteRowItem({
   depth,
   tags,
   onOpen,
+  onLongPress,
   t,
 }: {
   note: NoteRow;
   depth: number;
   tags?: TagRow[];
   onOpen: (id: string) => void;
+  onLongPress: (note: NoteRow) => void;
   t: Theme;
 }) {
   // Mirror the desktop NoteListItem: title, a 1-line content preview, then a
   // meta row of relative time + up to 3 tag chips. Tags are resolved once by the
   // parent (tagsByRow) and passed in, so this row does no DB work on render.
-  // `onOpen` is a stable ref → this memoised row skips re-render when unrelated
-  // parent state changes.
+  // `onOpen` / `onLongPress` are stable refs → this memoised row skips re-render
+  // when unrelated parent state changes.
   const preview = useMemo(() => {
     const text = stripMarkdown(note.content ?? "").trim();
     return text ? text.slice(0, 80) : "Empty note";
   }, [note.content]);
   const shownTags = useMemo(() => (tags ?? []).slice(0, 3), [tags]);
   const onPress = useCallback(() => onOpen(note.id), [onOpen, note.id]);
+  const handleLongPress = useCallback(() => onLongPress(note), [onLongPress, note]);
   return (
     <PressableScale
       scaleTo={1}
       dimTo={0.5}
       onPress={onPress}
+      onLongPress={handleLongPress}
+      delayLongPress={350}
       style={{
         gap: 3,
         paddingVertical: 10,

--- a/src/components/notes/notes-view/ArchivedNoteListItem.tsx
+++ b/src/components/notes/notes-view/ArchivedNoteListItem.tsx
@@ -7,35 +7,52 @@ import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
   DropdownMenuItem, DropdownMenuSeparator,
 } from "@/components/ui/dropdown";
+import {
+  ContextMenu, ContextMenuTrigger, ContextMenuContent,
+  ContextMenuItem, ContextMenuSeparator,
+} from "@/components/ui/context-menu";
 import type { Note } from "@/types";
 
 export function ArchivedNoteListItem({ note, onRestore, onDelete }: { note: Note; onRestore: () => void; onDelete: () => void }) {
   return (
-    <div className="group flex items-center gap-1.5 px-3 py-2">
-      <span className="flex-1 text-[0.786rem] text-[var(--text-tertiary)] truncate">{note.title}</span>
-      <Tooltip content="Restore note">
-        <button aria-label="Restore note" onClick={(e) => { e.stopPropagation(); onRestore(); }}
-          className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--accent)] hover:bg-[var(--accent-dim)] transition-all">
-          <ArchiveRestore size={11} />
-        </button>
-      </Tooltip>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button aria-label="More options" onClick={(e) => e.stopPropagation()}
-            className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-3)] transition-all">
-            <MoreHorizontal size={11} />
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+      <div className="group flex items-center gap-1.5 px-3 py-2">
+        <span className="flex-1 text-[0.786rem] text-[var(--text-tertiary)] truncate">{note.title}</span>
+        <Tooltip content="Restore note">
+          <button aria-label="Restore note" onClick={(e) => { e.stopPropagation(); onRestore(); }}
+            className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--accent)] hover:bg-[var(--accent-dim)] transition-all">
+            <ArchiveRestore size={11} />
           </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onRestore(); }}>
-            <ArchiveRestore size={12} />Restore
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onDelete(); }} className="text-[var(--danger)] hover:text-[var(--danger)]">
-            <Trash2 size={12} />Delete permanently
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+        </Tooltip>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button aria-label="More options" onClick={(e) => e.stopPropagation()}
+              className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-3)] transition-all">
+              <MoreHorizontal size={11} />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onRestore(); }}>
+              <ArchiveRestore size={12} />Restore
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onDelete(); }} className="text-[var(--danger)] hover:text-[var(--danger)]">
+              <Trash2 size={12} />Delete permanently
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={onRestore}>
+          <ArchiveRestore size={13} />Restore
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={onDelete} className="text-[var(--danger)] hover:text-[var(--danger)]">
+          <Trash2 size={13} />Delete permanently
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/src/components/notes/notes-view/MoveNoteModal.tsx
+++ b/src/components/notes/notes-view/MoveNoteModal.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { FolderInput, FolderOpen } from "lucide-react";
 import type { Project } from "@/types";
 import { ModalShell } from "@/components/ui/modal-shell";
+import { ProjectIcon } from "@/lib/workspace-icons";
 
 interface MoveNoteModalProps {
   workspaceProjects: Project[];
@@ -33,7 +34,7 @@ export function MoveNoteModal({ workspaceProjects, activeProjectId, onMove, onCl
               onClick={() => { onMove(p.id); onClose(); }}
               className="w-full text-left px-3 py-2 rounded-lg text-sm text-[var(--text-secondary)] hover:bg-[var(--surface-2)] hover:text-[var(--text-primary)] transition-colors flex items-center gap-2"
             >
-              <span className="text-base leading-none">{p.icon ?? "📁"}</span>
+              <ProjectIcon name={p.icon} size={14} className="text-[var(--text-tertiary)] shrink-0" />
               {p.name}
             </button>
           ))}

--- a/src/components/notes/notes-view/NoteListItem.tsx
+++ b/src/components/notes/notes-view/NoteListItem.tsx
@@ -14,6 +14,10 @@ import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
   DropdownMenuItem, DropdownMenuSeparator,
 } from "@/components/ui/dropdown";
+import {
+  ContextMenu, ContextMenuTrigger, ContextMenuContent,
+  ContextMenuItem, ContextMenuSeparator,
+} from "@/components/ui/context-menu";
 
 export interface NoteListItemProps {
   note: Note; isActive: boolean; indent?: number;
@@ -23,66 +27,106 @@ export interface NoteListItemProps {
   onDragEnd?: () => void;
 }
 
+/** Reveal-in-OS label matching the current platform. */
+function revealLabel(): string {
+  return window.electron?.platform === "win32"
+    ? "Explorer"
+    : window.electron?.platform === "linux"
+      ? "Files"
+      : "Finder";
+}
+
 export const NoteListItem = memo(function NoteListItem({ note, isActive, indent = 0, onClick, onPin, onDelete, onArchive, onMove, onMoveToFolder, onReveal, onDragStart, onDragEnd }: NoteListItemProps) {
   const getTagById = useCairnStore((s) => s.getTagById);
   const tags = note.tagIds.slice(0, 3).map((id) => getTagById(id)).filter(Boolean);
 
   return (
-    <div onClick={onClick}
-      draggable={!!onDragStart}
-      onDragStart={(e) => { e.stopPropagation(); onDragStart?.(note.id); }}
-      onDragEnd={(e) => { e.stopPropagation(); onDragEnd?.(); }}
-      className={cn("group relative flex flex-col gap-0.5 py-2.5 cursor-pointer transition-colors pr-3",
-        isActive ? "bg-[var(--surface-2)] border-l-2 border-[var(--accent)]" : "hover:bg-[var(--surface-2)] border-l-2 border-transparent")}
-      style={{ paddingLeft: `${12 + indent}px` }}
-    >
-      <div className="flex items-center gap-1.5">
-        {note.isPinned && <Pin size={9} className="text-[var(--accent)] flex-shrink-0" />}
-        {note.type === "dashboard" && <LayoutDashboard size={9} className="text-[var(--text-tertiary)] flex-shrink-0" />}
-        <Tooltip content={note.title}>
-          <span className={cn("text-xs font-medium truncate flex-1", isActive ? "text-[var(--text-primary)]" : "text-[var(--text-secondary)]")}>
-            {note.title}
-          </span>
-        </Tooltip>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button aria-label="Note actions" onClick={(e) => e.stopPropagation()}
-              className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-3)] transition-all">
-              <MoreHorizontal size={11} />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onPin(); }}>
-              {note.isPinned ? <PinOff size={12} /> : <Pin size={12} />}
-              {note.isPinned ? "Unpin" : "Pin"}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onReveal(); }}>
-              <FileText size={12} />Reveal in {window.electron?.platform === "win32" ? "Explorer" : window.electron?.platform === "linux" ? "Files" : "Finder"}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onArchive(); }}>
-              <Archive size={12} />Archive
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onMoveToFolder(); }}>
-              <FolderSymlink size={12} />Move to folder
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onMove(); }}>
-              <FolderInput size={12} />Move to project
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onDelete(); }} className="text-[var(--danger)] hover:text-[var(--danger)]">
-              <Trash2 size={12} />Delete
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+      <div onClick={onClick}
+        draggable={!!onDragStart}
+        onDragStart={(e) => { e.stopPropagation(); onDragStart?.(note.id); }}
+        onDragEnd={(e) => { e.stopPropagation(); onDragEnd?.(); }}
+        className={cn("group relative flex flex-col gap-0.5 py-2.5 cursor-pointer transition-colors pr-3",
+          isActive ? "bg-[var(--surface-2)] border-l-2 border-[var(--accent)]" : "hover:bg-[var(--surface-2)] border-l-2 border-transparent")}
+        style={{ paddingLeft: `${12 + indent}px` }}
+      >
+        <div className="flex items-center gap-1.5">
+          {note.isPinned && <Pin size={9} className="text-[var(--accent)] flex-shrink-0" />}
+          {note.type === "dashboard" && <LayoutDashboard size={9} className="text-[var(--text-tertiary)] flex-shrink-0" />}
+          <Tooltip content={note.title}>
+            <span className={cn("text-xs font-medium truncate flex-1", isActive ? "text-[var(--text-primary)]" : "text-[var(--text-secondary)]")}>
+              {note.title}
+            </span>
+          </Tooltip>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button aria-label="Note actions" onClick={(e) => e.stopPropagation()}
+                className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-3)] transition-all">
+                <MoreHorizontal size={11} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onPin(); }}>
+                {note.isPinned ? <PinOff size={12} /> : <Pin size={12} />}
+                {note.isPinned ? "Unpin" : "Pin"}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onReveal(); }}>
+                <FileText size={12} />Reveal in {revealLabel()}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onArchive(); }}>
+                <Archive size={12} />Archive
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onMoveToFolder(); }}>
+                <FolderSymlink size={12} />Move to folder
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onMove(); }}>
+                <FolderInput size={12} />Move to project
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onDelete(); }} className="text-[var(--danger)] hover:text-[var(--danger)]">
+                <Trash2 size={12} />Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+        <span className="text-[0.786rem] text-[var(--text-tertiary)] truncate">{note.contentText.slice(0, 60) || (note.type === "dashboard" ? "Dashboard" : "Empty note")}</span>
+        <div className="flex items-center gap-1.5">
+          <span className="text-[0.714rem] text-[var(--text-tertiary)]">{formatRelative(note.updatedAt)}</span>
+          {tags.length > 0 && tags.map((tag) => tag && (
+            <Badge key={tag.id} color={tag.color} size="xs">{tag.name}</Badge>
+          ))}
+        </div>
       </div>
-      <span className="text-[0.786rem] text-[var(--text-tertiary)] truncate">{note.contentText.slice(0, 60) || (note.type === "dashboard" ? "Dashboard" : "Empty note")}</span>
-      <div className="flex items-center gap-1.5">
-        <span className="text-[0.714rem] text-[var(--text-tertiary)]">{formatRelative(note.updatedAt)}</span>
-        {tags.length > 0 && tags.map((tag) => tag && (
-          <Badge key={tag.id} color={tag.color} size="xs">{tag.name}</Badge>
-        ))}
-      </div>
-    </div>
+      </ContextMenuTrigger>
+
+      {/* Right-click menu — mirrors the hover ⋯ dropdown so both share one action
+          set. Radix ContextMenu.Item.onSelect fires after close; no stopPropagation
+          needed (the row's onClick doesn't run on a right-click). */}
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={onPin}>
+          {note.isPinned ? <PinOff size={13} /> : <Pin size={13} />}
+          {note.isPinned ? "Unpin" : "Pin"}
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={onReveal}>
+          <FileText size={13} />Reveal in {revealLabel()}
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={onArchive}>
+          <Archive size={13} />Archive
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={onMoveToFolder}>
+          <FolderSymlink size={13} />Move to folder
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={onMove}>
+          <FolderInput size={13} />Move to project
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={onDelete} className="text-[var(--danger)] hover:text-[var(--danger)]">
+          <Trash2 size={13} />Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 });

--- a/src/lib/commands/note-commands.ts
+++ b/src/lib/commands/note-commands.ts
@@ -171,7 +171,7 @@ export function makeMoveNoteCmd(
             : n,
         ),
       }));
-      ipc((e) => e.note.update(noteId, { projectId: prevProjectId }));
+      ipc((e) => e.note.moveToProject(noteId, prevProjectId, prevWorkspaceId));
     },
     async redo() {
       set((s) => ({
@@ -181,7 +181,7 @@ export function makeMoveNoteCmd(
             : n,
         ),
       }));
-      ipc((e) => e.note.update(noteId, { projectId: targetProjectId }));
+      ipc((e) => e.note.moveToProject(noteId, targetProjectId, targetWorkspaceId));
     },
   };
 }

--- a/src/store/slices/notes.ts
+++ b/src/store/slices/notes.ts
@@ -149,7 +149,7 @@ export const createNotesSlice: StateCreator<CairnStore, [], [], NotesSlice> = (
     }));
     get().persist();
     markOwnNoteWrite(noteId);
-    ipc((e) => e.note.update(noteId, { projectId: targetProjectId }));
+    ipc((e) => e.note.moveToProject(noteId, targetProjectId, targetProject.workspaceId));
     historyManager.push(makeMoveNoteCmd(
       noteId, prevProjectId, prevWorkspaceId,
       targetProjectId, targetProject.workspaceId,

--- a/tests/fixtures/ipc-mock.ts
+++ b/tests/fixtures/ipc-mock.ts
@@ -229,6 +229,7 @@ export function buildIpcMock(opts?: { needsWorkspaceSetup?: boolean }): string {
       update:       noop,
       delete:       noop,
       moveToFolder: noop,
+      moveToProject: noop,
     },
 
     // ── Board columns ─────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Notes fixes and enhancements across desktop and mobile. Fixes the bug where moving a note between projects didn't stick (it reappeared in the old project), adds a right-click context menu for notes on desktop, and brings note-move-between-projects to mobile (both a long-press action menu and a chat tool). Also fixes two mobile chat issues (resume ghost bands, too-low agent step limit) and a project-icon rendering bug in the move-to-project pickers.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code quality
- [x] Docs / changelog
- [x] Tests

## Screenshots / recording

<!-- UI changes: desktop right-click note menu, corrected project icons in the "Move to project" picker, and the mobile long-press note action sheet. Screenshots to be attached. -->

## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (runs `npm run compile` first so `electron/bundle-guard.test.ts` actually executes — `npm run test:bundle` to run just that)
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts` — n/a (no schema change; reuses existing columns)
- [x] New SQL goes in `electron/db/queries.ts` — single source of truth (imported by both Electron main process and MCP server); never construct a `Database` instance outside `db/client.ts` (Electron) or `mcp-server.ts` (MCP runtime)
- [ ] New `dependencies` or `devDependencies` added to `ROLE_MAP` in `scripts/generate-licenses.js` and `licenses.json` regenerated — n/a (no new deps)
- [ ] New MCP tools registered in `electron/mcp/tools/index.ts` dispatch + `electron/lib/tool-schemas.ts` Zod schema — n/a (mobile chat tool only; not an MCP tool)
- [ ] If you added/removed a `--external:<pkg>` flag in the `compile` script — n/a

## Notes for reviewer

**Desktop — note move (`fix(desktop): persist note move between projects`)**
- Root cause: `updateNote()` in `electron/db/queries.ts` had no `project_id`/`workspace_id` in its `UPDATE`, so `note.update({ projectId })` was silently dropped. The row (and its `.md` file, left in the old project folder) kept the old project, so a refresh / file re-scan / device sync resurfaced the note.
- New `moveNoteToProject` query + `db:note:moveToProject` IPC handler (writes both columns, deletes the old-project `.md`, rewrites under the new project, recomputes relationships/embeddings). Store action + move undo/redo routed through it. New query unit tests added.
- Please sanity-check the two-device **sync** round-trip if you can — I couldn't exercise it locally. The row now carries the correct `project_id` in its full-row op and the old file is removed, so it should land and stay.

**Desktop — right-click menu**
- `NoteListItem` / `ArchivedNoteListItem` wrapped in the shared `ContextMenu` primitive (same pattern as `kanban/card.tsx`); mirrors the hover ⋯ dropdown. Worth confirming a right-click opens the menu without also triggering the row's `onClick`.
- Fixed `MoveNoteModal` rendering a project's Lucide icon *name* as text (e.g. "Briefcase") → now uses `<ProjectIcon>`.

**Mobile**
- New `moveNoteToProject` query (DB-only, no `.md` files) + `move_note_to_project` chat tool. This is the first way to move a note between projects on mobile — there was no manual UI either.
- Long-press a note row → native action sheet (Pin/Unpin, Move to project, Move to folder, Delete), with a reusable `NotePickerSheet`. Only touch-tested via type/lint here; a device check of the long-press + pickers would be good.
- Chat: raised `MAX_TURNS` 8 → 30 (matches desktop); resume-repaint key to clear iOS Liquid-Glass ghost bands after backgrounding.

**Changelogs:** `changelogs/v2.4.10.md` (desktop) and `mobile/changelogs/v0.1.3.md` (mobile, the pending release ahead of 0.1.2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added right-click menus for desktop notes, including archived notes.
  * Added mobile long-press actions for pinning, moving, and deleting notes.
  * Added project and folder pickers on mobile.
  * Chat can now move notes between projects.
* **Improvements**
  * Moving notes now reliably updates their project location and supports persistent undo/redo.
  * Project icons display correctly in move dialogs.
  * Improved iOS chat rendering when returning to the app.
  * Increased Chat’s research step limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->