### PR TITLE
fix(sync,chat,notes): delete resurrection, maxSteps persistence, chat quick-settings, notes DnD

### DIFF
--- a/changelogs/v2.5.5.md
+++ b/changelogs/v2.5.5.md
@@ -1,0 +1,17 @@
+# v2.5.5
+
+## Added
+
+- **Chat settings, without leaving the chat.** A new gear icon in the chat toolbar opens a compact popover to change the model, max tool-call steps, temperature, and subagents on the spot — no round-trip to Settings just to bump the step limit. The model picker uses the app's dropdown with a **Refresh models** action (re-queries your endpoint) and a **Custom model…** option for typing any model id the endpoint doesn't list. A "More settings…" link jumps to the full AI & Chat settings when you need endpoints, API keys, or MCP.
+- **The notes folder tree now remembers which folders are expanded.** Collapse/expand state is saved per project and restored when you switch views, change projects, or reload — no more re-opening the same folders every time you return to Notes.
+
+## Changed
+
+- **Subagents is now a single global preference** (in Settings → AI & Chat, and in the new in-chat gear popover) instead of a per-conversation toggle. Turn it on once and every chat uses the dispatch → research/write architecture. The old per-thread "Subagents" pill in the chat toolbar has been replaced by the gear popover.
+- **The "Move to root" drop zone is now pinned to the bottom of the notes panel** while dragging, instead of appearing inline between folders — so it's always in the same, easy-to-reach spot no matter how far you've scrolled.
+
+## Fixed
+
+- **Deleting a note no longer briefly "comes back" during sync.** When you deleted a note on desktop and then synced again before the other device (e.g. your phone) had picked up the deletion, the peer's still-stale copy of the note could be re-applied and resurrect the note — until the other device finally synced the deletion and it disappeared again. The desktop deletes rows physically (leaving no local tombstone), so the sync engine had nothing to compare an incoming older edit against and let it win. The engine now leaves a tombstone marker whenever a hard-deleted row is drained, so a stale edit from a peer can no longer bring a deleted note back. Deletions now stick immediately and both devices converge on the delete.
+- **Changing the chat tool-call limit ("Max steps") now sticks.** Setting a new limit (including "∞") in Settings would appear to work, then quietly revert to 30 partway through a conversation. The setting was being dropped from the backend settings cache, so the next time the app refreshed its config — which happens automatically after any turn that writes with a tool — the limit reset to the default. The full AI settings (max steps, temperature, context limit, AI-enabled) are now preserved end to end, and the config refresh no longer overwrites richer locally-saved settings with a partial cache.
+- **The "Move to root" notes drop zone no longer lingers after dragging a note or folder onto another project.** Because the dragged item moves out of the current project (and its row unmounts) the moment you drop it on another project, the drag-end that clears the drop zone never fired — so the zone stayed on screen until the next click. Drag state is now cleared reliably via a document-level listener, so the zone disappears as soon as you let go.

--- a/electron/lib/config-cache.test.ts
+++ b/electron/lib/config-cache.test.ts
@@ -14,7 +14,70 @@
  *   2. getEmbeddingsSettingsCached() must run without throwing when electron
  *      is unavailable — returning a plain object (possibly empty).
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// Point config-cache's userData resolver at a temp dir so the round-trip tests
+// below never touch the developer's real ai-settings-cache.json.
+let tmpDir: string;
+vi.mock("../runtime/port-discovery", () => ({
+  findUserDataDir: () => tmpDir,
+}));
+
+describe("config-cache AI settings round-trip", () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cairn-cfg-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("persists maxSteps (and other behavioural fields) for the 'ai' config", async () => {
+    const { saveCachedConfig, getCachedConfig } = await import("./config-cache");
+    saveCachedConfig("ai", {
+      provider: "openai",
+      baseUrl: "https://api.openai.com",
+      model: "gpt-4o",
+      apiKey: "sk-x",
+      maxSteps: 1000,
+      temperature: 0.5,
+      contextLimit: 200000,
+      aiEnabled: true,
+      subagentsEnabled: true,
+    });
+    const ai = getCachedConfig().aiConfig;
+    // Regression: maxSteps used to be silently dropped here, which reset the
+    // chat tool-call limit to the default (30) on the next hydrate.
+    expect(ai?.maxSteps).toBe(1000);
+    expect(ai?.temperature).toBe(0.5);
+    expect(ai?.contextLimit).toBe(200000);
+    expect(ai?.aiEnabled).toBe(true);
+    expect(ai?.subagentsEnabled).toBe(true);
+    expect(ai?.model).toBe("gpt-4o");
+  });
+
+  it("persists subagentsEnabled (global subagents preference)", async () => {
+    const { saveCachedConfig, getCachedConfig } = await import("./config-cache");
+    saveCachedConfig("ai", { subagentsEnabled: true });
+    expect(getCachedConfig().aiConfig?.subagentsEnabled).toBe(true);
+    // A later connection-only save must not clobber it.
+    saveCachedConfig("ai", { model: "gpt-4o" });
+    expect(getCachedConfig().aiConfig?.subagentsEnabled).toBe(true);
+  });
+
+  it("a later connection-only save preserves an existing maxSteps", async () => {
+    const { saveCachedConfig, getCachedConfig } = await import("./config-cache");
+    saveCachedConfig("ai", { maxSteps: 500 });
+    // A subsequent save that only carries connection fields (e.g. from the
+    // provider picker) must not wipe the previously-stored maxSteps.
+    saveCachedConfig("ai", { model: "gpt-4o-mini" });
+    const ai = getCachedConfig().aiConfig;
+    expect(ai?.maxSteps).toBe(500);
+    expect(ai?.model).toBe("gpt-4o-mini");
+  });
+});
 
 describe("config-cache without Electron", () => {
   it("imports without throwing the electron install error", async () => {

--- a/electron/lib/config-cache.ts
+++ b/electron/lib/config-cache.ts
@@ -15,6 +15,15 @@ export interface CachedConfig {
     baseUrl?: string;
     model?: string;
     apiKey?: string;
+    // Persist the FULL renderer AIConfig, not just connection fields. Dropping
+    // these here caused hydrateFromElectron() to reset them to DEFAULT_AI_CONFIG
+    // after every write-tool turn — e.g. the chat tool-call limit (maxSteps)
+    // silently "reverted to 30" mid-conversation.
+    maxSteps?: number;
+    temperature?: number;
+    contextLimit?: number;
+    aiEnabled?: boolean;
+    subagentsEnabled?: boolean;
   };
   agentConfig?: {
     baseUrl?: string;
@@ -80,6 +89,13 @@ export function saveCachedConfig(type: "ai" | "agent" | "embeddings" | "theme" |
         baseUrl: typeof configRecord.baseUrl === "string" ? configRecord.baseUrl : current.aiConfig?.baseUrl,
         model: typeof configRecord.model === "string" ? configRecord.model : current.aiConfig?.model,
         apiKey: typeof configRecord.apiKey === "string" ? configRecord.apiKey : current.aiConfig?.apiKey,
+        // Preserve behavioural fields too — omitting maxSteps here made the chat
+        // tool-call limit reset to the default on the next hydrate.
+        maxSteps: typeof configRecord.maxSteps === "number" ? configRecord.maxSteps : current.aiConfig?.maxSteps,
+        temperature: typeof configRecord.temperature === "number" ? configRecord.temperature : current.aiConfig?.temperature,
+        contextLimit: typeof configRecord.contextLimit === "number" ? configRecord.contextLimit : current.aiConfig?.contextLimit,
+        aiEnabled: typeof configRecord.aiEnabled === "boolean" ? configRecord.aiEnabled : current.aiConfig?.aiEnabled,
+        subagentsEnabled: typeof configRecord.subagentsEnabled === "boolean" ? configRecord.subagentsEnabled : current.aiConfig?.subagentsEnabled,
       };
     } else if (type === "agent" && configRecord) {
       current.agentConfig = {

--- a/shared/sync/engine.test.ts
+++ b/shared/sync/engine.test.ts
@@ -749,6 +749,35 @@ describe("sync engine — trigger→drain capture of real queries.ts writes", ()
       expect((B.db.prepare("SELECT COUNT(*) c FROM notes WHERE id='n1' AND deleted_at IS NULL").get() as { c: number }).c).toBe(0);
     });
 
+    it("a stale peer put drained AFTER a local hard-delete does not resurrect the row", () => {
+      // Real-world timing bug: desktop deletes a note (physical DELETE, no local
+      // tombstone), publishes the delete, then syncs AGAIN and reads the phone's
+      // still-stale oplog (a put@lowerHLC published before the phone saw the
+      // delete). With no local tombstone the staleness guard has nothing to
+      // compare against, so the older put would resurrect the note. The
+      // drainPending tombstone-shell fix keeps the delete sticky.
+      const clkA = clockFrom(12_150_000);
+      const clkB = clockFrom(12_150_000);
+      const A = makeDevice("A", clkA.now);
+      const B = makeDevice("B", clkB.now);
+      seedNoteOnBoth(A, B);
+      // Phone publishes its current (live) state — a put with the seed's HLC.
+      writeOplogFile(dir, "B", B.engine.exportOplog());
+      expect((B.db.prepare("SELECT COUNT(*) c FROM notes WHERE id='n1' AND deleted_at IS NULL").get() as { c: number }).c).toBe(1);
+
+      // Desktop deletes and republishes (higher HLC).
+      clkA.advance(100);
+      q.deleteNote(A.db, "n1");
+      A.engine.drainPending();
+      writeOplogFile(dir, "A", A.engine.exportOplog());
+      expect((A.db.prepare("SELECT COUNT(*) c FROM notes WHERE id='n1' AND deleted_at IS NULL").get() as { c: number }).c).toBe(0);
+
+      // Desktop syncs again while the phone is still offline: it reconciles the
+      // phone's stale put. The note must STAY deleted on desktop.
+      A.engine.applyRemote(readPeerOplogs(dir, "A"));
+      expect((A.db.prepare("SELECT COUNT(*) c FROM notes WHERE id='n1' AND deleted_at IS NULL").get() as { c: number }).c).toBe(0);
+    });
+
     it("a concurrent higher-HLC peer edit wins over an earlier hard-delete (row comes back on both)", () => {
       // Desktop hard-deletes n1, but the phone had a LATER edit it hadn't synced
       // yet. LWW: the higher-HLC edit wins, so the note is restored — and both

--- a/shared/sync/engine.ts
+++ b/shared/sync/engine.ts
@@ -188,6 +188,15 @@ export class SyncEngine {
       if (p.seq > maxSeq) maxSeq = p.seq;
     }
 
+    // A hard-deleted row leaves no tombstone, so we may need to insert a
+    // tombstone SHELL (placeholder FK columns) to keep the staleness guard armed
+    // against a later stale peer 'put'. Shells legitimately violate FKs, so
+    // disable enforcement around the transaction (the pragma is a no-op inside
+    // one) exactly as applyRemote does. Restored in `finally`.
+    const fkRow = this.db.prepare("PRAGMA foreign_keys").get() as { foreign_keys?: number } | undefined;
+    const fkWasOn = fkRow?.foreign_keys === 1;
+    if (fkWasOn) this.db.prepare("PRAGMA foreign_keys = OFF").run();
+
     const run = this.db.transaction(() => {
       this.setSuppress(true); // our hlc/deleted_at writes below must not re-stage
       for (const { entity, entity_id, op } of latest.values()) {
@@ -195,7 +204,19 @@ export class SyncEngine {
         const row = readRow(this.db, entity, entity_id);
         if (op === "delete" || !row) {
           // Row gone (hard delete) or explicitly tombstoned.
-          this.db.prepare(`UPDATE ${entity} SET deleted_at = COALESCE(deleted_at, ?), hlc = ? WHERE id = ?`).run(nowIso(), stamp, entity_id);
+          const upd = this.db
+            .prepare(`UPDATE ${entity} SET deleted_at = COALESCE(deleted_at, ?), hlc = ? WHERE id = ?`)
+            .run(nowIso(), stamp, entity_id) as { changes?: number };
+          // Desktop's q.deleteNote does a physical `DELETE FROM notes`, so by the
+          // time we drain the staged 'delete' the row is already gone and the
+          // UPDATE above matches zero rows — leaving NO local tombstone. Without a
+          // tombstone, a later peer 'put' with an OLDER HLC hits reconcileOne with
+          // local=undefined (localHlc=null), bypasses the staleness guard, and
+          // RESURRECTS the deleted row. Insert a tombstone shell (same as the
+          // delete-arrives-before-insert case) so the staleness guard trips and
+          // the stale put stays dead. FK columns on the shell are placeholders;
+          // the row is a tombstone and never read as live data.
+          if ((upd.changes ?? 0) === 0) this.insertTombstoneShell(entity, entity_id, stamp);
           this.appendOplog({ hlc: stamp, origin: this.deviceId, entity, entity_id, op: "delete", payload: null });
         } else {
           this.db.prepare(`UPDATE ${entity} SET hlc = ? WHERE id = ?`).run(stamp, entity_id);
@@ -218,7 +239,11 @@ export class SyncEngine {
       this.setSuppress(false);
       this.persistHlc();
     });
-    run();
+    try {
+      run();
+    } finally {
+      if (fkWasOn) this.db.prepare("PRAGMA foreign_keys = ON").run();
+    }
     return latest.size;
   }
 

--- a/src/components/chat/chat-panel/ChatQuickSettings.tsx
+++ b/src/components/chat/chat-panel/ChatQuickSettings.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import React, { useState, useRef, useEffect, useLayoutEffect, useCallback } from "react";
+import { Settings2, GitBranch, ExternalLink, ChevronDown, RefreshCw, Check, Pencil } from "lucide-react";
+import { useCairnStore } from "@/store";
+import { useShallow } from "zustand/react/shallow";
+import { cn } from "@/lib/utils";
+import { Tooltip } from "@/components/ui/tooltip";
+import { Toggle } from "@/components/ui/toggle";
+import {
+  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator,
+} from "@/components/ui/dropdown";
+import { useEndpointConfig, isLocalBaseUrl, LOCAL_FALLBACK_MODELS } from "@/components/settings/endpoint-components";
+
+const MAX_STEPS_PRESETS = [10, 20, 30, 50, 1000] as const;
+const CLOUD_FALLBACK_MODELS = ["gpt-4o-mini", "gpt-4o", "gpt-4-turbo", "gpt-4", "o1-mini", "o3-mini"];
+
+/**
+ * In-chat quick-settings popover. Surfaces the handful of AI settings people
+ * change *while chatting* — model, max steps, temperature, subagents — editing
+ * the SAME global aiConfig as Settings → AI & Chat (no per-thread overrides).
+ * The full endpoint / API-key / MCP surface stays in Settings behind the
+ * "More settings…" link. Replaces the old inline Subagents pill.
+ *
+ * `disabled` mirrors the toolbar's isLoading guard so settings can't be changed
+ * mid-stream.
+ */
+export function ChatQuickSettings({ disabled }: { disabled?: boolean }) {
+  const { aiConfig, setAIConfig, setSettingsSection, setView } = useCairnStore(
+    useShallow((s) => ({
+      aiConfig: s.aiConfig,
+      setAIConfig: s.setAIConfig,
+      setSettingsSection: s.setSettingsSection,
+      setView: s.setView,
+    })),
+  );
+
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const { availableModels, fetchModels, modelsLoading, testState } = useEndpointConfig();
+
+  const provider = aiConfig.provider ?? "openai";
+  const isLocal = isLocalBaseUrl(aiConfig.baseUrl);
+  const subagentsSupported = provider !== "localllm";
+
+  // Fetch the endpoint's model list once when the popover opens (cloud only).
+  // Users can re-fetch anytime via the Refresh action in the model picker.
+  useEffect(() => {
+    if (open && provider !== "localllm") {
+      fetchModels(aiConfig.baseUrl, aiConfig.apiKey);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Close on outside click / Escape. The model picker uses a Radix dropdown
+  // whose content is PORTALED outside rootRef — clicking a model item must not
+  // close the whole popover, so ignore clicks landing inside any Radix popper.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as Element | null;
+      if (target?.closest("[data-radix-popper-content-wrapper]")) return;
+      if (rootRef.current && !rootRef.current.contains(target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const openFullSettings = useCallback(() => {
+    setSettingsSection("ai");
+    setView("settings");
+    setOpen(false);
+  }, [setSettingsSection, setView]);
+
+  const modelOptions = availableModels.length > 0
+    ? availableModels
+    : (isLocal ? LOCAL_FALLBACK_MODELS : CLOUD_FALLBACK_MODELS);
+
+  const maxSteps = aiConfig.maxSteps ?? 30;
+  const temperature = aiConfig.temperature ?? 0.3;
+
+  return (
+    <div ref={rootRef} className="relative">
+      <Tooltip content="Chat settings — model, steps, temperature, subagents" side="left">
+        <button
+          onClick={() => setOpen((v) => !v)}
+          aria-label="Chat settings"
+          aria-expanded={open}
+          className={cn(
+            "flex items-center justify-center p-1 rounded transition-colors",
+            open
+              ? "text-[var(--accent)] bg-[var(--surface-3)]"
+              : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-3)]",
+          )}
+        >
+          <Settings2 size={12} />
+        </button>
+      </Tooltip>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-1 w-64 z-50 rounded-lg border border-[var(--border)] bg-[var(--surface)] shadow-xl p-3 space-y-3 animate-fade-in"
+          role="dialog"
+        >
+          <div className="text-[0.643rem] font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
+            Chat settings
+          </div>
+
+          {/* Model */}
+          <div className="space-y-1">
+            <span className="text-[0.714rem] text-[var(--text-secondary)]">Model</span>
+            <ModelPicker
+              value={aiConfig.model ?? ""}
+              options={modelOptions}
+              loading={modelsLoading}
+              errored={testState === "error"}
+              disabled={disabled}
+              placeholder={isLocal ? "local model" : "gpt-4o-mini"}
+              onChange={(m) => setAIConfig({ model: m })}
+              onRefresh={() => fetchModels(aiConfig.baseUrl, aiConfig.apiKey)}
+            />
+          </div>
+
+          {/* Max steps */}
+          <div className="space-y-1">
+            <div className="flex items-center justify-between">
+              <span className="text-[0.714rem] text-[var(--text-secondary)]">Max steps</span>
+              <span className="text-[0.643rem] text-[var(--text-tertiary)]">
+                {maxSteps === 1000 ? "∞" : maxSteps} tool rounds
+              </span>
+            </div>
+            <div className="flex gap-1">
+              {MAX_STEPS_PRESETS.map((n) => (
+                <button
+                  key={n}
+                  onClick={() => setAIConfig({ maxSteps: n })}
+                  disabled={disabled}
+                  className={cn(
+                    "flex-1 px-1 py-0.5 text-[0.643rem] rounded border transition-colors disabled:opacity-50",
+                    maxSteps === n
+                      ? "border-[var(--accent)] text-[var(--accent)] bg-[color-mix(in_srgb,var(--accent)_12%,transparent)]"
+                      : "border-[var(--border)] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-3)]",
+                  )}
+                >
+                  {n === 1000 ? "∞" : n}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Temperature */}
+          <label className="block space-y-1">
+            <div className="flex items-center justify-between">
+              <span className="text-[0.714rem] text-[var(--text-secondary)]">Temperature</span>
+              <span className="text-[0.643rem] text-[var(--text-tertiary)]">{temperature.toFixed(2)}</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={temperature}
+              onChange={(e) => setAIConfig({ temperature: parseFloat(e.target.value) })}
+              disabled={disabled}
+              className="w-full accent-[var(--accent)] disabled:opacity-50"
+            />
+          </label>
+
+          {/* Subagents (cloud only) */}
+          {subagentsSupported && (
+            <div className="flex items-center justify-between gap-2 pt-1">
+              <span className="flex items-center gap-1.5 text-[0.714rem] text-[var(--text-secondary)]">
+                <GitBranch size={11} className="text-[var(--text-tertiary)]" />
+                Subagents
+              </span>
+              <Toggle
+                checked={aiConfig.subagentsEnabled ?? false}
+                onCheckedChange={(v) => setAIConfig({ subagentsEnabled: v })}
+                disabled={disabled}
+                label="Enable subagents"
+              />
+            </div>
+          )}
+
+          <button
+            onClick={openFullSettings}
+            className="flex items-center gap-1.5 w-full pt-2 mt-1 border-t border-[var(--border-subtle)] text-[0.643rem] text-[var(--text-tertiary)] hover:text-[var(--accent)] transition-colors"
+          >
+            <ExternalLink size={10} />
+            More settings…
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A single-line, truncated label that shows the app Tooltip with the full text
+ * ONLY when the text is actually cut off (scrollWidth > clientWidth). Avoids a
+ * pointless tooltip on names that already fit.
+ */
+function TruncatedModel({ text, className }: { text: string; className?: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [overflowing, setOverflowing] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    setOverflowing(el.scrollWidth > el.clientWidth);
+  }, [text]);
+
+  const span = (
+    <span ref={ref} className={cn("truncate block min-w-0 flex-1", className)}>
+      {text}
+    </span>
+  );
+
+  if (!overflowing) return span;
+  return (
+    <Tooltip content={text} side="top">
+      {span}
+    </Tooltip>
+  );
+}
+
+/**
+ * Compact model selector for the quick-settings popover. Uses the shared Radix
+ * dropdown (consistent floating panel + click-away) to pick from the endpoint's
+ * fetched models, with a Refresh action to re-query the endpoint and a
+ * "Custom model…" affordance for typing any model id the endpoint didn't list.
+ */
+function ModelPicker({
+  value,
+  options,
+  loading,
+  errored,
+  disabled,
+  placeholder,
+  onChange,
+  onRefresh,
+}: {
+  value: string;
+  options: string[];
+  loading: boolean;
+  errored: boolean;
+  disabled?: boolean;
+  placeholder?: string;
+  onChange: (model: string) => void;
+  onRefresh: () => void;
+}) {
+  // Custom-entry mode: a free-text input for a model id not in the list.
+  const [custom, setCustom] = useState(false);
+  const customRef = useRef<HTMLInputElement>(null);
+  useEffect(() => { if (custom) customRef.current?.focus(); }, [custom]);
+
+  if (custom) {
+    return (
+      <div className="flex gap-1">
+        <input
+          ref={customRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") setCustom(false); }}
+          disabled={disabled}
+          placeholder={placeholder}
+          className="flex-1 min-w-0 px-2 py-1 text-[0.714rem] font-mono rounded-md border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)] disabled:opacity-50"
+        />
+        <Tooltip content="Done" side="top">
+          <button
+            onClick={() => setCustom(false)}
+            className="flex items-center justify-center px-1.5 rounded-md border border-[var(--border)] text-[var(--text-tertiary)] hover:text-[var(--accent)] hover:bg-[var(--surface-3)] transition-colors"
+          >
+            <Check size={12} />
+          </button>
+        </Tooltip>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-1">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild disabled={disabled}>
+          <button
+            className={cn(
+              "flex-1 min-w-0 flex items-center justify-between gap-1 px-2 py-1 text-[0.714rem] rounded-md border bg-[var(--surface-2)] text-[var(--text-primary)] transition-colors disabled:opacity-50",
+              errored ? "border-[var(--danger)]" : "border-[var(--border)] hover:border-[var(--muted)]",
+            )}
+          >
+            {value ? (
+              <TruncatedModel text={value} className="font-mono" />
+            ) : (
+              <span className="truncate font-sans text-[var(--text-tertiary)]">
+                {placeholder || "Select model"}
+              </span>
+            )}
+            <ChevronDown size={11} className="text-[var(--text-tertiary)] flex-shrink-0" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="max-w-[240px] max-h-64 overflow-y-auto">
+          <DropdownMenuItem
+            onSelect={(e) => { e.preventDefault(); onRefresh(); }}
+            className="text-[var(--text-secondary)]"
+          >
+            <RefreshCw size={12} className={loading ? "animate-spin" : ""} />
+            {loading ? "Refreshing…" : "Refresh models"}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setCustom(true)}>
+            <Pencil size={12} />
+            Custom model…
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          {errored && (
+            <div className="px-2.5 py-1.5 text-[0.643rem] text-[var(--danger)]">
+              Couldn&apos;t load models — check the endpoint in settings.
+            </div>
+          )}
+          {options.length === 0 && !errored && (
+            <div className="px-2.5 py-1.5 text-[0.643rem] text-[var(--text-tertiary)]">
+              No models — Refresh or add a custom one.
+            </div>
+          )}
+          {options.map((m) => (
+            <DropdownMenuItem
+              key={m}
+              onSelect={() => onChange(m)}
+              className={cn("font-mono text-xs", m === value && "text-[var(--accent)]")}
+            >
+              <span className="w-3.5 flex-shrink-0">
+                {m === value && <Check size={12} />}
+              </span>
+              <TruncatedModel text={m} />
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/src/components/chat/chat-panel/index.tsx
+++ b/src/components/chat/chat-panel/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useRef, useEffect, useMemo, useCallback } from "react";
-import { Trash2, ChevronDown, ArrowLeftFromLine, GitBranch } from "lucide-react";
+import { Trash2, ChevronDown, ArrowLeftFromLine } from "lucide-react";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { useChatStream } from "@/hooks/useChatStream";
@@ -14,6 +14,7 @@ import type { ChatHistoryEntry } from "@/types";
 import { Tooltip } from "@/components/ui/tooltip";
 import { ChatMessageBubble } from "./ChatMessageBubble";
 import { ChatSubagentBlock } from "./ChatSubagentBlock";
+import { ChatQuickSettings } from "./ChatQuickSettings";
 import { SuggestedPrompts } from "./SuggestedPrompts";
 import { ToolCallIndicator } from "./ToolCallIndicator";
 import { QuestionForm } from "./QuestionForm";
@@ -129,7 +130,6 @@ export function ChatPanel({ prefill, onPrefillConsumed, popoutMode }: ChatPanelP
   const [projectOpen, setProjectOpen] = useState(false);
 
   const { isLoading, toolCalls, streamingContent, streamingThought, subagents, pendingQuestions, sendStream, stopStream } = useChatStream(threadId);
-  const setThreadUseSubagents = useCairnStore((s) => s.setThreadUseSubagents);
 
   const project   = useMemo(() => projects.find((p) => p.id === activeProjectId),   [projects, activeProjectId]);
   const workspace = useMemo(() => workspaces.find((w) => w.id === activeWorkspaceId), [workspaces, activeWorkspaceId]);
@@ -470,9 +470,11 @@ export function ChatPanel({ prefill, onPrefillConsumed, popoutMode }: ChatPanelP
       },
       systemPrompt,
       images: imagesToSend?.map((img) => ({ name: img.name, dataUrl: img.dataUrl })),
-      useSubagents: activeThread?.useSubagents ?? false,
+      // Subagents is now a GLOBAL AI setting (aiConfig.subagentsEnabled), not a
+      // per-thread flag. Ignored server-side / here for the localllm provider.
+      useSubagents: aiConfig.provider !== "localllm" && (aiConfig.subagentsEnabled ?? false),
     });
-  }, [input, threadId, addMessage, sendStream, activeProjectId, activeWorkspaceId, messages, aiConfig, activeView, graphData, selectedNode, handleArchiveChat, project, pendingImages, activeThread]);
+  }, [input, threadId, addMessage, sendStream, activeProjectId, activeWorkspaceId, messages, aiConfig, activeView, graphData, selectedNode, handleArchiveChat, project, pendingImages]);
 
   const handleRetry = useCallback((content: string) => {
     handleSend(content);
@@ -573,28 +575,8 @@ export function ChatPanel({ prefill, onPrefillConsumed, popoutMode }: ChatPanelP
           />
         )}
 
-        {threadId && aiConfig.provider !== "localllm" && (
-          <Tooltip
-            content={
-              (activeThread?.useSubagents ? "Subagents ON — research/write are delegated to focused sub-agents (cheaper on long tasks). Click to turn off." : "Subagents OFF — single agent handles everything. Click to delegate research/write to sub-agents.")
-            }
-            side="left"
-          >
-            <button
-              onClick={() => { if (!isLoadingRef.current) setThreadUseSubagents(threadId, !(activeThread?.useSubagents ?? false)); }}
-              disabled={isLoading}
-              aria-pressed={activeThread?.useSubagents ?? false}
-              className={cn(
-                "flex items-center gap-1 px-1.5 py-0.5 rounded-md border text-[0.643rem] font-medium transition-colors disabled:opacity-50",
-                activeThread?.useSubagents
-                  ? "border-[var(--accent)] text-[var(--accent)] bg-[color-mix(in_srgb,var(--accent)_12%,transparent)]"
-                  : "border-[var(--border)] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-3)]",
-              )}
-            >
-              <GitBranch size={10} />
-              <span>Subagents</span>
-            </button>
-          </Tooltip>
+        {threadId && (
+          <ChatQuickSettings disabled={isLoading} />
         )}
 
 

--- a/src/components/notes/notes-view.tsx
+++ b/src/components/notes/notes-view.tsx
@@ -46,6 +46,9 @@ export function NotesView() {
     aiConfig,
     notesSidebarWidth,
     setNotesSidebarWidth,
+    notesCollapsedFolders,
+    toggleNotesFolder,
+    setNotesFolderCollapsed,
     notesFullscreen,
     toggleNotesFullscreen,
   } = useCairnStore(useShallow((s) => ({
@@ -69,6 +72,9 @@ export function NotesView() {
     aiConfig:                s.aiConfig,
     notesSidebarWidth:       s.notesSidebarWidth,
     setNotesSidebarWidth:    s.setNotesSidebarWidth,
+    notesCollapsedFolders:   s.notesCollapsedFolders,
+    toggleNotesFolder:       s.toggleNotesFolder,
+    setNotesFolderCollapsed: s.setNotesFolderCollapsed,
     notesFullscreen:         s.notesFullscreen,
     toggleNotesFullscreen:   s.toggleNotesFullscreen,
   })));
@@ -134,8 +140,19 @@ export function NotesView() {
     };
   }, [setNotesSidebarWidth]);
 
-  // folder → collapsed state; true = collapsed, undefined/false = open
-  const [collapsedFolders, setCollapsedFolders]  = useState<Record<string, boolean>>({});
+  // Folder collapse state is persisted per-project in the store (keyed by
+  // `${projectId}:${lowercasedPath}`). Derive a plain-path map for the ACTIVE
+  // project so FolderTreeNode can keep looking up by node.path unchanged.
+  // Presence = collapsed; absence = expanded (folders default open).
+  const collapsedFolders = useMemo(() => {
+    if (!activeProjectId) return {} as Record<string, boolean>;
+    const prefix = `${activeProjectId}:`;
+    const out: Record<string, boolean> = {};
+    for (const [key, val] of Object.entries(notesCollapsedFolders)) {
+      if (val && key.startsWith(prefix)) out[key.slice(prefix.length)] = true;
+    }
+    return out;
+  }, [notesCollapsedFolders, activeProjectId]);
 
   // ⌘F / Ctrl+F — focus the filter input, but only when the CM6 editor
   // is NOT focused (CM6's own searchKeymap handles it when the editor is active).
@@ -246,6 +263,28 @@ export function NotesView() {
     setIsDragging(false);
   }, [moveNoteToFolder, moveFolder, activeProjectId]);
 
+  // Belt-and-suspenders drag-state reset. The source element's onDragEnd is the
+  // primary reset, but when a note/folder is dropped onto ANOTHER project it is
+  // moved out of this project's list and its DOM node unmounts mid-drag — so its
+  // onDragEnd never fires and the pinned "Move to root" zone would linger. A
+  // document-level dragend/drop listener (active only while dragging) clears the
+  // local drag UI regardless of which element ended the drag.
+  useEffect(() => {
+    if (!isDragging) return;
+    const reset = () => {
+      dragNoteIdRef.current = null;
+      dragFolderPathRef.current = null;
+      setDropTarget(null);
+      setIsDragging(false);
+    };
+    document.addEventListener("dragend", reset);
+    document.addEventListener("drop", reset);
+    return () => {
+      document.removeEventListener("dragend", reset);
+      document.removeEventListener("drop", reset);
+    };
+  }, [isDragging]);
+
 
   // Subscribe to allNotes directly so this component re-renders when note
   // content changes (e.g. while typing). The selector functions are stable
@@ -329,8 +368,8 @@ export function NotesView() {
   }
 
   const toggleFolder = useCallback((folderPath: string) => {
-    setCollapsedFolders((prev) => ({ ...prev, [folderPath]: !prev[folderPath] }));
-  }, []);
+    if (activeProjectId) toggleNotesFolder(activeProjectId, folderPath);
+  }, [activeProjectId, toggleNotesFolder]);
 
   function handleCreateDashboard() {
     if (!activeProjectId) return;
@@ -609,22 +648,6 @@ export function NotesView() {
                   onFolderDrop={handleFolderDrop}
                 />
               ))}
-              {/* Root drop zone — visible only while dragging, when folders exist */}
-              {folderTree.length > 0 && (dropTarget !== null || isDragging) && (
-                <div
-                  className={cn(
-                    "mx-2 my-1 px-3 py-1.5 rounded text-[0.714rem] text-center transition-colors border border-dashed",
-                    dropTarget === "__root__"
-                      ? "border-[var(--accent)] bg-[color-mix(in_srgb,var(--accent)_12%,transparent)] text-[var(--accent)]"
-                      : "border-[var(--border)] text-[var(--text-tertiary)]",
-                  )}
-                  onDragOver={(e) => { e.preventDefault(); setDropTarget("__root__"); }}
-                  onDragLeave={() => setDropTarget(null)}
-                  onDrop={(e) => { e.preventDefault(); handleFolderDrop(""); }}
-                >
-                  Move to root
-                </div>
-              )}
               {/* Root notes (no folder) */}
               {rootNotes.map((note) => (
                 <NoteListItem
@@ -661,6 +684,26 @@ export function NotesView() {
             </div>
           )}
         </div>
+
+        {/* Move-to-root drop zone — pinned to the bottom of the panel, shown only
+            while dragging a note/folder within THIS project (not a cross-project
+            drag). Sits above the New-note footer as a flex-shrink-0 sibling so it
+            never scrolls with the list. */}
+        {!isFiltering && folderTree.length > 0 && isDragging && (
+          <div
+            className={cn(
+              "flex-shrink-0 mx-2 mb-1 px-3 py-2 rounded text-[0.714rem] text-center transition-colors border border-dashed",
+              dropTarget === "__root__"
+                ? "border-[var(--accent)] bg-[color-mix(in_srgb,var(--accent)_12%,transparent)] text-[var(--accent)]"
+                : "border-[var(--border)] text-[var(--text-tertiary)]",
+            )}
+            onDragOver={(e) => { e.preventDefault(); setDropTarget("__root__"); }}
+            onDragLeave={() => setDropTarget(null)}
+            onDrop={(e) => { e.preventDefault(); handleFolderDrop(""); }}
+          >
+            Move to root
+          </div>
+        )}
 
         {/* Footer */}
         <div className="p-2 border-t border-[var(--border)]">
@@ -728,7 +771,7 @@ export function NotesView() {
           mode="create"
           onSelect={(path) => {
             handleCreateNote(path);
-            setCollapsedFolders((prev) => ({ ...prev, [path]: false }));
+            if (activeProjectId) setNotesFolderCollapsed(activeProjectId, path, false);
             setNewFolderOpen(false);
           }}
           onClose={() => setNewFolderOpen(false)}

--- a/src/components/notes/notes-view/FolderTreeNode.tsx
+++ b/src/components/notes/notes-view/FolderTreeNode.tsx
@@ -40,7 +40,9 @@ export const FolderTreeNode = memo(function FolderTreeNode({
   onFolderDragStart, onFolderDragEndSource,
   onFolderDragOver, onFolderDragLeave, onFolderDrop,
 }: FolderTreeNodeProps) {
-  const isCollapsed = collapsed[node.path];
+  // The collapsed map is keyed by LOWERCASED folder path (persisted state uses
+  // case-insensitive keys, matching buildFolderTree's case-insensitive dedupe).
+  const isCollapsed = collapsed[node.path.toLowerCase()];
   const indent = depth * 10;
   const isDragOver = dropTarget === node.path;
 

--- a/src/components/settings/AISettings.tsx
+++ b/src/components/settings/AISettings.tsx
@@ -144,6 +144,20 @@ export function AISettings() {
             {/* Max Steps — applies to all providers */}
             {maxStepsRow}
 
+            {/* Subagents — dispatch → research/write architecture. Cloud only
+                (small on-device models are unreliable with the multi-hop split),
+                mirroring the chat toolbar's original provider !== "localllm" guard. */}
+            <SettingsRow
+              label="Subagents"
+              description="Route chat through a dispatcher that delegates research and writing to focused sub-agents. Cheaper on long, tool-heavy tasks; adds overhead on quick questions."
+            >
+              <Toggle
+                checked={aiConfig.subagentsEnabled ?? false}
+                onChange={(v) => updateAIConfig({ subagentsEnabled: v })}
+                label="Enable subagents"
+              />
+            </SettingsRow>
+
             {/* Cloud connection status */}
             <div className="flex items-center gap-3 pt-1 text-xs">
               <CloudConnectionStatus testState={testState} baseUrl={baseUrl} model={model} />

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -101,6 +101,7 @@ export const DEFAULT_AI_CONFIG: AIConfig = {
   temperature:  0.3,
   contextLimit: 128000,
   aiEnabled:    true,
+  subagentsEnabled: false,
 };
 
 /** Default Coding Agent config values. */
@@ -130,6 +131,9 @@ export const CHAT_PANEL_WIDTH_KEY = "chatPanelWidth";
 
 /** localStorage key for the persisted notes sidebar width (px). */
 export const NOTES_SIDEBAR_WIDTH_KEY = "notesSidebarWidth";
+
+/** localStorage key for per-project collapsed notes folders (Record<`${projectId}:${lowercasedPath}`, true>). */
+export const NOTES_COLLAPSED_FOLDERS_KEY = "notesCollapsedFolders";
 
 /** localStorage key for the last-used note editor mode ("write" | "read"). */
 export const NOTE_EDITOR_MODE_KEY = "noteEditorMode";

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -19,7 +19,7 @@ import type {
 import { storage } from "@/lib/storage";
 import { historyManager } from "@/lib/history";
 import { isOwnNoteWrite, isAiNoteWrite } from "./ipc";
-import { DEFAULT_AI_CONFIG, DEFAULT_AGENT_CONFIG, AI_CONFIG_KEY, AGENT_CONFIG_KEY, ACTIVE_PROJECT_KEY, CHAT_PANEL_WIDTH_KEY, NOTES_SIDEBAR_WIDTH_KEY } from "@/lib/constants";
+import { DEFAULT_AI_CONFIG, DEFAULT_AGENT_CONFIG, AI_CONFIG_KEY, AGENT_CONFIG_KEY, ACTIVE_PROJECT_KEY, CHAT_PANEL_WIDTH_KEY, NOTES_SIDEBAR_WIDTH_KEY, NOTES_COLLAPSED_FOLDERS_KEY } from "@/lib/constants";
 import { MIN_NOTES_SIDEBAR_WIDTH, MAX_NOTES_SIDEBAR_WIDTH } from "./slices/ui";
 
 // ── Slice imports ─────────────────────────────────────────────────────────────
@@ -235,6 +235,11 @@ function restorePersistedUiPrefs(set: PartialSetter): void {
   if (savedNotesWidth != null) {
     set({ notesSidebarWidth: Math.min(MAX_NOTES_SIDEBAR_WIDTH, Math.max(MIN_NOTES_SIDEBAR_WIDTH, savedNotesWidth)) });
   }
+
+  const savedCollapsedFolders = storage.get<Record<string, boolean>>(NOTES_COLLAPSED_FOLDERS_KEY);
+  if (savedCollapsedFolders && typeof savedCollapsedFolders === "object") {
+    set({ notesCollapsedFolders: savedCollapsedFolders });
+  }
 }
 
 // ── Store creation ────────────────────────────────────────────────────────────
@@ -319,15 +324,25 @@ export const useCairnStore = create<CairnStore>()(
         restorePersistedTheme(set);
       }
 
-      const savedConfig = backendAiConfig || storage.get<AIConfig>(AI_CONFIG_KEY);
+      // Merge, don't shadow: an older backend cache may be missing behavioural
+      // fields (maxSteps/temperature/contextLimit/aiEnabled). Layering
+      // localStorage UNDER the backend config preserves those fields instead of
+      // letting a field-poor backend object reset them to DEFAULT_AI_CONFIG on
+      // every hydrate (the "maxSteps reverts to 30" bug).
+      const localAiConfig = storage.get<AIConfig>(AI_CONFIG_KEY);
+      const savedConfig = backendAiConfig
+        ? { ...localAiConfig, ...backendAiConfig }
+        : localAiConfig;
       if (savedConfig) {
         if (savedConfig.provider === ("apple-fm" as unknown as "openai" | "localllm")) {
           savedConfig.provider = "localllm";
         }
-        set({ aiConfig: { ...DEFAULT_AI_CONFIG, ...savedConfig } });
-        storage.set(AI_CONFIG_KEY, savedConfig);
+        const mergedAiConfig = { ...DEFAULT_AI_CONFIG, ...savedConfig };
+        set({ aiConfig: mergedAiConfig });
+        // Persist the FULLY-merged config so localStorage never loses fields.
+        storage.set(AI_CONFIG_KEY, mergedAiConfig);
         if (!backendAiConfig && window.electron && window.electron.saveAiSettings) {
-          window.electron.saveAiSettings(savedConfig as unknown as Record<string, unknown>).catch(() => {});
+          window.electron.saveAiSettings(mergedAiConfig as unknown as Record<string, unknown>).catch(() => {});
         }
       } else if (window.electron && window.electron.ai && window.electron.ai.localLLMStatus) {
         try {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -341,7 +341,11 @@ export const useCairnStore = create<CairnStore>()(
         set({ aiConfig: mergedAiConfig });
         // Persist the FULLY-merged config so localStorage never loses fields.
         storage.set(AI_CONFIG_KEY, mergedAiConfig);
-        if (!backendAiConfig && window.electron && window.electron.saveAiSettings) {
+        // Also write the merged config back to the backend cache — even when a
+        // backendAiConfig already existed, since it may have been field-poor
+        // (missing maxSteps/temperature/…). This lets the backend cache
+        // self-heal in one hydrate instead of staying stale.
+        if (window.electron && window.electron.saveAiSettings) {
           window.electron.saveAiSettings(mergedAiConfig as unknown as Record<string, unknown>).catch(() => {});
         }
       } else if (window.electron && window.electron.ai && window.electron.ai.localLLMStatus) {

--- a/src/store/slices/chat.ts
+++ b/src/store/slices/chat.ts
@@ -31,7 +31,6 @@ export interface ChatSlice {
   confirmAction: (action: PendingAction) => void;
   deleteThread: (threadId: ID) => void;
   renameThread: (threadId: ID, title: string) => void;
-  setThreadUseSubagents: (threadId: ID, useSubagents: boolean) => void;
   createNewThread: (workspaceId: ID, projectId?: ID) => ChatThread;
   compactChatThread: (threadId: ID) => Promise<void>;
   clearThreadMessages: (threadId: ID) => Promise<void>;
@@ -143,17 +142,6 @@ export const createChatSlice: StateCreator<CairnStore, [], [], ChatSlice> = (
     set((s) => ({
       chatThreads: s.chatThreads.map((t) =>
         t.id === threadId ? { ...t, title: title.trim() || undefined, updatedAt: now() } : t
-      ),
-    }));
-    get().persist();
-    const thread = get().chatThreads.find((t) => t.id === threadId);
-    if (thread) ipc((e) => e.chat.upsertThread(thread));
-  },
-
-  setThreadUseSubagents(threadId, useSubagents) {
-    set((s) => ({
-      chatThreads: s.chatThreads.map((t) =>
-        t.id === threadId ? { ...t, useSubagents, updatedAt: now() } : t
       ),
     }));
     get().persist();

--- a/src/store/slices/ui.ts
+++ b/src/store/slices/ui.ts
@@ -6,7 +6,7 @@ import type { StateCreator } from "zustand";
 import type { CairnStore } from "../index";
 import type { ID, AppUIState, SettingsSection } from "@/types";
 import { storage } from "@/lib/storage";
-import { DEFAULT_AI_CONFIG, DEFAULT_AGENT_CONFIG, AI_CONFIG_KEY, AGENT_CONFIG_KEY, ACTIVE_PROJECT_KEY, CHAT_PANEL_WIDTH_KEY, NOTES_SIDEBAR_WIDTH_KEY } from "@/lib/constants";
+import { DEFAULT_AI_CONFIG, DEFAULT_AGENT_CONFIG, AI_CONFIG_KEY, AGENT_CONFIG_KEY, ACTIVE_PROJECT_KEY, CHAT_PANEL_WIDTH_KEY, NOTES_SIDEBAR_WIDTH_KEY, NOTES_COLLAPSED_FOLDERS_KEY } from "@/lib/constants";
 
 // ── View visibility ───────────────────────────────────────────────────────────
 
@@ -37,6 +37,12 @@ export interface AIConfig {
   contextLimit: number;
   /** When false, all in-app AI features are hidden/disabled. Defaults to true. */
   aiEnabled: boolean;
+  /**
+   * Route chat through the dispatch → research/write subagent architecture.
+   * Global preference. Ignored on the on-device Llama provider (small models are
+   * unreliable with the multi-hop split).
+   */
+  subagentsEnabled: boolean;
 }
 
 export interface AgentConfig {
@@ -144,6 +150,14 @@ export interface UISlice extends AppUIState {
   notesSidebarWidth: number;
   setNotesSidebarWidth: (width: number) => void;
 
+  // Notes folder tree collapse state. Keyed by `${projectId}:${lowercasedPath}`
+  // so each project remembers its own tree and the key survives the
+  // case-insensitive folder dedupe in buildFolderTree. Presence = collapsed;
+  // absence = expanded (folders default open). Persisted to localStorage.
+  notesCollapsedFolders: Record<string, boolean>;
+  toggleNotesFolder: (projectId: ID, folderPath: string) => void;
+  setNotesFolderCollapsed: (projectId: ID, folderPath: string, collapsed: boolean) => void;
+
   // Distraction-free note editing: hides the notes-list sidebar (and app rail)
   // so the editor fills the window. Session-scoped (not persisted).
   notesFullscreen: boolean;
@@ -221,6 +235,7 @@ export const createUISlice: StateCreator<CairnStore, [], [], UISlice> = (
   hiddenViews: new Set<ToggleableView>(),
   chatPanelWidth: DEFAULT_CHAT_PANEL_WIDTH,
   notesSidebarWidth: DEFAULT_NOTES_SIDEBAR_WIDTH,
+  notesCollapsedFolders: {},
   chatPoppedOut: false,
   notesFullscreen: false,
   // ── AI config ──────────────────────────────────
@@ -300,6 +315,28 @@ export const createUISlice: StateCreator<CairnStore, [], [], UISlice> = (
     const clamped = Math.min(MAX_NOTES_SIDEBAR_WIDTH, Math.max(MIN_NOTES_SIDEBAR_WIDTH, width));
     set({ notesSidebarWidth: clamped });
     storage.set(NOTES_SIDEBAR_WIDTH_KEY, clamped);
+  },
+
+  // ── Notes folder collapse state ────────────────
+  toggleNotesFolder(projectId, folderPath) {
+    const key = `${projectId}:${folderPath.toLowerCase()}`;
+    set((s) => {
+      const next = { ...s.notesCollapsedFolders };
+      if (next[key]) delete next[key]; // collapsed → expanded (drop entry)
+      else next[key] = true;           // expanded → collapsed
+      storage.set(NOTES_COLLAPSED_FOLDERS_KEY, next);
+      return { notesCollapsedFolders: next };
+    });
+  },
+  setNotesFolderCollapsed(projectId, folderPath, collapsed) {
+    const key = `${projectId}:${folderPath.toLowerCase()}`;
+    set((s) => {
+      const next = { ...s.notesCollapsedFolders };
+      if (collapsed) next[key] = true;
+      else delete next[key];
+      storage.set(NOTES_COLLAPSED_FOLDERS_KEY, next);
+      return { notesCollapsedFolders: next };
+    });
   },
 
   // ── Distraction-free note editing ──────────────

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -228,8 +228,6 @@ export interface ChatThread {
   title?: string;
   createdAt: string;
   updatedAt: string;
-  /** When true, this thread runs the dispatch → research/write subagent architecture instead of the single-agent loop. Per-thread, persisted. */
-  useSubagents?: boolean;
   lastUsage?: {
     promptTokens: number;
     completionTokens: number;


### PR DESCRIPTION
## What does this PR do?

Fixes a sync bug where deleted notes could resurrect, makes the chat "Max steps" limit persist, adds an in-chat quick-settings popover, moves Subagents to a global preference, persists notes folder expand/collapse state, and fixes two notes drag-and-drop issues.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code quality
- [x] Docs / changelog
- [x] Tests

## Details

**Sync**
- Deleting a note on desktop, then syncing again before the peer picked up the deletion, let the peer's stale `put` resurrect the note. Desktop does a physical `DELETE` (no tombstone), so `drainPending`'s delete `UPDATE` matched zero rows and the staleness guard in `reconcileOne` was bypassed (`localHlc` null). `drainPending` now inserts a tombstone shell when the delete matches no rows (FK-toggled like `applyRemote`). Regression test added.

**Chat / AI settings**
- "Max steps" reverted to 30 mid-conversation: the backend settings cache dropped `maxSteps` (and `temperature`/`contextLimit`/`aiEnabled`), and `hydrateFromElectron` (run after every write-tool turn) let the field-poor backend config shadow the richer localStorage copy. The cache now persists all AI fields and hydrate merges instead of shadowing.
- New in-chat quick-settings gear popover: model (custom Radix dropdown with **Refresh models** + **Custom model…**), max steps, temperature, subagents, and a "More settings…" deep-link. Long model names show a tooltip only when actually truncated.
- **Subagents is now a global preference** (`aiConfig.subagentsEnabled`) surfaced in Settings + the popover; the per-thread pill is removed and `setThreadUseSubagents` / `ChatThread.useSubagents` retired (DB column left dormant, no migration).

**Notes**
- Folder-tree expand/collapse state is now persisted per-project in localStorage.
- The "Move to root" drop zone is pinned to the bottom of the panel while dragging (was inline in the scroll list), and lingering drag state after a cross-project drop is cleared via a document-level `dragend`/`drop` listener (the dragged element unmounts mid-drag so its `onDragEnd` never fired).

## Screenshots / recording

<!-- UI changes (chat quick-settings popover, pinned drop zone) — screenshots to be added. -->

## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [ ] `npm test` passes — 1271/1272 pass; the sole failure is `tool-schema-optimization.test.ts`, a LIVE, opt-in LLM benchmark that failed by its 1-item non-determinism slack (`10 >= 11`) and is unrelated to these changes
- [ ] `npm run test:e2e` — not run yet
- [x] No hardcoded colours — CSS variables only
- [x] No `text-[Npx]` pixel font classes — rem equivalents only
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>` — n/a (no new IPC handlers)
- [x] New DB migrations appended (not edited) in `schema.ts` — n/a (no schema changes; dormant `use_subagents` column left as-is)
- [x] New SQL goes in `electron/db/queries.ts` — n/a (no new SQL)
- [x] New dependencies added to `ROLE_MAP` / `licenses.json` — n/a (no new deps)
- [x] New MCP tools registered — n/a (no new MCP tools)
- [x] `--external:<pkg>` flags — n/a (unchanged)

## Notes for reviewer

- The `tool-schema-optimization` failure is a flaky live-model benchmark, not a regression — happy to re-run.
- The `chat_threads.use_subagents` DB column is intentionally left dormant (dropping a SQLite column needs a risky table rebuild for no benefit); the global `aiConfig.subagentsEnabled` now drives behaviour.
- Per-thread subagents dead code (`setThreadUseSubagents`, `ChatThread.useSubagents`) removed from the renderer.
- Open question deferred: project ordering in the leftmost sidebar is currently most-recently-updated-first (not alphabetical) — not changed in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-chat quick controls for AI model, maximum steps, temperature, and subagents.
  * Added a global Subagents setting for supported providers.
  * Persisted notes-folder expansion and collapse preferences across sessions.
  * Added a pinned “Move to root” drop zone while dragging notes.

* **Bug Fixes**
  * Fixed AI settings being reset after subsequent updates.
  * Improved note deletion synchronization to prevent deleted notes from reappearing.
  * Fixed lingering drag-and-drop UI after cross-project moves.
  * Fixed chat maximum-step setting persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->