### PR TITLE
Fix note-link deletion in packaged MCP binary (pkg realpathSync quirk) + release smoke gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,7 @@ jobs:
           node -e "const fs = require('fs'); ['win32-arm64', 'win32-x64'].forEach(p => fs.rmSync('node_modules/node-pty/prebuilds/' + p, { recursive: true, force: true }))"
           node scripts/build-mcp-binary.js --mac
           chmod +x dist-mcp/cairn-mcp dist-mcp/cairn-mcp-x64
+          npm run smoke-test:mcp
           npx electron-builder --mac --publish onTagOrDraft
 
   # ── Windows ───────────────────────────────────────────────────────────────
@@ -265,6 +266,7 @@ jobs:
           node -e "const fs = require('fs'); ['darwin', 'linux'].forEach(p => fs.rmSync('node_modules/onnxruntime-node/bin/napi-v3/' + p, { recursive: true, force: true }))"
           node -e "const fs = require('fs'); ['darwin-arm64', 'darwin-x64'].forEach(p => fs.rmSync('node_modules/node-pty/prebuilds/' + p, { recursive: true, force: true }))"
           node scripts/build-mcp-binary.js --win
+          npm run smoke-test:mcp
           npx electron-builder --win --publish onTagOrDraft
 
   # ── Linux ─────────────────────────────────────────────────────────────────
@@ -335,6 +337,7 @@ jobs:
           node -e "const fs = require('fs'); ['darwin-arm64', 'darwin-x64', 'win32-arm64', 'win32-x64'].forEach(p => fs.rmSync('node_modules/node-pty/prebuilds/' + p, { recursive: true, force: true }))"
           node scripts/build-mcp-binary.js --linux
           chmod +x dist-mcp/cairn-mcp-linux
+          npm run smoke-test:mcp
           npx electron-builder --linux --publish onTagOrDraft
 
   # ── Publish the release ───────────────────────────────────────────────────

--- a/changelogs/v2.5.14.md
+++ b/changelogs/v2.5.14.md
@@ -1,0 +1,7 @@
+## Fixes
+
+- **Linking a note to a task no longer deletes the note in the packaged app.** The previous fix was correct in the source bundle but broke once packaged into the standalone `cairn-mcp` binary: the pkg runtime's `fs.realpathSync.native` does not canonicalise filename case on macOS, so a note whose stored folder casing differed from its on-disk directory (e.g. `Research` vs `research/`) was still misread as a *move* and its file unlinked. Same-file detection now uses the file's device + inode identity (`fs.statSync`), which the real OS resolves correctly under both plain Node and the packaged binary — so a case-only difference is treated as an in-place rewrite and the note is preserved.
+
+## Under the hood
+
+- **New release gate: `npm run smoke-test:mcp`.** The release workflow now boots the actual built `cairn-mcp` binary on each platform, links a note to a task in a throwaway workspace that reproduces the folder-case mismatch, and fails the build if the note's file is deleted or relocated. This closes the gap that let the bug ship — a fix can be correct in unit tests (plain Node) yet broken once packaged by pkg, and only a test against the real binary catches it.

--- a/electron/shared/notes-io.ts
+++ b/electron/shared/notes-io.ts
@@ -135,22 +135,25 @@ function findInDir(dir: string, noteId: string): string | null {
  * writeNoteFile misclassify a metadata-only write as a relocation and unlink
  * the file it just wrote — deleting the note.
  *
- * We rely solely on real inode identity (fs.realpathSync resolves case +
- * symlinks). On a case-insensitive FS a case-variant of an existing file
- * resolves to the same real path, so that scenario is caught here. We do NOT
- * fall back to a case-folded string compare: on a case-SENSITIVE FS (Linux)
- * `Research/x.md` and `research/x.md` are genuinely different files, and folding
- * would wrongly treat a real relocation as in-place (skipping the move + leaving
- * a stale duplicate). When two distinct paths can't both be resolved, assume
- * they differ.
+ * We compare real file identity via `statSync` device + inode. We deliberately
+ * do NOT use `fs.realpathSync(.native)`: inside the packaged MCP binary (yao-pkg)
+ * pkg's patched `fs.realpathSync.native` does NOT canonicalise case for real
+ * files — it returns the path as given — so a case-variant of an existing file
+ * compares unequal, sending the write down the relocation branch and DELETING
+ * the note. `statSync` dev+ino is resolved by the real OS syscall and reports
+ * the same inode for both casings under both plain Node and pkg (verified).
+ *
+ * When either path can't be stat'd (e.g. the target doesn't exist yet — a
+ * genuine relocation, or a case-SENSITIVE FS where the variant truly is a
+ * different, absent file), we return false so the relocation proceeds.
  */
 function isSameFile(a: string, b: string): boolean {
   if (a === b) return true;
   try {
-    if (fs.existsSync(a) && fs.existsSync(b)) {
-      return fs.realpathSync.native(a) === fs.realpathSync.native(b);
-    }
-  } catch { /* unresolvable — treat as different */ }
+    const sa = fs.statSync(a);
+    const sb = fs.statSync(b);
+    return sa.dev === sb.dev && sa.ino === sb.ino;
+  } catch { /* one side missing/unstattable — treat as different */ }
   return false;
 }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "type-check:all": "npm run type-check && npm run type-check:electron && npm run type-check:shared",
     "mcp": "node dist-mcp/mcp-server.bundle.js",
     "smoke-test": "node scripts/smoke-test.js",
+    "smoke-test:mcp": "node scripts/smoke-test-mcp.js",
     "test:e2e": "playwright test",
     "test:bundle": "npm run compile && vitest run electron/bundle-guard.test.ts electron/native-deps-guard.test.ts electron/mcp-server.test.ts",
     "test:e2e:ui": "playwright test --ui",

--- a/scripts/smoke-test-mcp.js
+++ b/scripts/smoke-test-mcp.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * smoke-test-mcp.js — behavioural smoke test for the PACKAGED cairn-mcp binary.
+ *
+ * Runs via: node scripts/smoke-test-mcp.js [path-to-binary]
+ * (defaults to the platform binary in dist-mcp/)
+ *
+ * Why this exists: a bug can be correct in the compiled `mcp-server.bundle.js`
+ * yet BREAK once packaged by pkg — pkg patches Node's `fs` and its
+ * `realpathSync.native` does not canonicalise case on macOS, which silently sent
+ * `link_note_to_task` down its relocation branch and DELETED the linked note.
+ * The unit tests (plain Node) passed; only the shipped pkg binary was broken.
+ *
+ * This test therefore drives the ACTUAL built binary over stdio JSON-RPC against
+ * a throwaway workspace that reproduces the exact failing scenario (a note whose
+ * stored folder casing differs from its on-disk directory), links it to a task,
+ * and asserts the note's .md file still exists afterwards.
+ *
+ * Exit codes: 0 = passed, 1 = failed (note file was deleted or tool errored).
+ */
+
+const { spawn, execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+
+function platformBinary() {
+  if (process.platform === "win32") return path.join(root, "dist-mcp", "cairn-mcp.exe");
+  if (process.platform === "linux") return path.join(root, "dist-mcp", "cairn-mcp-linux");
+  return path.join(root, "dist-mcp", "cairn-mcp");
+}
+
+const BIN = process.argv[2] || platformBinary();
+
+function fail(msg) {
+  console.error(`  ✗  ${msg}`);
+  process.exit(1);
+}
+
+console.log("\nCairn MCP binary smoke test\n");
+if (!fs.existsSync(BIN)) fail(`binary not found: ${BIN} (run build-mcp-binary.js first)`);
+
+// ── Build an isolated workspace with the exact case-mismatch scenario ────────
+const ws = fs.mkdtempSync(path.join(os.tmpdir(), "cairn-mcp-smoke-"));
+const cfgBase = path.join(ws, "config");
+const dbPath = path.join(ws, "cairn.db");
+const projectDirName = "SmokeProj";
+const noteDir = path.join(ws, projectDirName, "research"); // on-disk: lowercase
+fs.mkdirSync(noteDir, { recursive: true });
+
+// Point the binary's DB/workspace discovery at our sandbox via workspace-config.
+// getConfigBasePath() is platform-specific: macOS → <HOME>/Library/Application
+// Support, Windows → %APPDATA%, Linux → $XDG_CONFIG_HOME (or <HOME>/.config). We
+// set HOME (and APPDATA/XDG) to the sandbox and write the config under whichever
+// base this platform resolves.
+const configBases = [];
+if (process.platform === "darwin") {
+  configBases.push(path.join(ws, "Library", "Application Support"));
+} else if (process.platform === "win32") {
+  configBases.push(cfgBase);
+} else {
+  configBases.push(cfgBase, path.join(ws, ".config"));
+}
+for (const base of configBases) {
+  for (const name of ["Cairn", "cairn"]) {
+    fs.mkdirSync(path.join(base, name), { recursive: true });
+    fs.writeFileSync(
+      path.join(base, name, "workspace-config.json"),
+      JSON.stringify({ workspacePath: ws }),
+    );
+  }
+}
+
+// Seed a minimal DB using the app's REAL schema (applySchema) so the row shape
+// matches exactly what link_note_to_task expects — hand-writing CREATE TABLEs
+// drifts (e.g. a missing `archived_at` column silently makes the tool error and
+// the test falsely pass). We esbuild schema.ts to a temp CJS module and apply it
+// via the system-Node better-sqlite3 (ABI matches in CI right after `compile`).
+function seedDb() {
+  const tmpSchema = path.join(ws, "_schema.cjs");
+  execFileSync(
+    "npx",
+    ["esbuild", path.join(root, "electron/db/schema.ts"),
+     "--bundle", "--platform=node", "--format=cjs",
+     "--external:better-sqlite3", "--outfile=" + tmpSchema],
+    { stdio: "ignore", cwd: root },
+  );
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { applySchema } = require(tmpSchema);
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Database = require(path.join(root, "node_modules/better-sqlite3"));
+  const db = new Database(dbPath);
+  applySchema(db);
+  const now = "2026-01-01T00:00:00.000Z";
+  db.prepare("INSERT INTO workspaces (id,name,created_at,updated_at) VALUES ('ws','WS',?,?)").run(now, now);
+  db.prepare("INSERT INTO projects (id,workspace_id,name,status,priority,tag_ids,created_at,updated_at) VALUES ('proj','ws',?,'active','medium','[]',?,?)").run(projectDirName, now, now);
+  db.prepare("INSERT INTO board_columns (id,project_id,workspace_id,name,type,\"order\",created_at,updated_at) VALUES ('col','proj','ws','Todo','todo',0,?,?)").run(now, now);
+  db.prepare("INSERT INTO notes (id,project_id,workspace_id,title,content,content_text,tag_ids,linked_note_ids,linked_card_ids,is_pinned,type,folder,created_at,updated_at) VALUES ('note1','proj','ws','SmokeNote','body','body','[]','[]','[]',0,'note','Research',?,?)").run(now, now);
+  db.prepare("INSERT INTO task_cards (id,column_id,project_id,workspace_id,title,description,tag_ids,priority,linked_note_ids,\"order\",created_at,updated_at) VALUES ('card1','col','proj','ws','SmokeCard','','[]','medium','[]',0,?,?)").run(now, now);
+  db.close();
+}
+try {
+  seedDb();
+} catch (e) {
+  fail(`could not seed sqlite db via applySchema: ${e.message}`);
+}
+
+// Note file lives in the lowercase "research" dir; the DB folder is "Research".
+const notePath = path.join(noteDir, "SmokeNote.md");
+fs.writeFileSync(
+  notePath,
+  `---\nid: note1\nprojectId: proj\nworkspaceId: ws\ntitle: SmokeNote\nfolder: Research\ntagIds: []\nlinkedNoteIds: []\nlinkedCardIds: []\nisPinned: false\ncreatedAt: 'x'\nupdatedAt: 'x'\n---\nbody\n`,
+);
+
+const inoBefore = fs.statSync(notePath).ino;
+
+// ── Drive the binary over stdio JSON-RPC ─────────────────────────────────────
+const child = spawn(BIN, [], {
+  env: {
+    ...process.env,
+    HOME: ws,
+    XDG_CONFIG_HOME: cfgBase,
+    APPDATA: cfgBase,
+  },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+let stdout = "";
+child.stdout.on("data", (d) => (stdout += d.toString()));
+let stderr = "";
+child.stderr.on("data", (d) => (stderr += d.toString()));
+
+const send = (o) => child.stdin.write(JSON.stringify(o) + "\n");
+
+send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "smoke", version: "1" } } });
+setTimeout(() => {
+  send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "link_note_to_task", arguments: { noteId: "note1", cardId: "card1" } } });
+}, 700);
+
+setTimeout(() => {
+  child.kill();
+
+  const linkResp = stdout.split("\n").find((l) => l.includes('"id":2'));
+  if (!linkResp) {
+    console.error(stderr);
+    fail("no response to link_note_to_task (binary failed to start or DB not found)");
+  }
+
+  // Case-sensitive existence check: read the lowercase "research" directory and
+  // confirm SmokeNote.md is STILL there by exact name. A plain
+  // fs.existsSync(notePath) is case-BLIND on macOS — if the buggy relocation
+  // branch moved the file to a "Research"/ directory (same inode), existsSync on
+  // the lowercase path would still return true and hide the regression.
+  let survivedExactCase = false;
+  try {
+    survivedExactCase = fs.readdirSync(noteDir).includes("SmokeNote.md");
+  } catch { /* dir gone */ }
+
+  // Also detect a stale duplicate directory left by a relocation (case-variant).
+  const upperDir = path.join(ws, projectDirName, "Research");
+  let duplicateDir = false;
+  try {
+    // On a case-insensitive FS readdir of the project dir returns ONE entry for
+    // research/Research; a genuine relocation still leaves the file under the
+    // wrong-cased name. Compare the on-disk directory entry's exact casing.
+    const projEntries = fs.readdirSync(path.join(ws, projectDirName));
+    duplicateDir = projEntries.includes("Research") && !projEntries.includes("research");
+  } catch { /* ignore */ }
+
+  const inoAfter = survivedExactCase ? fs.statSync(notePath).ino : null;
+
+  if (!survivedExactCase) {
+    console.error(`     link response: ${linkResp}`);
+    fail("linked note's .md file was DELETED or relocated by link_note_to_task (regression!)");
+  }
+  if (duplicateDir) {
+    fail('note was relocated to a case-variant "Research/" directory (regression!)');
+  }
+  if (inoAfter !== inoBefore) {
+    fail(`note file inode changed (${inoBefore} → ${inoAfter}) — write was not in-place`);
+  }
+
+  console.log("  ✓  link_note_to_task preserved the linked note's file (in place)");
+  console.log("\n1 passed, 0 failed\n");
+  fs.rmSync(ws, { recursive: true, force: true });
+  process.exit(0);
+}, 3000);

--- a/scripts/smoke-test-mcp.js
+++ b/scripts/smoke-test-mcp.js
@@ -85,7 +85,9 @@ function seedDb() {
     ["esbuild", path.join(root, "electron/db/schema.ts"),
      "--bundle", "--platform=node", "--format=cjs",
      "--external:better-sqlite3", "--outfile=" + tmpSchema],
-    { stdio: "ignore", cwd: root },
+    // On Windows `npx` is `npx.cmd`, which execFileSync can't run without a
+    // shell; enable shell only there so POSIX runners keep the safer no-shell path.
+    { stdio: "ignore", cwd: root, shell: process.platform === "win32" },
   );
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { applySchema } = require(tmpSchema);
@@ -127,27 +129,41 @@ const child = spawn(BIN, [], {
   stdio: ["pipe", "pipe", "pipe"],
 });
 
-let stdout = "";
-child.stdout.on("data", (d) => (stdout += d.toString()));
+// A spawn failure (binary not executable, bad arch, missing loader) otherwise
+// surfaces as a silent "no response" timeout — report it directly.
+child.on("error", (err) => fail(`failed to launch ${BIN}: ${err.message}`));
+
 let stderr = "";
 child.stderr.on("data", (d) => (stderr += d.toString()));
 
 const send = (o) => child.stdin.write(JSON.stringify(o) + "\n");
 
-send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "smoke", version: "1" } } });
-setTimeout(() => {
-  send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "link_note_to_task", arguments: { noteId: "note1", cardId: "card1" } } });
-}, 700);
+// Response-driven flow: parse complete newline-delimited JSON-RPC messages and
+// react when id:1 (initialize) and id:2 (tools/call) arrive, instead of racing
+// fixed sleeps. A generous timeout remains only as a fallback for a hung/crashed
+// binary that never replies.
+let buffer = "";
+let initialized = false;
+let done = false;
 
-setTimeout(() => {
-  child.kill();
+const timeout = setTimeout(() => {
+  if (done) return;
+  console.error(stderr);
+  finish(false, "timed out waiting for JSON-RPC responses (binary hung or DB not found)");
+}, 15000);
 
-  const linkResp = stdout.split("\n").find((l) => l.includes('"id":2'));
-  if (!linkResp) {
-    console.error(stderr);
-    fail("no response to link_note_to_task (binary failed to start or DB not found)");
+function finish(ok, msg, linkResp) {
+  if (done) return;
+  done = true;
+  clearTimeout(timeout);
+  try { child.kill(); } catch { /* already gone */ }
+
+  if (!ok) {
+    if (linkResp) console.error(`     link response: ${linkResp}`);
+    fail(msg);
   }
 
+  // ── Assertions: the linked note's file must be preserved in place ──────────
   // Case-sensitive existence check: read the lowercase "research" directory and
   // confirm SmokeNote.md is STILL there by exact name. A plain
   // fs.existsSync(notePath) is case-BLIND on macOS — if the buggy relocation
@@ -158,13 +174,9 @@ setTimeout(() => {
     survivedExactCase = fs.readdirSync(noteDir).includes("SmokeNote.md");
   } catch { /* dir gone */ }
 
-  // Also detect a stale duplicate directory left by a relocation (case-variant).
-  const upperDir = path.join(ws, projectDirName, "Research");
+  // Detect a stale duplicate directory left by a relocation (case-variant).
   let duplicateDir = false;
   try {
-    // On a case-insensitive FS readdir of the project dir returns ONE entry for
-    // research/Research; a genuine relocation still leaves the file under the
-    // wrong-cased name. Compare the on-disk directory entry's exact casing.
     const projEntries = fs.readdirSync(path.join(ws, projectDirName));
     duplicateDir = projEntries.includes("Research") && !projEntries.includes("research");
   } catch { /* ignore */ }
@@ -172,7 +184,7 @@ setTimeout(() => {
   const inoAfter = survivedExactCase ? fs.statSync(notePath).ino : null;
 
   if (!survivedExactCase) {
-    console.error(`     link response: ${linkResp}`);
+    if (linkResp) console.error(`     link response: ${linkResp}`);
     fail("linked note's .md file was DELETED or relocated by link_note_to_task (regression!)");
   }
   if (duplicateDir) {
@@ -186,4 +198,24 @@ setTimeout(() => {
   console.log("\n1 passed, 0 failed\n");
   fs.rmSync(ws, { recursive: true, force: true });
   process.exit(0);
-}, 3000);
+}
+
+child.stdout.on("data", (d) => {
+  buffer += d.toString();
+  let nl;
+  while ((nl = buffer.indexOf("\n")) !== -1) {
+    const line = buffer.slice(0, nl).trim();
+    buffer = buffer.slice(nl + 1);
+    if (!line) continue;
+    let msg;
+    try { msg = JSON.parse(line); } catch { continue; } // ignore non-JSON log lines
+    if (msg.id === 1 && !initialized) {
+      initialized = true;
+      send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "link_note_to_task", arguments: { noteId: "note1", cardId: "card1" } } });
+    } else if (msg.id === 2) {
+      finish(true, null, line);
+    }
+  }
+});
+
+send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "smoke", version: "1" } } });


### PR DESCRIPTION
## What does this PR do?

Fixes the note-deletion-on-link bug for real this time, and adds a CI gate so it can never silently ship again.

**Root cause (finally):** The v2.5.13 fix (`isSameFile` via `fs.realpathSync.native`) was correct in the compiled bundle and passed all unit tests — but **broke once packaged into the standalone `cairn-mcp` binary**. yao-pkg patches Node's `fs`, and its `realpathSync.native` does **not** canonicalise filename case on macOS (it returns the path as given). So a note whose stored folder casing differed from its on-disk directory (e.g. `Research` in the DB, `research/` on disk) still compared unequal → the write took the *relocation* branch → unlinked the file it had just written → note deleted. Verified directly: identical bundle run under `node` preserves the note; packaged by pkg it deletes it.

**Fix:** `isSameFile` now compares `fs.statSync` device + inode. The real OS syscall reports the same inode for both case-variants under **both** plain Node and the pkg binary (verified with a standalone pkg micro-test).

**CI gate:** new `npm run smoke-test:mcp` boots the actual built binary on each platform, links a note→task in a throwaway workspace that reproduces the case mismatch, and fails the build if the `.md` is deleted or relocated. Confirmed it **fails on the broken binary** and **passes on the fixed one**.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [x] Docs / changelog
- [x] Tests

## Screenshots / recording

N/A — backend / packaging fix.

## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [ ] `npm test` (ran affected unit suites: notes-io, link-note-task — green; did not run full compile+bundle-guard locally)
- [x] `npm run smoke-test:mcp` passes on the fixed binary; fails on the broken one (verified)
- [x] No hardcoded colours / pixel font classes — N/A
- [x] New DB migrations — N/A
- [x] New SQL in queries.ts — N/A
- [x] New MCP tools registered — N/A

## Notes for reviewer

- The key lesson: **pkg changes `fs` semantics**, so MCP-binary correctness can't be assumed from bundle/unit tests. The new smoke test runs the real artifact — that's the durable guard.
- The smoke test seeds its sandbox DB via the app's own `applySchema` (esbuild-compiled at test time), not hand-written CREATE TABLEs, so it can't drift from the real schema (an earlier hand-seeded version silently passed against a broken binary because a missing column made the tool error out before writing).
- Depends on the `sqlite3`-free path: seeding uses `node_modules/better-sqlite3` (CI Node ABI, present right after `npm ci`/`rebuild`). Runs after `build-mcp-binary.js` on all three platforms.
- Changelog: v2.5.13 is released, so the entry is in new `changelogs/v2.5.14.md`.
- Broader idea discussed but out of scope here: publishing `cairn-mcp` as a standalone `npx`-runnable package to decouple MCP fixes from the app release cycle. Worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where linking a note to a task could delete or relocate the note in the packaged app.
  * Improved handling of file paths that differ only by letter casing.

* **Quality Improvements**
  * Added an automated packaged-app smoke test to verify note linking across macOS, Windows, and Linux builds.
  * Release builds now validate that linked notes remain intact and in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->