### PR TITLE
fix(notes): stop currency amounts rendering as inline math

### DIFF
--- a/changelogs/v2.5.3.md
+++ b/changelogs/v2.5.3.md
@@ -1,0 +1,5 @@
+## What's new
+
+### Fixes
+
+- **Dollar amounts in notes no longer get mangled.** Text like `$145.000 - $250.000` was being treated as inline LaTeX math — the `$` signs were swallowed and the text between them reformatted. Notes now require `$$…$$` for math, so ordinary currency renders exactly as written. Existing block math (`$$x^2$$`) is unaffected.

--- a/src/components/notes/markdown-pipeline.bench.test.ts
+++ b/src/components/notes/markdown-pipeline.bench.test.ts
@@ -308,9 +308,12 @@ describe("Markdown pipeline benchmarks", () => {
           const remarkPlugins = buildNoteRemarkPlugins(source, { wikilinks: true });
           const rehypePlugins = buildNoteRehypePlugins(source, { latex });
           const processor = unified().use(remarkParse);
-          for (const p of remarkPlugins) processor.use(p as any);
+          // Apply the whole PluggableList in one call so tuple entries such as
+          // [remarkMath, { singleDollarTextMath: false }] keep their options
+          // (iterating + processor.use(tuple) misreads the options as a preset).
+          processor.use(remarkPlugins);
           processor.use(remarkRehype, { allowDangerousHtml: true });
-          for (const p of rehypePlugins) processor.use(p as any);
+          processor.use(rehypePlugins);
           return bench(() => processor.runSync(processor.parse(source)), 50);
         }
 

--- a/src/lib/markdown/pipeline.test.ts
+++ b/src/lib/markdown/pipeline.test.ts
@@ -190,11 +190,12 @@ function runBuilders(md: string): Root {
   const remarkPlugins = buildNoteRemarkPlugins(md, { wikilinks: true });
   const rehypePlugins = buildNoteRehypePlugins(md, { latex });
   const proc = unified().use(remarkParse);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  for (const p of remarkPlugins) proc.use(p as any);
+  // Pass the whole PluggableList at once so tuple entries like
+  // [remarkMath, { singleDollarTextMath: false }] are applied with their
+  // options (iterating + proc.use(tuple) would misread the options as a preset).
+  proc.use(remarkPlugins);
   proc.use(remarkRehype, { allowDangerousHtml: true });
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  for (const p of rehypePlugins) proc.use(p as any);
+  proc.use(rehypePlugins);
   return proc.runSync(proc.parse(md)) as Root;
 }
 
@@ -240,5 +241,31 @@ describe("buildNote{Remark,Rehype}Plugins — content-aware assembly", () => {
     const tags = tagNames(tree);
     expect(tags).toContain("mark");
     expect(tags).toContain("mathblock");
+  });
+
+  it("does NOT treat currency like '$145.000 - $250.000' as inline math", () => {
+    // singleDollarTextMath is disabled, so a $…$ pair on a line is plain text,
+    // not KaTeX. The $ signs must survive and no katex/math node is produced.
+    const tree = runBuilders("Budget: $145.000 - $250.000 total.");
+
+    // No KaTeX artifacts.
+    expect(tagNames(tree)).not.toContain("mathblock");
+    let hasKatex = false;
+    visit(tree, "element", (n: Element) => {
+      const cls = Array.isArray(n.properties?.className) ? n.properties!.className.map(String) : [];
+      if (cls.some((c) => c.startsWith("katex"))) hasKatex = true;
+    });
+    expect(hasKatex).toBe(false);
+
+    // Both dollar signs survive in the rendered text.
+    let text = "";
+    visit(tree, "text", (n: { value?: string }) => { text += n.value ?? ""; });
+    expect(text).toContain("$145.000");
+    expect(text).toContain("$250.000");
+  });
+
+  it("still renders explicit $$…$$ display math (currency fix does not disable block math)", () => {
+    const tree = runBuilders("Total cost model:\n\n$$c = 145 + 250$$\n");
+    expect(tagNames(tree)).toContain("mathblock");
   });
 });

--- a/src/lib/markdown/pipeline.tsx
+++ b/src/lib/markdown/pipeline.tsx
@@ -386,7 +386,11 @@ export function buildNoteRemarkPlugins(content: string, opts: RemarkBuildOpts = 
   const plugins: PluggableList = [remarkGfm, remarkBreaks];
   if (contentHasMath(content)) {
     // remarkMath must precede remarkPromoteDisplayMath (which reshapes math nodes).
-    plugins.push(remarkMath, remarkPromoteDisplayMath);
+    // singleDollarTextMath:false — require $$…$$ for math so ordinary currency
+    // like "$145.000 - $250.000" is NOT parsed as inline math (which would eat
+    // the $ signs and reformat the middle via KaTeX). Display math ($$) is
+    // unaffected; a lone-paragraph $$…$$ is still promoted to a mathblock.
+    plugins.push([remarkMath, { singleDollarTextMath: false }], remarkPromoteDisplayMath);
   }
   plugins.push(remarkCallout, remarkObsidianEmbeds);
   if (opts.wikilinks) plugins.push(remarkWikilinks);


### PR DESCRIPTION
## What does this PR do?

Fixes note text like `$145.000 - $250.000` being mangled in the preview. `remark-math@6` enables single-dollar inline math by default, so a `$…$` pair on a line (two currency amounts) was parsed as inline LaTeX — rehype-katex ate the `$` signs and reformatted the middle. Math now requires `$$…$$`, so ordinary currency renders verbatim. Block math is unaffected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [x] Docs / changelog
- [x] Tests

## Screenshots / recording

<!-- Before: "$145.000 - $250.000" rendered with the $ signs dropped and the middle reformatted as math. After: renders exactly as typed. -->

## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [x] `npm test` passes — all markdown/pipeline tests (22 unit + 42 bench) green. One unrelated **live-LLM** test (`electron/lib/tool-error-audit.test.ts` — "actionable errors drive self-correction") is non-deterministic and passes in isolation; it does not touch this code path.
- [ ] `npm run test:e2e` (not run — no interactive UI change; render-only fix)
- [x] No hardcoded colours — CSS variables only (n/a)
- [x] No `text-[Npx]` pixel font classes (n/a)
- [x] New IPC handlers wrapped in `handle()` (n/a)
- [x] New DB migrations appended (n/a)
- [x] New SQL in `queries.ts` (n/a)
- [x] New deps in `ROLE_MAP` (n/a — none added)
- [x] New MCP tools registered (n/a)
- [x] `--external:<pkg>` allowlist (n/a)

## Notes for reviewer

- One-line behavioural change: `pipeline.tsx:389` now passes `[remarkMath, { singleDollarTextMath: false }]`. This requires `$$…$$` for math. Existing math in the app is block math (`$$`) — the `MathBlock` toggle and all existing tests only exercise `$$`, and inline `$x$` was never reliably usable precisely because it collided with currency. I chose this over a currency-detection heuristic because heuristics on `$` are fragile.
- The two test-harness edits (`pipeline.test.ts`, `markdown-pipeline.bench.test.ts`) fix a latent harness bug: they iterated the plugin list and called `proc.use(tuple)`, which misreads a `[plugin, options]` tuple as a preset. They now pass the whole `PluggableList` to a single `.use()` (what ReactMarkdown does in production). No product code depended on the old harness behaviour.
- Desktop-only; mobile has no `remark-math` usage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed currency amounts in notes so dollar signs and values, such as `$145.000 - $250.000`, remain unchanged.
  * Preserved support for display math wrapped in `$$…$$`.

* **Documentation**
  * Added a changelog entry describing the currency formatting fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->