### PR TITLE
feat: prompt-cache tracking + consistent styled dropdowns

### DIFF
--- a/changelogs/v2.6.7.md
+++ b/changelogs/v2.6.7.md
@@ -1,0 +1,9 @@
+## What's new
+
+### New
+
+- **See prompt-cache hits on every chat and agent turn.** The context ring (chat header, Agent pane, and subagent rings) now shows a **Prompt cache** row whenever the provider reports cached tokens — how many input tokens were served from cache (and written to it) this turn, plus the percentage of input that hit the cache. The ring's hover tooltip also notes cached tokens at a glance.
+- **The Usage view tracks prompt caching.** Cached-input tokens are captured per LLM call across chat, the Agent, subagents, automations, and the one-shot AI features, and appear as a **Cached input** stat (with % of input) and a **Cached** column in the usage history table — each row shows the cached tokens and what percentage of that call's input they saved, so you can see how much of your prompt spend is being saved by caching.
+- **Filter estimated cost out of the Usage view.** A new **Estimates** toggle (on by default) lets you hide calls whose cost is estimated from models.dev pricing (because the provider reported none) — the totals, chart, model breakdown, and history then reflect only provider-reported spend.
+- **Cost estimates are cache-aware.** When a provider doesn't report cost, the models.dev estimate now prices cached input at the model's cache-read/write rates instead of full input — cache hits no longer over-bill in the tracker.
+- **Consistent styled dropdowns everywhere.** The model picker rows now put the model name on one line with its input capabilities and cost underneath — in both the open menu and the closed trigger — so long model ids no longer crowd out the metadata. Native `<select>` dropdowns across the app (usage source filter, chat quick-settings provider, card column and blocker pickers, automation project/approval mode, schedule units, spawn-agent binary, local context limit, service HTTP method, and the mobile view selector) all now use the shared styled dropdown for the same floating panel and theming.

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -1026,6 +1026,10 @@ function ensureColumns(db: Database.Database): void {
   // v38 llm_usage — cost_estimated added after the initial table shipped in an
   // interim build; existing dev DBs get the column here, fresh ones from v38.
   ensure("llm_usage", "cost_estimated", "cost_estimated INTEGER NOT NULL DEFAULT 0");
+  // Prompt-cache token counts (cache_read/cache_creation) added for cache-hit
+  // tracking — additive, so a guard rather than a new migration is enough.
+  ensure("llm_usage", "cache_read_tokens", "cache_read_tokens INTEGER NOT NULL DEFAULT 0");
+  ensure("llm_usage", "cache_creation_tokens", "cache_creation_tokens INTEGER NOT NULL DEFAULT 0");
 }
 
 function runMigrations(db: Database.Database): void {

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -974,6 +974,21 @@ const MIGRATIONS: Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_llm_usage_workspace ON llm_usage(workspace_id, created_at);
     `);
   },
+
+  // v39: Prompt-cache token counts on llm_usage (cache_read_tokens /
+  // cache_creation_tokens) — the columns backing cache-hit tracking in the Usage
+  // view. Added transactionally here so every DB (fresh or upgraded) gets them
+  // before the schema version advances; the ensureColumns guards below remain as
+  // a compatibility fallback for DBs whose user_version was already advanced.
+  (db) => {
+    const cols = db.prepare("PRAGMA table_info(llm_usage)").all() as { name: string }[];
+    if (cols.length > 0 && !cols.some((c) => c.name === "cache_read_tokens")) {
+      db.exec("ALTER TABLE llm_usage ADD COLUMN cache_read_tokens INTEGER NOT NULL DEFAULT 0");
+    }
+    if (cols.length > 0 && !cols.some((c) => c.name === "cache_creation_tokens")) {
+      db.exec("ALTER TABLE llm_usage ADD COLUMN cache_creation_tokens INTEGER NOT NULL DEFAULT 0");
+    }
+  },
 ];
 
 export function applySchema(db: Database.Database): void {

--- a/electron/db/usage-queries.test.ts
+++ b/electron/db/usage-queries.test.ts
@@ -124,6 +124,44 @@ describe("usage-queries", () => {
     expect(recent[0].model).toBe("m0");
   });
 
+  it("persists and aggregates prompt-cache tokens", () => {
+    insertLlmUsage(db, rec({ source: "chat", promptTokens: 1000, cacheReadTokens: 700, cacheCreationTokens: 0, createdAt: NOW - DAY }));
+    insertLlmUsage(db, rec({ source: "pi-agent", promptTokens: 500, cacheReadTokens: 100, cacheCreationTokens: 50, createdAt: NOW }));
+
+    const overview = queryUsageOverview(db, {});
+    expect(overview.totals.cacheReadTokens).toBe(800);
+    expect(overview.totals.promptTokens).toBe(1500);
+    // Cached input rides along in the day series too.
+    expect(overview.series).toHaveLength(2);
+
+    const recent = queryRecentUsage(db, {}, 10);
+    expect(recent[0].source).toBe("pi-agent");
+    expect(recent[0].cacheReadTokens).toBe(100);
+    expect(recent[0].cacheCreationTokens).toBe(50);
+    expect(recent[1].cacheReadTokens).toBe(700);
+    expect(recent[1].cacheCreationTokens).toBe(0);
+  });
+
+  it("excludes rows with estimated cost when the filter is set", () => {
+    insertLlmUsage(db, rec({ source: "chat", promptTokens: 100, costUsd: 0.01, costEstimated: false, createdAt: NOW - 1000 }));
+    insertLlmUsage(db, rec({ source: "chat", promptTokens: 200, costUsd: 0.02, costEstimated: true, createdAt: NOW }));
+    insertLlmUsage(db, rec({ source: "pi-agent", promptTokens: 300, costUsd: 0.03, costEstimated: false, createdAt: NOW }));
+
+    const all = queryUsageOverview(db, {});
+    expect(all.totals.requests).toBe(3);
+    expect(all.totals.promptTokens).toBe(600);
+    expect(all.totals.costUsd).toBeCloseTo(0.06, 6);
+
+    const real = queryUsageOverview(db, { excludeEstimated: true });
+    expect(real.totals.requests).toBe(2);
+    expect(real.totals.promptTokens).toBe(400);
+    expect(real.totals.costUsd).toBeCloseTo(0.04, 6);
+
+    const recent = queryRecentUsage(db, { excludeEstimated: true }, 10);
+    expect(recent).toHaveLength(2);
+    expect(recent.every((r) => r.costEstimated === false)).toBe(true);
+  });
+
   it("writes a recovered turn cost back onto estimated rows proportionally", () => {
     insertLlmUsage(db, rec({ source: "chat", sessionId: "t1", completionTokens: 100, costUsd: 0.01, costEstimated: true, createdAt: NOW }));
     insertLlmUsage(db, rec({ source: "chat", sessionId: "t1", completionTokens: 300, costUsd: 0.03, costEstimated: true, createdAt: NOW + 1 }));

--- a/electron/db/usage-queries.test.ts
+++ b/electron/db/usage-queries.test.ts
@@ -142,14 +142,17 @@ describe("usage-queries", () => {
     expect(recent[1].cacheCreationTokens).toBe(0);
   });
 
-  it("excludes rows with estimated cost when the filter is set", () => {
+  it("excludes rows with estimated or missing cost when the filter is set", () => {
     insertLlmUsage(db, rec({ source: "chat", promptTokens: 100, costUsd: 0.01, costEstimated: false, createdAt: NOW - 1000 }));
     insertLlmUsage(db, rec({ source: "chat", promptTokens: 200, costUsd: 0.02, costEstimated: true, createdAt: NOW }));
     insertLlmUsage(db, rec({ source: "pi-agent", promptTokens: 300, costUsd: 0.03, costEstimated: false, createdAt: NOW }));
+    // Not an estimate, but the provider reported no cost AND no model price is
+    // known — no real cost either, so it must be dropped alongside estimates.
+    insertLlmUsage(db, rec({ source: "chat", promptTokens: 400, costUsd: undefined, costEstimated: false, createdAt: NOW }));
 
     const all = queryUsageOverview(db, {});
-    expect(all.totals.requests).toBe(3);
-    expect(all.totals.promptTokens).toBe(600);
+    expect(all.totals.requests).toBe(4);
+    expect(all.totals.promptTokens).toBe(1000);
     expect(all.totals.costUsd).toBeCloseTo(0.06, 6);
 
     const real = queryUsageOverview(db, { excludeEstimated: true });
@@ -160,6 +163,7 @@ describe("usage-queries", () => {
     const recent = queryRecentUsage(db, { excludeEstimated: true }, 10);
     expect(recent).toHaveLength(2);
     expect(recent.every((r) => r.costEstimated === false)).toBe(true);
+    expect(recent.every((r) => r.costUsd != null)).toBe(true);
   });
 
   it("writes a recovered turn cost back onto estimated rows proportionally", () => {

--- a/electron/db/usage-queries.ts
+++ b/electron/db/usage-queries.ts
@@ -130,7 +130,11 @@ function whereClause(f: UsageQueryFilter): { sql: string; params: unknown[] } {
     params.push(f.to);
   }
   if (f.excludeEstimated) {
-    conds.push("cost_estimated = 0");
+    // Only calls with a provider-reported cost survive: a row is never an
+    // estimate when cost_estimated is 0, but it may still carry no cost at all
+    // (provider reported none and pricing is unknown) — those have no real cost
+    // either and are dropped so the view reflects actual billed spend.
+    conds.push("cost_estimated = 0 AND cost_usd IS NOT NULL");
   }
   return { sql: conds.length > 0 ? ` WHERE ${conds.join(" AND ")}` : "", params };
 }

--- a/electron/db/usage-queries.ts
+++ b/electron/db/usage-queries.ts
@@ -54,6 +54,10 @@ export interface LlmUsageRecord {
   promptTokens?: number;
   completionTokens?: number;
   reasoningTokens?: number;
+  /** Prompt tokens served from the provider's cache (billed at the cache_read rate). */
+  cacheReadTokens?: number;
+  /** Prompt tokens written to the provider's cache (billed at the cache_write rate). */
+  cacheCreationTokens?: number;
   costUsd?: number;
   /** True when cost_usd is a models.dev estimate (provider reported none). */
   costEstimated?: boolean;
@@ -66,8 +70,9 @@ export function insertLlmUsage(db: Database.Database, record: LlmUsageRecord): v
   db.prepare(
     `INSERT INTO llm_usage (
        id, workspace_id, project_id, source, session_id, provider, model, base_url,
-       prompt_tokens, completion_tokens, reasoning_tokens, cost_usd, cost_estimated, finish_reason, created_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       prompt_tokens, completion_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens,
+       cost_usd, cost_estimated, finish_reason, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     record.id || newId(),
     record.workspaceId ?? null,
@@ -80,6 +85,8 @@ export function insertLlmUsage(db: Database.Database, record: LlmUsageRecord): v
     Math.max(0, Math.round(record.promptTokens ?? 0)),
     Math.max(0, Math.round(record.completionTokens ?? 0)),
     Math.max(0, Math.round(record.reasoningTokens ?? 0)),
+    Math.max(0, Math.round(record.cacheReadTokens ?? 0)),
+    Math.max(0, Math.round(record.cacheCreationTokens ?? 0)),
     typeof record.costUsd === "number" && Number.isFinite(record.costUsd) ? record.costUsd : null,
     record.costEstimated ? 1 : 0,
     record.finishReason ?? null,
@@ -94,6 +101,8 @@ export interface UsageQueryFilter {
   from?: number;
   /** Epoch ms, inclusive. */
   to?: number;
+  /** Drop rows whose cost is a models.dev estimate (provider reported none). */
+  excludeEstimated?: boolean;
 }
 
 /**
@@ -120,6 +129,9 @@ function whereClause(f: UsageQueryFilter): { sql: string; params: unknown[] } {
     conds.push("created_at <= ?");
     params.push(f.to);
   }
+  if (f.excludeEstimated) {
+    conds.push("cost_estimated = 0");
+  }
   return { sql: conds.length > 0 ? ` WHERE ${conds.join(" AND ")}` : "", params };
 }
 
@@ -127,6 +139,8 @@ export interface UsageTotals {
   promptTokens: number;
   completionTokens: number;
   reasoningTokens: number;
+  /** Prompt tokens served from the provider's cache across the window. */
+  cacheReadTokens: number;
   costUsd: number;
   requests: number;
 }
@@ -156,6 +170,7 @@ export interface UsageOverview {
 const TOTAL_COLS = `COALESCE(SUM(prompt_tokens), 0) AS prompt_tokens,
   COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
   COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+  COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
   COALESCE(SUM(cost_usd), 0) AS cost_usd,
   COUNT(*) AS requests`;
 
@@ -164,6 +179,7 @@ function toTotals(row: Record<string, number>): UsageTotals {
     promptTokens: Number(row.prompt_tokens) || 0,
     completionTokens: Number(row.completion_tokens) || 0,
     reasoningTokens: Number(row.reasoning_tokens) || 0,
+    cacheReadTokens: Number(row.cache_read_tokens) || 0,
     costUsd: Number(row.cost_usd) || 0,
     requests: Number(row.requests) || 0,
   };
@@ -241,6 +257,10 @@ export interface UsageRecentRow {
   promptTokens: number;
   completionTokens: number;
   reasoningTokens: number;
+  /** Prompt tokens served from the provider's cache. */
+  cacheReadTokens: number;
+  /** Prompt tokens written to the provider's cache. */
+  cacheCreationTokens: number;
   costUsd: number | null;
   costEstimated: boolean;
   finishReason: string | null;
@@ -283,7 +303,8 @@ export function queryRecentUsage(db: Database.Database, filter: UsageQueryFilter
   const rows = db
     .prepare(
       `SELECT id, workspace_id, project_id, source, session_id, provider, model, base_url,
-         prompt_tokens, completion_tokens, reasoning_tokens, cost_usd, cost_estimated, finish_reason, created_at
+         prompt_tokens, completion_tokens, reasoning_tokens, cache_read_tokens, cache_creation_tokens,
+         cost_usd, cost_estimated, finish_reason, created_at
        FROM llm_usage${where.sql}
        ORDER BY created_at DESC LIMIT ?`
     )
@@ -301,6 +322,8 @@ export function queryRecentUsage(db: Database.Database, filter: UsageQueryFilter
     promptTokens: Number(r.prompt_tokens) || 0,
     completionTokens: Number(r.completion_tokens) || 0,
     reasoningTokens: Number(r.reasoning_tokens) || 0,
+    cacheReadTokens: Number(r.cache_read_tokens) || 0,
+    cacheCreationTokens: Number(r.cache_creation_tokens) || 0,
     costUsd: r.cost_usd == null ? null : Number(r.cost_usd),
     costEstimated: Number(r.cost_estimated) === 1,
     finishReason: (r.finish_reason as string | null) ?? null,

--- a/electron/ipc/chat.ts
+++ b/electron/ipc/chat.ts
@@ -188,6 +188,8 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
     let promptTokens = 0;
     let completionTokens = 0;
     let reasoningTokens = 0;
+    let cacheReadTokens = 0;
+    let cacheCreationTokens = 0;
     let costUsd: number | undefined = undefined;
     let lastBreakdown: TokenBreakdown | undefined = undefined;
 
@@ -201,7 +203,7 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
     }
     const allTools = externalDefs.length > 0 ? [...TOOLS, ...externalDefs] : TOOLS;
 
-    const addUsage = (pt: number, ct: number, rt?: number, cost?: number) => {
+    const addUsage = (pt: number, ct: number, rt?: number, cost?: number, cacheRead?: number, cacheCreate?: number) => {
       // Persist one usage row per tool-loop round (source = chat) for the Usage view.
       recordLlmUsage({
         source: "chat",
@@ -214,11 +216,17 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
         promptTokens: pt,
         completionTokens: ct,
         reasoningTokens: typeof rt === "number" ? rt : 0,
+        cacheReadTokens: cacheRead,
+        cacheCreationTokens: cacheCreate,
         costUsd: cost,
       });
       promptTokens = pt;
       completionTokens += ct;
       if (typeof rt === "number") reasoningTokens += rt;
+      // Cache tokens are last-round only, mirroring promptTokens (the context
+      // window shown is the current round's, not a running sum).
+      if (typeof cacheRead === "number") cacheReadTokens = cacheRead;
+      if (typeof cacheCreate === "number") cacheCreationTokens = cacheCreate;
       // Provider-reported USD cost of this call (e.g. Neuralwatt usage.cost);
       // accumulated across tool-loop rounds like completion tokens. Only
       // non-negative finite values are accepted; an explicitly reported 0 is
@@ -232,7 +240,7 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
       } catch (err) {
         console.error("[chat] failed to calculate breakdown:", err);
       }
-      send("chat:usage", { promptTokens, completionTokens, reasoningTokens, breakdown: lastBreakdown, costUsd });
+      send("chat:usage", { promptTokens, completionTokens, reasoningTokens, breakdown: lastBreakdown, costUsd, cacheReadTokens, cacheCreationTokens });
     };
 
     // Final usage object attached to chat:done (or undefined when nothing ran —
@@ -245,6 +253,8 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
             reasoningTokens,
             breakdown: lastBreakdown,
             costUsd: costUsd != null ? costUsd : undefined,
+            cacheReadTokens,
+            cacheCreationTokens,
           }
         : undefined;
 
@@ -281,8 +291,10 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
         promptTokens = m.dispatcherPromptTokens;
         completionTokens = m.dispatcherCompletionTokens;
         reasoningTokens = m.dispatcherReasoningTokens;
+        cacheReadTokens = m.dispatcherCacheReadTokens;
+        cacheCreationTokens = m.dispatcherCacheCreationTokens;
         if (typeof m.costUsd === "number") costUsd = m.costUsd;
-        send("chat:usage", { promptTokens, completionTokens, reasoningTokens, breakdown: lastBreakdown, costUsd });
+        send("chat:usage", { promptTokens, completionTokens, reasoningTokens, breakdown: lastBreakdown, costUsd, cacheReadTokens, cacheCreationTokens });
 
         // Stream the dispatcher's final reply as content tokens so it renders like
         // a normal assistant message.
@@ -364,7 +376,7 @@ export function registerChatHandler(db: Database.Database, workspacePath: string
               if (Number.isFinite(diff) && diff >= 0) {
                 costUsd = diff;
                 if (promptTokens > 0) {
-                  send("chat:usage", { promptTokens, completionTokens, reasoningTokens, breakdown: lastBreakdown, costUsd });
+                  send("chat:usage", { promptTokens, completionTokens, reasoningTokens, breakdown: lastBreakdown, costUsd, cacheReadTokens, cacheCreationTokens });
                 }
                 // Write the recovered provider-reported cost back onto this
                 // turn's recorded usage rows (they were persisted during the

--- a/electron/ipc/pi-agent.ts
+++ b/electron/ipc/pi-agent.ts
@@ -134,7 +134,7 @@ async function runSession(
         }
       },
       onStepStart:    () => send("pi-agent:step",  { sessionId }),
-      onUsage:        (promptTokens, completionTokens, reasoningTokens, breakdown) => send("pi-agent:usage", { sessionId, promptTokens, completionTokens, reasoningTokens, breakdown }),
+      onUsage:        (promptTokens, completionTokens, reasoningTokens, breakdown, _cost, cacheRead, cacheCreate) => send("pi-agent:usage", { sessionId, promptTokens, completionTokens, reasoningTokens, breakdown, cacheReadTokens: cacheRead, cacheCreationTokens: cacheCreate }),
       onRetry:        (attempt, maxRetries, delayMs, error) => send("pi-agent:retry", { sessionId, attempt, maxRetries, delayMs, error }),
       transformContext: session.compactionTransformer,
       onDone: () => {

--- a/electron/ipc/tool-builder.ts
+++ b/electron/ipc/tool-builder.ts
@@ -28,7 +28,7 @@ import * as secrets from "../lib/secure-store";
 import { buildBuilderSystemPrompt, BUILDER_TOOL_DEFS } from "../lib/tool-builder-prompt";
 import { parseToolArgs } from "../lib/parse-tool-args";
 import { resolveMaxOutputTokens } from "../../shared/models/model-catalog";
-import { recordLlmUsage, extractCost } from "../lib/usage-recorder";
+import { recordLlmUsage, extractCost, extractCacheTokens } from "../lib/usage-recorder";
 
 interface OpenAIMessage {
   role: "system" | "user" | "assistant" | "tool";
@@ -109,6 +109,7 @@ async function callModel(
   const msg = json.choices?.[0]?.message;
   if (!msg) throw new Error("No response from AI endpoint");
 
+  const cache = extractCacheTokens(json.usage);
   recordLlmUsage({
     source: "tool-builder",
     sessionId: attrib?.sessionId,
@@ -119,6 +120,8 @@ async function callModel(
     promptTokens: json.usage?.prompt_tokens ?? 0,
     completionTokens: json.usage?.completion_tokens ?? 0,
     reasoningTokens: json.usage?.completion_tokens_details?.reasoning_tokens ?? 0,
+    cacheReadTokens: cache.cacheReadTokens,
+    cacheCreationTokens: cache.cacheCreationTokens,
     costUsd: extractCost(json.cost, json.usage),
   });
   return msg;

--- a/electron/ipc/usage-handlers.ts
+++ b/electron/ipc/usage-handlers.ts
@@ -17,42 +17,40 @@ export interface UsageRangeArgs {
   /** Epoch ms, inclusive. Omit for all time. */
   from?: number;
   to?: number;
+  /** Drop rows whose cost is a models.dev estimate (provider reported none). */
+  excludeEstimated?: boolean;
 }
 
 export function registerUsageHandlers(ctx: DbContext): void {
   // models.dev per-1M pricing map pushed by the renderer once its catalog loads,
   // so the recorder can estimate cost for providers that don't report it.
-  registerIpcHandle("app:modelPricing", (_e, map: Record<string, { input: number | null; output: number | null }> | null) => {
+  registerIpcHandle("app:modelPricing", (_e, map: Record<string, { input: number | null; output: number | null; cacheRead?: number | null; cacheWrite?: number | null }> | null) => {
     return handle(() => {
       setModelPricing(map);
       return { ok: true };
     });
   });
 
+  const toFilter = (args: UsageRangeArgs): UsageQueryFilter => ({
+    workspaceId: args?.workspaceId,
+    source: args?.source,
+    from: args?.from,
+    to: args?.to,
+    excludeEstimated: args?.excludeEstimated,
+  });
+
   // Everything the view needs for a range: headline totals, previous window
   // (delta chips), per-day series, and source + model breakdowns.
   registerIpcHandle("usage:overview", async (_e, args: UsageRangeArgs) => {
     return handle(() => {
-      const filter: UsageQueryFilter = {
-        workspaceId: args?.workspaceId,
-        source: args?.source,
-        from: args?.from,
-        to: args?.to,
-      };
-      return queryUsageOverview(ctx.db, filter);
+      return queryUsageOverview(ctx.db, toFilter(args));
     });
   });
 
   // Most recent per-call rows for the history table.
   registerIpcHandle("usage:recent", async (_e, args: UsageRangeArgs & { limit?: number }) => {
     return handle(() => {
-      const filter: UsageQueryFilter = {
-        workspaceId: args?.workspaceId,
-        source: args?.source,
-        from: args?.from,
-        to: args?.to,
-      };
-      return queryRecentUsage(ctx.db, filter, args?.limit ?? 50);
+      return queryRecentUsage(ctx.db, toFilter(args), args?.limit ?? 50);
     });
   });
 }

--- a/electron/lib/chat-loop.ts
+++ b/electron/lib/chat-loop.ts
@@ -18,6 +18,7 @@ import type { OpenAIMessage } from "./llm";
 import { buildApiUrl } from "./llm";
 import { buildChatCompletionsBody, consumeAssistantStream, failToolCallsFromTruncatedMessage, interruptedStreamToolCallError } from "./llm-stream";
 import { TOOLS, type ChatRequest } from "./tools";
+import { extractCacheTokens } from "./usage-recorder";
 import { executeTool } from "../ipc/chat-executor";
 import { executeExternalTool, isExternalToolName, externalToolLabel } from "./external-tools";
 import { extractExternalRef } from "./external-ref";
@@ -48,7 +49,7 @@ export async function runToolLoop(
   signal?: AbortSignal,
   getWin?: () => BrowserWindow | null,
   provider?: string,
-  onUsage?: (pt: number, ct: number, rt?: number, costUsd?: number) => void,
+  onUsage?: (pt: number, ct: number, rt?: number, costUsd?: number, cacheReadTokens?: number, cacheCreationTokens?: number) => void,
   emitToolCallDone?: (e: { tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string }; externalRef?: { url: string; title?: string; snippet?: string }; output?: string; callId?: string; ok?: boolean; error?: string }) => void,
   onToken?: (delta: string) => void,
   onThought?: (delta: string) => void,
@@ -109,11 +110,14 @@ export async function runToolLoop(
             : typeof topCost?.request_cost_usd === "number"
               ? topCost.request_cost_usd
               : undefined;
+          const cache = extractCacheTokens(res.usage);
           onUsage(
             res.usage.prompt_tokens ?? 0,
             res.usage.completion_tokens ?? 0,
             res.usage.completion_tokens_details?.reasoning_tokens ?? 0,
             costVal,
+            cache.cacheReadTokens,
+            cache.cacheCreationTokens,
           );
         }
         const rawMsg = choice.message as OpenAIMessage & { reasoning?: string; reasoning_content?: string };
@@ -247,6 +251,8 @@ export async function runToolLoop(
               : typeof topCost?.request_cost_usd === "number"
                 ? topCost.request_cost_usd
                 : undefined,
+            usage.cacheReadTokens,
+            usage.cacheCreationTokens,
           );
         },
       });

--- a/electron/lib/chat-subagent-loop.ts
+++ b/electron/lib/chat-subagent-loop.ts
@@ -25,7 +25,7 @@ import { TOOLS, type ChatRequest } from "./tools";
 import { runToolLoop, type RunToolLoopResult } from "./chat-loop";
 import { parseToolArgs } from "./parse-tool-args";
 import { buildAttachmentParts } from "../../shared/models/pdf-attach";
-import { recordLlmUsage, extractCost } from "./usage-recorder";
+import { recordLlmUsage, extractCost, extractCacheTokens } from "./usage-recorder";
 
 /** Loosely-typed OpenAI function tool — the synthetic dispatch tools ("research",
  *  "write") aren't in the schema-derived `typeof TOOLS` union, so we widen. */
@@ -167,6 +167,12 @@ export interface SubagentMetrics {
   dispatcherPromptTokens: number;
   dispatcherCompletionTokens: number;
   dispatcherReasoningTokens: number;
+  /** Cache tokens (read/creation) across the dispatcher + every subagent turn. */
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  /** The DISPATCHER's own cache tokens on its last turn (context semantics). */
+  dispatcherCacheReadTokens: number;
+  dispatcherCacheCreationTokens: number;
   toolCalls: number;
   toolErrors: number;
   subagentRuns: number;
@@ -210,7 +216,7 @@ export interface SubagentEvents {
   /** A tool call finished inside a subagent. */
   onSubagentToolCallDone?: (e: { childId: string; tool: string; cairnRef?: { type: "note" | "task"; id: string; title: string }; externalRef?: { url: string; title?: string; snippet?: string }; output?: string; callId?: string; ok?: boolean; error?: string }) => void;
   /** Latest token usage for a subagent (its OWN context window) — drives its ring. */
-  onSubagentUsage?: (e: { childId: string; promptTokens: number; completionTokens: number; reasoningTokens?: number; costUsd?: number }) => void;
+  onSubagentUsage?: (e: { childId: string; promptTokens: number; completionTokens: number; reasoningTokens?: number; costUsd?: number; cacheReadTokens?: number; cacheCreationTokens?: number }) => void;
 }
 
 const DISPATCH_SYSTEM_PROMPT = (date: string) =>
@@ -288,7 +294,7 @@ async function runSubagent(
     signal,
     getWin,
     cfg.provider,
-    (pt, ct, rt, cost) => {
+    (pt, ct, rt, cost, cacheRead, cacheCreate) => {
       // Persist one usage row per subagent round for the Usage view.
       recordLlmUsage({
         source: "chat-subagent",
@@ -301,15 +307,18 @@ async function runSubagent(
         promptTokens: pt,
         completionTokens: ct,
         reasoningTokens: rt ?? 0,
+        cacheReadTokens: cacheRead,
+        cacheCreationTokens: cacheCreate,
         costUsd: cost,
       });
       // Accumulate into the total-cost figures…
       metrics.promptTokens += pt; metrics.completionTokens += ct; if (rt) metrics.reasoningTokens += rt;
+      metrics.cacheReadTokens += cacheRead ?? 0; metrics.cacheCreationTokens += cacheCreate ?? 0;
       // …and report THIS subagent's own context window (its latest prompt size)
       // so the renderer can give it a dedicated ring. prompt_tokens is the size
       // of the context this turn, not a running sum — take the latest value.
       addCost(cost);
-      if (childId) events?.onSubagentUsage?.({ childId, promptTokens: pt, completionTokens: ct, reasoningTokens: rt, costUsd: costAcc.usd });
+      if (childId) events?.onSubagentUsage?.({ childId, promptTokens: pt, completionTokens: ct, reasoningTokens: rt, costUsd: costAcc.usd, cacheReadTokens: cacheRead, cacheCreationTokens: cacheCreate });
     },
     (e) => {
       // Count tool errors by sniffing the JSON output for an error field.
@@ -394,9 +403,12 @@ async function forceFinalAnswer(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data = await response.json() as any;
     if (data.usage) {
+      const cache = extractCacheTokens(data.usage);
       metrics.promptTokens += data.usage.prompt_tokens ?? 0;
       metrics.completionTokens += data.usage.completion_tokens ?? 0;
       metrics.reasoningTokens += data.usage.completion_tokens_details?.reasoning_tokens ?? 0;
+      metrics.cacheReadTokens += cache.cacheReadTokens;
+      metrics.cacheCreationTokens += cache.cacheCreationTokens;
       addCost?.(data.cost ?? data.usage?.cost);
       recordLlmUsage({
         source: "chat-subagent",
@@ -409,6 +421,8 @@ async function forceFinalAnswer(
         promptTokens: data.usage.prompt_tokens ?? 0,
         completionTokens: data.usage.completion_tokens ?? 0,
         reasoningTokens: data.usage.completion_tokens_details?.reasoning_tokens ?? 0,
+        cacheReadTokens: cache.cacheReadTokens,
+        cacheCreationTokens: cache.cacheCreationTokens,
         costUsd: extractCost(data.cost, data.usage),
       });
     }
@@ -460,6 +474,8 @@ export async function runDispatchLoop(
   const metrics: SubagentMetrics = {
     promptTokens: 0, completionTokens: 0, reasoningTokens: 0,
     dispatcherPromptTokens: 0, dispatcherCompletionTokens: 0, dispatcherReasoningTokens: 0,
+    cacheReadTokens: 0, cacheCreationTokens: 0,
+    dispatcherCacheReadTokens: 0, dispatcherCacheCreationTokens: 0,
     toolCalls: 0, toolErrors: 0, subagentRuns: 0,
     writeInvocations: 0, researchInvocations: 0,
   };
@@ -532,6 +548,7 @@ export async function runDispatchLoop(
       const pt = data.usage.prompt_tokens ?? 0;
       const ct = data.usage.completion_tokens ?? 0;
       const rt = data.usage.completion_tokens_details?.reasoning_tokens ?? 0;
+      const cache = extractCacheTokens(data.usage);
       // Persist one usage row per dispatcher round for the Usage view.
       recordLlmUsage({
         source: "chat-subagent",
@@ -544,12 +561,16 @@ export async function runDispatchLoop(
         promptTokens: pt,
         completionTokens: ct,
         reasoningTokens: rt,
+        cacheReadTokens: cache.cacheReadTokens,
+        cacheCreationTokens: cache.cacheCreationTokens,
         costUsd: extractCost(data.cost, data.usage),
       });
       // Total-cost figures accumulate across all turns…
       metrics.promptTokens += pt;
       metrics.completionTokens += ct;
       metrics.reasoningTokens += rt;
+      metrics.cacheReadTokens += cache.cacheReadTokens;
+      metrics.cacheCreationTokens += cache.cacheCreationTokens;
       // …but the dispatcher's CONTEXT is the latest turn's prompt size (system
       // prompt + subagent briefs fed back), NOT a running sum. This is what the
       // main/total ContextRing should reflect — the dispatcher never holds the
@@ -557,6 +578,8 @@ export async function runDispatchLoop(
       metrics.dispatcherPromptTokens = pt;
       metrics.dispatcherCompletionTokens += ct;
       metrics.dispatcherReasoningTokens += rt;
+      metrics.dispatcherCacheReadTokens = cache.cacheReadTokens;
+      metrics.dispatcherCacheCreationTokens = cache.cacheCreationTokens;
     }
     const costVal = typeof (data.cost as { request_cost_usd?: unknown } | undefined)?.request_cost_usd === "number"
       ? (data.cost as { request_cost_usd: number }).request_cost_usd

--- a/electron/lib/coding-tools/subagent.test.ts
+++ b/electron/lib/coding-tools/subagent.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression tests for electron/lib/coding-tools/subagent.ts — specifically the
+ * onUsage relay to the renderer.
+ *
+ * The subagent's `pi-agent:usage` event must forward every usage argument in
+ * AgentLoopCallbacks.onUsage order under its own field. A mis-shift here
+ * silently mislabels the subagent's context ring (reasoning tokens shown as
+ * breakdown, cache tokens dropped, etc.). We drive runAgentLoop's onUsage
+ * callback directly with distinct values and assert the exact payload.
+ */
+
+import { it, expect, vi, beforeEach } from "vitest";
+import { spawnSubagentTool, type SpawnSubagentArgs } from "./subagent";
+import { runAgentLoop, type AgentLLMConfig, type AgentToolContext, type AgentLoopCallbacks } from "../pi-agent-loop";
+
+vi.mock("../pi-agent-loop", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../pi-agent-loop")>();
+  return { ...mod, runAgentLoop: vi.fn() };
+});
+
+const runAgentLoopMock = vi.mocked(runAgentLoop);
+
+const LLM_CONFIG: AgentLLMConfig = {
+  baseUrl: "https://api.example.com",
+  model: "test-model",
+  apiKey: "key",
+  maxSteps: 5,
+  temperature: 0.3,
+};
+
+function makeToolCtx(send: (channel: string, payload: unknown) => void): AgentToolContext {
+  return {
+    cwd: "/tmp",
+    db: {} as AgentToolContext["db"],
+    req: { threadId: "parent", message: "x", config: {} } as AgentToolContext["req"],
+    workspacePath: "/tmp/ws",
+    sessionId: "parent",
+    send,
+  };
+}
+
+let callbacks: AgentLoopCallbacks;
+beforeEach(() => {
+  callbacks = undefined as unknown as AgentLoopCallbacks;
+  runAgentLoopMock.mockImplementation(async (
+    _session,
+    _systemPrompt,
+    _config,
+    cb: AgentLoopCallbacks,
+  ) => {
+    callbacks = cb;
+  });
+});
+
+it("forwards every onUsage argument under its own field (no shifting)", async () => {
+  const send = vi.fn();
+  const ctx = makeToolCtx(send);
+  const run = spawnSubagentTool({ prompt: "do a thing" } as SpawnSubagentArgs, ctx, LLM_CONFIG);
+  // runAgentLoop is mocked; let the async function reach the callback capture.
+  await new Promise((r) => setImmediate(r));
+  expect(callbacks).toBeDefined();
+
+  const breakdown = { systemPrompt: 10, skills: 0, tools: 1, conversation: 2, toolOutputs: 3, rules: 0, mcp: 0, subagentDefinitions: 4 };
+  callbacks.onUsage(111, 222, 333, breakdown, 0.44, 555, 666);
+  await run;
+
+  const usage = send.mock.calls.find(([ch]) => ch === "pi-agent:usage");
+  expect(usage).toBeDefined();
+  const [channel, payload] = usage as [string, Record<string, unknown>];
+
+  expect(channel).toBe("pi-agent:usage");
+  expect(String(payload.sessionId)).toMatch(/^parent:sub:/);
+  expect(payload).toMatchObject({
+    promptTokens: 111,
+    completionTokens: 222,
+    reasoningTokens: 333,
+    breakdown,
+    costUsd: 0.44,
+    cacheReadTokens: 555,
+    cacheCreationTokens: 666,
+  });
+  expect(String(payload.sessionId)).toBe(String(send.mock.calls.find(([ch]) => ch === "pi-agent:subagent")?.[1]?.childSessionId));
+});

--- a/electron/lib/coding-tools/subagent.ts
+++ b/electron/lib/coding-tools/subagent.ts
@@ -105,7 +105,7 @@ export async function spawnSubagentTool(
       onStepStart:  () => childToolCtx.send("pi-agent:step", { sessionId: childSessionId }),
       // Usage recording for the child happens inside runAgentLoop with source
       // "pi-subagent"; this callback only relays the renderer event.
-      onUsage:      (pt, ct, breakdown) => childToolCtx.send("pi-agent:usage", { sessionId: childSessionId, promptTokens: pt, completionTokens: ct, breakdown }),
+      onUsage:      (pt, ct, breakdown, _cost, cacheRead, cacheCreate) => childToolCtx.send("pi-agent:usage", { sessionId: childSessionId, promptTokens: pt, completionTokens: ct, breakdown, cacheReadTokens: cacheRead, cacheCreationTokens: cacheCreate }),
       onDone:       () => { /* handled below via session.messages */ },
       onError:      (msg) => { errorMessage = msg; },
     },

--- a/electron/lib/coding-tools/subagent.ts
+++ b/electron/lib/coding-tools/subagent.ts
@@ -104,8 +104,19 @@ export async function spawnSubagentTool(
       onToolEnd:     (name, label, ok, output, callId) => childToolCtx.send("pi-agent:tool", { sessionId: childSessionId, name, label, callId, status: "end", ok, output }),
       onStepStart:  () => childToolCtx.send("pi-agent:step", { sessionId: childSessionId }),
       // Usage recording for the child happens inside runAgentLoop with source
-      // "pi-subagent"; this callback only relays the renderer event.
-      onUsage:      (pt, ct, breakdown, _cost, cacheRead, cacheCreate) => childToolCtx.send("pi-agent:usage", { sessionId: childSessionId, promptTokens: pt, completionTokens: ct, breakdown, cacheReadTokens: cacheRead, cacheCreationTokens: cacheCreate }),
+      // "pi-subagent"; this callback only relays the renderer event. Args are in
+      // AgentLoopCallbacks.onUsage order — every value forwarded under its own
+      // field (a mis-shift here would silently mislabel the subagent's ring).
+      onUsage:      (promptTokens, completionTokens, reasoningTokens, breakdown, costUsd, cacheReadTokens, cacheCreationTokens) => childToolCtx.send("pi-agent:usage", {
+        sessionId: childSessionId,
+        promptTokens,
+        completionTokens,
+        reasoningTokens,
+        breakdown,
+        costUsd,
+        cacheReadTokens,
+        cacheCreationTokens,
+      }),
       onDone:       () => { /* handled below via session.messages */ },
       onError:      (msg) => { errorMessage = msg; },
     },

--- a/electron/lib/compaction.ts
+++ b/electron/lib/compaction.ts
@@ -19,7 +19,7 @@
 
 import type { AgentLLMConfig, AgentMessage, AgentToolResultMsg, PiAgentSession } from "./pi-agent-loop";
 import { buildApiUrl, postChatCompletions } from "./llm";
-import { recordLlmUsage, extractCost } from "./usage-recorder";
+import { recordLlmUsage, extractCost, extractCacheTokens } from "./usage-recorder";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -158,7 +158,7 @@ export async function generateSummary(
 
   const decoder = new TextDecoder();
   let content = "";
-  let usage: { pt?: number; ct?: number; rt?: number; chunkCost?: unknown; raw?: unknown } | undefined;
+  let usage: { pt?: number; ct?: number; rt?: number; cacheRead?: number; cacheCreate?: number; chunkCost?: unknown; raw?: unknown } | undefined;
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
@@ -170,10 +170,13 @@ export async function generateSummary(
       try {
         const obj = JSON.parse(jsonStr);
         if (obj.usage) {
+          const cache = extractCacheTokens(obj.usage);
           usage = {
             pt: obj.usage.prompt_tokens ?? 0,
             ct: obj.usage.completion_tokens ?? 0,
             rt: obj.usage.completion_tokens_details?.reasoning_tokens ?? 0,
+            cacheRead: cache.cacheReadTokens,
+            cacheCreate: cache.cacheCreationTokens,
             chunkCost: obj.cost,
             raw: obj.usage,
           };
@@ -196,6 +199,8 @@ export async function generateSummary(
       promptTokens: usage.pt ?? 0,
       completionTokens: usage.ct ?? 0,
       reasoningTokens: usage.rt ?? 0,
+      cacheReadTokens: usage.cacheRead,
+      cacheCreationTokens: usage.cacheCreate,
       costUsd: extractCost(usage.chunkCost, usage.raw),
     });
   }

--- a/electron/lib/heartbeat-runner.ts
+++ b/electron/lib/heartbeat-runner.ts
@@ -239,7 +239,7 @@ export async function runAutomation(
     provider,
     // Persist one usage row per automation round for the Usage view (previously
     // usage was never captured for background runs).
-    (pt, ct, rt, costUsd) => {
+    (pt, ct, rt, costUsd, cacheRead, cacheCreate) => {
       recordLlmUsage({
         source: "automation",
         sessionId: run.id,
@@ -251,6 +251,8 @@ export async function runAutomation(
         promptTokens: pt,
         completionTokens: ct,
         reasoningTokens: rt ?? 0,
+        cacheReadTokens: cacheRead,
+        cacheCreationTokens: cacheCreate,
         costUsd,
       });
     },

--- a/electron/lib/llm-stream.ts
+++ b/electron/lib/llm-stream.ts
@@ -26,6 +26,7 @@
 
 import { iterSseData } from "./sse";
 import { isSendableMessage, type OpenAIMessage } from "./llm";
+import { extractCacheTokens } from "./usage-recorder";
 
 /** Reasoning field names used by OpenAI-compatible providers, in priority order. */
 export const REASONING_FIELDS = ["reasoning_content", "reasoning", "reasoning_text"] as const;
@@ -44,6 +45,10 @@ export interface StreamUsage {
   promptTokens: number;
   completionTokens: number;
   reasoningTokens: number;
+  /** Prompt tokens served from the provider's cache (Anthropic-style / OpenAI cached_tokens). */
+  cacheReadTokens: number;
+  /** Prompt tokens written to the provider's cache (Anthropic-style). 0 when not split out. */
+  cacheCreationTokens: number;
   /** Raw provider `usage` object (may carry provider-specific fields like cost). */
   raw: unknown;
   /** Raw top-level `cost` field on the chunk, if the provider reports it there. */
@@ -110,10 +115,13 @@ export async function consumeAssistantStream(
 
     // Usage chunk — sent as the final SSE chunk when stream_options.include_usage is set.
     if (c.usage) {
+      const cache = extractCacheTokens(c.usage);
       opts.onUsage?.({
         promptTokens: c.usage.prompt_tokens ?? 0,
         completionTokens: c.usage.completion_tokens ?? 0,
         reasoningTokens: c.usage.completion_tokens_details?.reasoning_tokens ?? 0,
+        cacheReadTokens: cache.cacheReadTokens,
+        cacheCreationTokens: cache.cacheCreationTokens,
         raw: c.usage,
         chunkCost: c.cost,
       });

--- a/electron/lib/llm.ts
+++ b/electron/lib/llm.ts
@@ -4,7 +4,7 @@
 
 import { encode } from "gpt-tokenizer";
 import { pdfTokenEstimate } from "../../shared/models/pdf-attach";
-import { recordLlmUsage, extractCost } from "./usage-recorder";
+import { recordLlmUsage, extractCost, extractCacheTokens } from "./usage-recorder";
 import type { UsageSource } from "../db/usage-queries";
 
 /**
@@ -160,6 +160,8 @@ export async function callLLM(
     rt: number,
     cost?: number,
     meta?: { provider?: string; model?: string; baseUrl?: string },
+    cacheReadTokens?: number,
+    cacheCreationTokens?: number,
   ) => {
     recordLlmUsage({
       source: opts.source ?? "chat",
@@ -172,6 +174,8 @@ export async function callLLM(
       promptTokens: pt,
       completionTokens: ct,
       reasoningTokens: rt,
+      cacheReadTokens,
+      cacheCreationTokens,
       costUsd: cost,
     });
   };
@@ -194,12 +198,15 @@ export async function callLLM(
     const content = res.choices?.[0]?.message?.content ?? "";
     const usage = res?.usage;
     if (usage) {
+      const cache = extractCacheTokens(usage);
       record(
         usage.prompt_tokens ?? 0,
         usage.completion_tokens ?? 0,
         usage.completion_tokens_details?.reasoning_tokens ?? 0,
         extractCost(res?.cost, usage),
         localMeta,
+        cache.cacheReadTokens,
+        cache.cacheCreationTokens,
       );
     } else {
       record(tok(systemPrompt) + tok(userPrompt), tok(content), 0, undefined, localMeta);
@@ -232,7 +239,7 @@ export async function callLLM(
 
   const decoder = new TextDecoder();
   let content = "";
-  let usage: { pt?: number; ct?: number; rt?: number; chunkCost?: unknown; raw?: unknown } | undefined;
+  let usage: { pt?: number; ct?: number; rt?: number; cacheRead?: number; cacheCreate?: number; chunkCost?: unknown; raw?: unknown } | undefined;
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
@@ -244,10 +251,13 @@ export async function callLLM(
       try {
         const obj = JSON.parse(jsonStr);
         if (obj.usage) {
+          const cache = extractCacheTokens(obj.usage);
           usage = {
             pt: obj.usage.prompt_tokens ?? 0,
             ct: obj.usage.completion_tokens ?? 0,
             rt: obj.usage.completion_tokens_details?.reasoning_tokens ?? 0,
+            cacheRead: cache.cacheReadTokens,
+            cacheCreate: cache.cacheCreationTokens,
             chunkCost: obj.cost,
             raw: obj.usage,
           };
@@ -259,7 +269,7 @@ export async function callLLM(
   }
 
   if (usage) {
-    record(usage.pt ?? 0, usage.ct ?? 0, usage.rt ?? 0, extractCost(usage.chunkCost, usage.raw));
+    record(usage.pt ?? 0, usage.ct ?? 0, usage.rt ?? 0, extractCost(usage.chunkCost, usage.raw), undefined, usage.cacheRead, usage.cacheCreate);
   } else {
     record(tok(systemPrompt) + tok(userPrompt), tok(content), 0);
   }

--- a/electron/lib/model-pricing.test.ts
+++ b/electron/lib/model-pricing.test.ts
@@ -8,6 +8,7 @@ import { setModelPricing, pricePerMillion, estimateCostUsd } from "./model-prici
 const PRICING = {
   "deepseek-v4-flash": { input: 0.04, output: 0.12 },
   "gpt-4o": { input: 2.5, output: 10 },
+  "claude-cached": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
 };
 
 describe("model-pricing", () => {
@@ -15,6 +16,32 @@ describe("model-pricing", () => {
 
   it("returns the exact price for a known model", () => {
     expect(pricePerMillion("gpt-4o")).toEqual({ input: 2.5, output: 10 });
+  });
+
+  it("exposes cache read/write prices when the model prices them", () => {
+    expect(pricePerMillion("claude-cached")).toEqual({ input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 });
+  });
+
+  it("prices cached input at the cache_read rate instead of full input", () => {
+    // 1M prompt with 600K served from cache @ claude-cached rates:
+    //   400K fresh * $3 + 600K cache read * $0.3 + 100K output * $15
+    expect(estimateCostUsd("claude-cached", 1_000_000, 100_000, 600_000, 0))
+      .toBeCloseTo(0.4 * 3 + 0.6 * 0.3 + 0.1 * 15, 6);
+  });
+
+  it("prices cache writes at the cache_write rate and falls back to input when unknown", () => {
+    // 400K fresh + 200K cache write + 400K cache read + 0 output
+    expect(estimateCostUsd("claude-cached", 1_000_000, 0, 400_000, 200_000))
+      .toBeCloseTo(0.4 * 3 + 0.2 * 3.75 + 0.4 * 0.3, 6);
+    // Model without cache prices → cached tokens billed at the input rate.
+    expect(estimateCostUsd("gpt-4o", 1_000_000, 0, 600_000, 0))
+      .toBeCloseTo(0.4 * 2.5 + 0.6 * 2.5, 6);
+  });
+
+  it("clamps cache counts that exceed the prompt size", () => {
+    // cacheRead clamps to promptTokens; never a negative fresh portion.
+    expect(estimateCostUsd("gpt-4o", 1000, 0, 5000, 0))
+      .toBeCloseTo((1000 / 1e6) * 2.5, 6);
   });
 
   it("returns null for an unknown model", () => {

--- a/electron/lib/model-pricing.ts
+++ b/electron/lib/model-pricing.ts
@@ -2,19 +2,28 @@
  * Cairn — models.dev pricing cache (main process).
  *
  * The renderer owns the models.dev catalog (fetched once per run, cached in
- * localStorage). It pushes a compact `modelId → { input, output }` pricing map
- * (USD per 1M tokens) over IPC once the catalog loads; this module holds it and
- * lets the usage recorder estimate cost for providers that don't report it.
+ * localStorage). It pushes a compact `modelId → pricing` map (USD per 1M
+ * tokens) over IPC once the catalog loads; this module holds it and lets the
+ * usage recorder estimate cost for providers that don't report it.
  */
 
-let pricing: Record<string, { input: number | null; output: number | null }> | null = null;
+export interface ModelPrice {
+  input: number | null;
+  output: number | null;
+  /** USD per 1M prompt-cache-read tokens (models.dev cost.cache_read). */
+  cacheRead?: number | null;
+  /** USD per 1M prompt-cache-write tokens (models.dev cost.cache_write). */
+  cacheWrite?: number | null;
+}
 
-export function setModelPricing(map: Record<string, { input: number | null; output: number | null }> | null): void {
+let pricing: Record<string, ModelPrice> | null = null;
+
+export function setModelPricing(map: Record<string, ModelPrice> | null): void {
   pricing = map && Object.keys(map).length > 0 ? map : null;
 }
 
 /** USD per 1M tokens for a model id, or null when unknown. */
-export function pricePerMillion(model: string): { input: number | null; output: number | null } | null {
+export function pricePerMillion(model: string): ModelPrice | null {
   if (!pricing || !model) return null;
   const exact = pricing[model];
   if (exact) return exact;
@@ -34,13 +43,36 @@ export function pricePerMillion(model: string): { input: number | null; output: 
 /**
  * Estimate the USD cost of a request from models.dev per-1M pricing.
  * Returns undefined when pricing is unknown for the model or there are no tokens.
+ *
+ * Cache-aware: when the provider reports cache-read/creation token counts, the
+ * cached portions are priced at the model's cache rates (falling back to the
+ * full input rate when the catalog doesn't price them) instead of the full
+ * input rate — mirroring how providers actually bill prompt caching. The
+ * provider's own `usage.cost` (when present) already accounts for this.
  */
-export function estimateCostUsd(model: string, promptTokens: number, completionTokens: number): number | undefined {
+export function estimateCostUsd(
+  model: string,
+  promptTokens: number,
+  completionTokens: number,
+  cacheReadTokens = 0,
+  cacheCreationTokens = 0,
+): number | undefined {
   const price = pricePerMillion(model);
   if (!price) return undefined;
   const input = price.input ?? 0;
   const output = price.output ?? 0;
+  const cacheReadPrice = price.cacheRead ?? input;
+  const cacheWritePrice = price.cacheWrite ?? input;
   if (input <= 0 && output <= 0) return undefined;
   if (promptTokens <= 0 && completionTokens <= 0) return undefined;
-  return (promptTokens / 1e6) * input + (completionTokens / 1e6) * output;
+
+  const read = Math.max(0, Math.min(cacheReadTokens, promptTokens));
+  const write = Math.max(0, Math.min(cacheCreationTokens, promptTokens - read));
+  const fresh = Math.max(0, promptTokens - read - write);
+
+  const promptCost =
+    (fresh / 1e6) * input +
+    (read / 1e6) * cacheReadPrice +
+    (write / 1e6) * cacheWritePrice;
+  return promptCost + (completionTokens / 1e6) * output;
 }

--- a/electron/lib/pi-agent-loop.ts
+++ b/electron/lib/pi-agent-loop.ts
@@ -158,7 +158,7 @@ export interface AgentLoopCallbacks {
   /** callId links back to the same chip created by onToolPending / updated by onToolStart. */
   onToolEnd:       (name: string, label: string, ok: boolean, output: string, callId?: string, args?: ToolArgs) => void;
   onStepStart:     () => void;
-  onUsage:         (promptTokens: number, completionTokens: number, reasoningTokens: number, breakdown?: TokenBreakdown, costUsd?: number) => void;
+  onUsage:         (promptTokens: number, completionTokens: number, reasoningTokens: number, breakdown?: TokenBreakdown, costUsd?: number, cacheReadTokens?: number, cacheCreationTokens?: number) => void;
   onDone:          () => void;
   onError:         (message: string) => void;
   /** Fired when a tool call needs user confirmation before execution. */
@@ -690,6 +690,7 @@ export async function runAgentLoop(
         const pt = usage.promptTokens;
         const ct = usage.completionTokens;
         const rt = usage.reasoningTokens;
+        const cost = extractCost(usage.chunkCost, usage.raw);
         // Persist one usage row per agent round for the Usage view.
         recordLlmUsage({
           source: usageSource,
@@ -702,7 +703,9 @@ export async function runAgentLoop(
           promptTokens: pt,
           completionTokens: ct,
           reasoningTokens: rt,
-          costUsd: extractCost(usage.chunkCost, usage.raw),
+          cacheReadTokens: usage.cacheReadTokens,
+          cacheCreationTokens: usage.cacheCreationTokens,
+          costUsd: cost,
         });
         session.lastPromptTokens = pt;
         // Accumulate completion + reasoning across rounds (total output for the turn).
@@ -716,7 +719,7 @@ export async function runAgentLoop(
         } catch (err) {
           console.error("[pi-agent] failed to calculate breakdown:", err);
         }
-        callbacks.onUsage(pt, session.totalCompletionTokens ?? 0, session.totalReasoningTokens ?? 0, breakdown, extractCost(usage.chunkCost, usage.raw));
+        callbacks.onUsage(pt, session.totalCompletionTokens ?? 0, session.totalReasoningTokens ?? 0, breakdown, cost, usage.cacheReadTokens, usage.cacheCreationTokens);
       },
     });
 

--- a/electron/lib/usage-recorder.test.ts
+++ b/electron/lib/usage-recorder.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { resolveProviderName, extractCost } from "./usage-recorder";
+import { resolveProviderName, extractCost, extractCacheTokens } from "./usage-recorder";
 
 describe("resolveProviderName", () => {
   it("resolves well-known providers from the base URL hostname", () => {
@@ -48,5 +48,35 @@ describe("extractCost", () => {
   });
   it("returns undefined when the provider reports nothing", () => {
     expect(extractCost(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("extractCacheTokens", () => {
+  it("reads Anthropic-style top-level cache fields", () => {
+    expect(extractCacheTokens({ cache_read_input_tokens: 1200, cache_creation_input_tokens: 300 }))
+      .toEqual({ cacheReadTokens: 1200, cacheCreationTokens: 300 });
+  });
+
+  it("reads OpenAI-style prompt_tokens_details.cached_tokens", () => {
+    expect(extractCacheTokens({ prompt_tokens_details: { cached_tokens: 800 } }))
+      .toEqual({ cacheReadTokens: 800, cacheCreationTokens: 0 });
+  });
+
+  it("sums compatible gateway variants", () => {
+    expect(extractCacheTokens({
+      cache_read_input_tokens: 100,
+      prompt_tokens_details: { cached_tokens: 50, cache_creation_tokens: 20 },
+    })).toEqual({ cacheReadTokens: 150, cacheCreationTokens: 20 });
+  });
+
+  it("returns zeros when the provider reports no cache fields", () => {
+    expect(extractCacheTokens({ prompt_tokens: 1000 })).toEqual({ cacheReadTokens: 0, cacheCreationTokens: 0 });
+    expect(extractCacheTokens(undefined)).toEqual({ cacheReadTokens: 0, cacheCreationTokens: 0 });
+    expect(extractCacheTokens("nope")).toEqual({ cacheReadTokens: 0, cacheCreationTokens: 0 });
+  });
+
+  it("ignores negative / non-numeric values", () => {
+    expect(extractCacheTokens({ cache_read_input_tokens: -5, cache_creation_input_tokens: "x" }))
+      .toEqual({ cacheReadTokens: 0, cacheCreationTokens: 0 });
   });
 });

--- a/electron/lib/usage-recorder.ts
+++ b/electron/lib/usage-recorder.ts
@@ -162,6 +162,38 @@ export function resolveProviderName(baseUrl?: string, providerSlug?: string): st
   return "OpenAI";
 }
 
+/** Tokens served from / written to the provider's prompt cache. */
+export interface CacheTokens {
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+}
+
+/**
+ * Normalise provider-reported prompt-cache token counts from the various
+ * shapes seen across OpenAI-compatible endpoints. Handles the Anthropic-style
+ * top-level fields (`cache_read_input_tokens`, `cache_creation_input_tokens`)
+ * and the OpenAI-style nested `prompt_tokens_details.cached_tokens` (plus a
+ * couple of compatible variants some gateways use). Returns zeros when the
+ * provider reported none — callers treat that as "no caching".
+ */
+export function extractCacheTokens(raw: unknown): CacheTokens {
+  if (!raw || typeof raw !== "object") return { cacheReadTokens: 0, cacheCreationTokens: 0 };
+  const u = raw as Record<string, unknown>;
+  const details = (u.prompt_tokens_details ?? {}) as Record<string, unknown>;
+  const num = (v: unknown): number =>
+    typeof v === "number" && Number.isFinite(v) && v >= 0 ? Math.round(v) : 0;
+  return {
+    cacheReadTokens:
+      num(u.cache_read_input_tokens) +
+      num(details.cached_tokens) +
+      num(details.cache_read_input_tokens),
+    cacheCreationTokens:
+      num(u.cache_creation_input_tokens) +
+      num(details.cache_creation_input_tokens) +
+      num(details.cache_creation_tokens),
+  };
+}
+
 /**
  * Normalise provider-reported cost from the various shapes seen across
  * OpenAI-compatible endpoints. Accepts a top-level `cost` on the chunk
@@ -202,6 +234,10 @@ export interface RecordUsageArgs {
   promptTokens?: number;
   completionTokens?: number;
   reasoningTokens?: number;
+  /** Prompt tokens served from the provider's cache (billed at the cache_read rate). */
+  cacheReadTokens?: number;
+  /** Prompt tokens written to the provider's cache (billed at the cache_write rate). */
+  cacheCreationTokens?: number;
   costUsd?: number;
   /** True when the caller already knows the cost is a models.dev estimate. */
   costEstimated?: boolean;
@@ -222,11 +258,19 @@ export function recordLlmUsage(entry: RecordUsageArgs): void {
       resolveProviderName(entry.baseUrl, entry.provider);
 
     // When the provider doesn't report cost, estimate it from models.dev
-    // per-1M pricing (flagged so the UI can mark it as an estimate).
+    // per-1M pricing (flagged so the UI can mark it as an estimate). The
+    // estimate is cache-aware — cached input is priced at the model's cache
+    // rates instead of full input, so cache hits don't over-bill.
     let costUsd = entry.costUsd;
     let costEstimated = entry.costEstimated ?? false;
     if (costUsd == null) {
-      const estimate = estimateCostUsd(entry.model, entry.promptTokens ?? 0, entry.completionTokens ?? 0);
+      const estimate = estimateCostUsd(
+        entry.model,
+        entry.promptTokens ?? 0,
+        entry.completionTokens ?? 0,
+        entry.cacheReadTokens ?? 0,
+        entry.cacheCreationTokens ?? 0,
+      );
       if (estimate != null) {
         costUsd = estimate;
         costEstimated = true;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -156,7 +156,7 @@ type UsageSource =
   | "summary" | "tool-builder";
 interface UsageTotals {
   promptTokens: number; completionTokens: number; reasoningTokens: number;
-  costUsd: number; requests: number;
+  cacheReadTokens: number; costUsd: number; requests: number;
 }
 interface UsageOverviewData {
   totals: UsageTotals;
@@ -169,6 +169,7 @@ interface UsageRecentRow {
   id: string; workspaceId: string | null; projectId: string | null; source: UsageSource;
   sessionId: string | null; provider: string | null; model: string; baseUrl: string | null;
   promptTokens: number; completionTokens: number; reasoningTokens: number;
+  cacheReadTokens: number; cacheCreationTokens: number;
   costUsd: number | null; costEstimated: boolean; finishReason: string | null; createdAt: number;
 }
 
@@ -324,7 +325,7 @@ const api = {
       ipcRenderer.on("chat:thought", handler);
       return () => ipcRenderer.off("chat:thought", handler);
     },
-    onDone: (cb: (e: { content: string; reasoning?: string; contextRefs: unknown[]; error?: string; threadId?: string; usage?: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: unknown; costUsd?: number } }) => void) => {
+    onDone: (cb: (e: { content: string; reasoning?: string; contextRefs: unknown[]; error?: string; threadId?: string; usage?: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: unknown; costUsd?: number; cacheReadTokens?: number; cacheCreationTokens?: number } }) => void) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const handler = (_: any, e: { content: string; reasoning?: string; contextRefs: unknown[]; error?: string; threadId?: string }) => cb(e);
       ipcRenderer.on("chat:done", handler);
@@ -342,9 +343,9 @@ const api = {
       ipcRenderer.on("chat:tool-call-done", handler);
       return () => ipcRenderer.off("chat:tool-call-done", handler);
     },
-    onUsage: (cb: (e: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: unknown; costUsd?: number; threadId?: string }) => void) => {
+    onUsage: (cb: (e: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: unknown; costUsd?: number; cacheReadTokens?: number; cacheCreationTokens?: number; threadId?: string }) => void) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const handler = (_: any, e: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: unknown; costUsd?: number; threadId?: string }) => cb(e);
+      const handler = (_: any, e: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: unknown; costUsd?: number; cacheReadTokens?: number; cacheCreationTokens?: number; threadId?: string }) => cb(e);
       ipcRenderer.on("chat:usage", handler);
       return () => ipcRenderer.off("chat:usage", handler);
     },
@@ -379,7 +380,7 @@ const api = {
       ipcRenderer.on("chat:subagent-tool-call-done", handler);
       return () => ipcRenderer.off("chat:subagent-tool-call-done", handler);
     },
-    onSubagentUsage: (cb: (e: { childId: string; promptTokens: number; completionTokens: number; reasoningTokens?: number; costUsd?: number; threadId?: string }) => void) => {
+    onSubagentUsage: (cb: (e: { childId: string; promptTokens: number; completionTokens: number; reasoningTokens?: number; costUsd?: number; cacheReadTokens?: number; cacheCreationTokens?: number; threadId?: string }) => void) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const handler = (_: any, e: any) => cb(e);
       ipcRenderer.on("chat:subagent-usage", handler);
@@ -467,12 +468,12 @@ const api = {
 
   // ── Usage statistics (LLM/agent usage log) ─────
   usage: {
-    overview: (args: { workspaceId?: string; source?: UsageSource; from?: number; to?: number }) =>
+    overview: (args: { workspaceId?: string; source?: UsageSource; from?: number; to?: number; excludeEstimated?: boolean }) =>
       invoke<UsageOverviewData>("usage:overview", args),
-    recent: (args: { workspaceId?: string; source?: UsageSource; from?: number; to?: number; limit?: number }) =>
+    recent: (args: { workspaceId?: string; source?: UsageSource; from?: number; to?: number; limit?: number; excludeEstimated?: boolean }) =>
       invoke<UsageRecentRow[]>("usage:recent", args),
     /** Push the models.dev per-1M pricing map (used for cost estimation). */
-    setPricing: (map: Record<string, { input: number | null; output: number | null }>) =>
+    setPricing: (map: Record<string, { input: number | null; output: number | null; cacheRead?: number | null; cacheWrite?: number | null }>) =>
       invoke<{ ok: boolean }>("app:modelPricing", map),
   },
 
@@ -927,9 +928,9 @@ const api = {
       ipcRenderer.on("pi-agent:step", handler);
       return () => ipcRenderer.off("pi-agent:step", handler);
     },
-    onUsage: (cb: (e: { sessionId: string; promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: unknown }) => void) => {
+    onUsage: (cb: (e: { sessionId: string; promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: unknown; cacheReadTokens?: number; cacheCreationTokens?: number }) => void) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const handler = (_: any, e: { sessionId: string; promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: unknown }) => cb(e);
+      const handler = (_: any, e: { sessionId: string; promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: unknown; cacheReadTokens?: number; cacheCreationTokens?: number }) => cb(e);
       ipcRenderer.on("pi-agent:usage", handler);
       return () => ipcRenderer.off("pi-agent:usage", handler);
     },

--- a/shared/models/model-catalog.test.ts
+++ b/shared/models/model-catalog.test.ts
@@ -47,6 +47,8 @@ describe("parseModelCatalog", () => {
       maxOutput: 128000,
       input: 1.25,
       output: 10,
+      cacheRead: null,
+      cacheWrite: null,
       modes: ["text", "image", "pdf"],
       toolCall: true,
       reasoning: true,
@@ -57,6 +59,8 @@ describe("parseModelCatalog", () => {
       maxOutput: null,
       input: null,
       output: null,
+      cacheRead: null,
+      cacheWrite: null,
       modes: [],
       toolCall: null,
       reasoning: null,
@@ -73,6 +77,8 @@ describe("parseModelCatalog", () => {
       maxOutput: null,
       input: null,
       output: null,
+      cacheRead: null,
+      cacheWrite: null,
       modes: [],
       toolCall: null,
       reasoning: null,
@@ -163,8 +169,15 @@ describe("resolveMaxOutputTokens", () => {
 
 describe("normalizeModelInfo", () => {
   it("passes well-formed entries through unchanged", () => {
-    const info = { context: 1000, maxOutput: 8000, input: 1, output: 2, modes: ["text"], toolCall: true, reasoning: true, provider: "x" };
+    const info = { context: 1000, maxOutput: 8000, input: 1, output: 2, cacheRead: 3, cacheWrite: 4, modes: ["text"], toolCall: true, reasoning: true, provider: "x" };
     expect(normalizeModelInfo(info as never)).toEqual(info);
+  });
+
+  it("defaults cacheRead/cacheWrite to null when a legacy cache entry lacks them", () => {
+    const legacy = { context: 1000, input: 1, output: 2, modes: ["text"], toolCall: true, provider: "x" };
+    const norm = normalizeModelInfo(legacy as never);
+    expect(norm?.cacheRead).toBeNull();
+    expect(norm?.cacheWrite).toBeNull();
   });
 
   it("defaults maxOutput to null when a legacy cache entry lacks it", () => {

--- a/shared/models/model-catalog.ts
+++ b/shared/models/model-catalog.ts
@@ -24,6 +24,10 @@ export interface ModelInfo {  /** Context window in tokens (limit.context). */
   input: number | null;
   /** USD per 1M output tokens (cost.output). */
   output: number | null;
+  /** USD per 1M prompt-cache-read tokens (cost.cache_read), when the model prices cache hits. */
+  cacheRead: number | null;
+  /** USD per 1M prompt-cache-write tokens (cost.cache_write), when the model prices cache writes. */
+  cacheWrite: number | null;
   /** Input modalities (modalities.input): text, image, pdf, video, audio… */
   modes: string[];
   /** Whether the model supports tool calls, when known. */
@@ -292,6 +296,8 @@ export function normalizeModelInfo(info: ModelInfo | null | undefined): ModelInf
     maxOutput: positiveTokenLimit(info.maxOutput),
     input: typeof info.input === "number" ? info.input : null,
     output: typeof info.output === "number" ? info.output : null,
+    cacheRead: typeof info.cacheRead === "number" ? info.cacheRead : null,
+    cacheWrite: typeof info.cacheWrite === "number" ? info.cacheWrite : null,
     modes,
     toolCall: typeof info.toolCall === "boolean" ? info.toolCall : null,
     reasoning: typeof info.reasoning === "boolean" ? info.reasoning : null,
@@ -312,7 +318,7 @@ export function parseModelCatalog(catalog: unknown): Record<string, ModelInfo> {
     for (const [id, model] of Object.entries(models as Record<string, unknown>)) {
       const m = model as {
         limit?: { context?: unknown; output?: unknown };
-        cost?: { input?: unknown; output?: unknown };
+        cost?: { input?: unknown; output?: unknown; cache_read?: unknown; cache_write?: unknown };
         modalities?: { input?: unknown };
         tool_call?: unknown;
         reasoning?: unknown;
@@ -327,6 +333,8 @@ export function parseModelCatalog(catalog: unknown): Record<string, ModelInfo> {
         maxOutput: positiveTokenLimit(m.limit?.output),
         input: readNum(m.cost?.input),
         output: readNum(m.cost?.output),
+        cacheRead: readNum(m.cost?.cache_read),
+        cacheWrite: readNum(m.cost?.cache_write),
         modes: inModes,
         toolCall: typeof m.tool_call === "boolean" ? m.tool_call : null,
         reasoning: typeof m.reasoning === "boolean" ? m.reasoning : null,

--- a/src/components/agent/AgentChatPane.tsx
+++ b/src/components/agent/AgentChatPane.tsx
@@ -246,10 +246,10 @@ export function AgentChatPane({ session, isActive }: AgentChatPaneProps) {
     const unsubUsage = electron.piAgent.onUsage((e) => {
       if (e.sessionId === sessionId) {
         // Parent step — update the parent ring
-        updatePiUsage(sessionId, e.promptTokens, e.completionTokens, e.reasoningTokens ?? 0, e.breakdown as TokenBreakdown | undefined);
+        updatePiUsage(sessionId, e.promptTokens, e.completionTokens, e.reasoningTokens ?? 0, e.breakdown as TokenBreakdown | undefined, e.cacheReadTokens, e.cacheCreationTokens);
       } else if (e.sessionId.startsWith(`${sessionId}:sub:`)) {
         // Subagent step — update usage on the subagent inline block, not the parent ring
-        updatePiSubagentUsage(sessionId, e.sessionId, e.promptTokens, e.completionTokens, e.reasoningTokens ?? 0, e.breakdown as TokenBreakdown | undefined);
+        updatePiSubagentUsage(sessionId, e.sessionId, e.promptTokens, e.completionTokens, e.reasoningTokens ?? 0, e.breakdown as TokenBreakdown | undefined, e.cacheReadTokens, e.cacheCreationTokens);
       }
     });
 
@@ -661,6 +661,8 @@ export function AgentChatPane({ session, isActive }: AgentChatPaneProps) {
             breakdown={session.lastUsage.breakdown}
             completionTokens={session.lastUsage.completionTokens}
             reasoningTokens={session.lastUsage.reasoningTokens}
+            cacheReadTokens={session.lastUsage.cacheReadTokens}
+            cacheCreationTokens={session.lastUsage.cacheCreationTokens}
             costUsd={session.lastUsage.costUsd}
           />
         )}

--- a/src/components/agent/AgentMessageBubble.tsx
+++ b/src/components/agent/AgentMessageBubble.tsx
@@ -183,6 +183,8 @@ function SubagentBlock({ sub }: { sub: PiSubagentMessage }) {
             breakdown={sub.lastUsage.breakdown}
             completionTokens={sub.lastUsage.completionTokens}
             reasoningTokens={sub.lastUsage.reasoningTokens}
+            cacheReadTokens={sub.lastUsage.cacheReadTokens}
+            cacheCreationTokens={sub.lastUsage.cacheCreationTokens}
             costUsd={sub.lastUsage.costUsd}
             showBalance={false}
             size={12}

--- a/src/components/agent/ContextRing.tsx
+++ b/src/components/agent/ContextRing.tsx
@@ -115,6 +115,10 @@ interface ContextRingProps {
   completionTokens?: number;
   /** Subset of completionTokens spent on reasoning/thinking. 0/undefined if the model didn't split. */
   reasoningTokens?: number;
+  /** Prompt tokens served from the provider's cache this turn (0 when the provider doesn't cache/report). */
+  cacheReadTokens?: number;
+  /** Prompt tokens written to the provider's cache this turn (0 when not split out). */
+  cacheCreationTokens?: number;
   /** Provider-reported USD cost of the turn (e.g. Neuralwatt usage.cost), when present. */
   costUsd?: number;
   /** Show the account-level provider balance row (default true; off for subagent rings). */
@@ -131,6 +135,8 @@ export function ContextRing({
   breakdown,
   completionTokens,
   reasoningTokens,
+  cacheReadTokens,
+  cacheCreationTokens,
   costUsd,
   showBalance = true,
   size = 16,
@@ -138,6 +144,10 @@ export function ContextRing({
 }: ContextRingProps) {
   const [isOpen, setIsOpen] = useState(false);
   const balance = useProviderBalance(showBalance);
+
+  const cacheRead = cacheReadTokens ?? 0;
+  const cacheCreation = cacheCreationTokens ?? 0;
+  const hasCache = cacheRead > 0 || cacheCreation > 0;
 
   const pct  = Math.min(promptTokens / contextLimit, 1);
   const r    = (size - stroke) / 2;
@@ -215,7 +225,11 @@ export function ContextRing({
         trigger
       ) : (
         <Tooltip
-          content={`Context: ${promptTokens.toLocaleString()} / ${contextLimit.toLocaleString()} tokens (${pctLabel})`}
+          content={
+            hasCache
+              ? `Context: ${promptTokens.toLocaleString()} / ${contextLimit.toLocaleString()} tokens (${pctLabel}) · ${formatTokenCount(cacheRead)} cached`
+              : `Context: ${promptTokens.toLocaleString()} / ${contextLimit.toLocaleString()} tokens (${pctLabel})`
+          }
           side="bottom"
         >
           {trigger}
@@ -301,6 +315,32 @@ export function ContextRing({
                 <span className="text-[var(--text-tertiary)]">Total</span>
                 <span className="font-mono text-[var(--text-tertiary)]">{formatTokenCount(completionTokens)}</span>
               </div>
+            </div>
+          )}
+
+          {/* Prompt cache — tokens served from / written to the provider's cache
+              (Anthropic cache_read_input_tokens / OpenAI cached_tokens). Shown
+              whenever the provider reported any cached tokens this turn. */}
+          {hasCache && (
+            <div className="mt-3 pt-3 border-t border-[var(--border)] space-y-1.5">
+              <div className="flex items-center justify-between text-[0.714rem]">
+                <span className="flex items-center gap-1.5 text-[var(--text-secondary)]">
+                  <div className="w-2.5 h-2.5 rounded-sm opacity-90" style={{ backgroundColor: "var(--warning)" }} />
+                  Prompt cache
+                </span>
+                <span className="font-mono text-[var(--text-primary)] font-medium">
+                  {formatTokenCount(cacheRead)} read
+                  {cacheCreation > 0 && <span className="text-[var(--text-tertiary)]"> · {formatTokenCount(cacheCreation)} written</span>}
+                </span>
+              </div>
+              {cacheRead > 0 && promptTokens > 0 && (
+                <div className="flex items-center justify-between text-[0.714rem]">
+                  <span className="text-[var(--text-tertiary)]">% of input cached</span>
+                  <span className="font-mono text-[var(--text-tertiary)]">
+                    {Math.round((cacheRead / promptTokens) * 100)}%
+                  </span>
+                </div>
+              )}
             </div>
           )}
 

--- a/src/components/agent/SpawnAgentModal.tsx
+++ b/src/components/agent/SpawnAgentModal.tsx
@@ -17,6 +17,7 @@ import { Terminal, MessageSquare, AlertTriangle, Zap, Map as MapIcon } from "luc
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogClose } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Select } from "@/components/ui/select";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { id } from "@/lib/utils";
@@ -271,15 +272,13 @@ export function SpawnAgentModal({ card, open, onClose }: SpawnAgentModalProps) {
                   <label className="text-[0.714rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] block mb-1">
                     Agent binary
                   </label>
-                  <select
+                  <Select
                     value={selectedAgentId}
-                    onChange={(e) => setSelectedAgentId(e.target.value)}
-                    className="w-full rounded-md border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] text-sm px-3 py-1.5 focus:outline-none"
-                  >
-                    {agents.map((a) => (
-                      <option key={a.id} value={a.id}>{a.name}{a.isDefault ? " (default)" : ""}</option>
-                    ))}
-                  </select>
+                    onChange={setSelectedAgentId}
+                    size="md"
+                    className="w-full"
+                    options={agents.map((a) => ({ value: a.id, label: a.isDefault ? `${a.name} (default)` : a.name }))}
+                  />
                 </div>
               )}
             </>

--- a/src/components/automations/automations-view.tsx
+++ b/src/components/automations/automations-view.tsx
@@ -9,6 +9,7 @@ import { revealNote, revealCard } from "@/lib/events";
 import { Button } from "@/components/ui/button";
 import { Toggle } from "@/components/ui/toggle";
 import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
 import {
   DialogClose,
 } from "@/components/ui/dialog";
@@ -541,16 +542,16 @@ function AutomationDialog({
         </div>
         <label className="block space-y-1">
           <span className="text-xs text-[var(--text-secondary)]">Project scope</span>
-          <select
+          <Select
             value={projectId}
-            onChange={(e) => setProjectId(e.target.value)}
-            className="w-full rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
-          >
-            <option value="">Workspace (all projects)</option>
-            {projects.map((p) => (
-              <option key={p.id} value={p.id}>{p.name}</option>
-            ))}
-          </select>
+            onChange={setProjectId}
+            size="md"
+            className="w-full"
+            options={[
+              { value: "", label: "Workspace (all projects)" },
+              ...projects.map((p) => ({ value: p.id, label: p.name })),
+            ]}
+          />
         </label>
         <div className="grid grid-cols-2 gap-3">
           <label className="block space-y-1">
@@ -564,14 +565,16 @@ function AutomationDialog({
         </div>
         <label className="block space-y-1">
           <span className="text-xs text-[var(--text-secondary)]">Approval mode</span>
-          <select
+          <Select
             value={approvalMode}
-            onChange={(e) => setApprovalMode(e.target.value as "auto" | "ask")}
-            className="w-full rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
-          >
-            <option value="auto">Auto — run freely (writes happen automatically)</option>
-            <option value="ask">Ask — approve or deny each write</option>
-          </select>
+            onChange={setApprovalMode}
+            size="md"
+            className="w-full"
+            options={[
+              { value: "auto", label: "Auto — run freely (writes happen automatically)" },
+              { value: "ask", label: "Ask — approve or deny each write" },
+            ]}
+          />
           <span className="text-[0.714rem] text-[var(--text-tertiary)]">
             {approvalMode === "ask"
               ? "Write actions park in the approval inbox and the run waits for your decision."

--- a/src/components/automations/schedule-builder.tsx
+++ b/src/components/automations/schedule-builder.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
 import { DatePicker } from "@/components/ui/date-picker";
 import { TimePicker } from "@/components/ui/time-picker";
 import { SegmentedControl } from "@/components/ui/segmented-control";
@@ -237,13 +238,12 @@ export function ScheduleBuilder({ initialKind, initialExpr, timezone, onChange, 
               onChange={(e) => setIntervalN(Math.max(1, parseInt(e.target.value, 10) || 1))}
               className="w-20"
             />
-            <select
+            <Select
               value={intervalUnit}
-              onChange={(e) => setIntervalUnit(e.target.value)}
-              className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
-            >
-              {INTERVAL_UNITS.map((u) => <option key={u} value={u}>{u}</option>)}
-            </select>
+              onChange={setIntervalUnit}
+              size="md"
+              options={INTERVAL_UNITS.map((u) => ({ value: u, label: u }))}
+            />
             <span className="text-[var(--text-secondary)]">— repeats on that interval</span>
           </div>
         )}
@@ -289,13 +289,12 @@ export function ScheduleBuilder({ initialKind, initialExpr, timezone, onChange, 
         {mode === "monthly" && (
           <div className="flex items-center gap-2">
             <span className="text-[var(--text-secondary)]">On day</span>
-            <select
+            <Select
               value={dayOfMonth}
-              onChange={(e) => setDayOfMonth(parseInt(e.target.value, 10))}
-              className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]"
-            >
-              {MONTH_DAYS.map((d) => <option key={d} value={d}>{d}</option>)}
-            </select>
+              onChange={setDayOfMonth}
+              size="md"
+              options={MONTH_DAYS.map((d) => ({ value: d, label: d }))}
+            />
             <span className="text-[var(--text-secondary)]">at</span>
             <TimeInput value={timeStr} onChange={setTimeStr} />
           </div>

--- a/src/components/automations/schedule-builder.tsx
+++ b/src/components/automations/schedule-builder.tsx
@@ -242,6 +242,7 @@ export function ScheduleBuilder({ initialKind, initialExpr, timezone, onChange, 
               value={intervalUnit}
               onChange={setIntervalUnit}
               size="md"
+              ariaLabel="Interval unit"
               options={INTERVAL_UNITS.map((u) => ({ value: u, label: u }))}
             />
             <span className="text-[var(--text-secondary)]">— repeats on that interval</span>
@@ -293,6 +294,7 @@ export function ScheduleBuilder({ initialKind, initialExpr, timezone, onChange, 
               value={dayOfMonth}
               onChange={setDayOfMonth}
               size="md"
+              ariaLabel="Day of month"
               options={MONTH_DAYS.map((d) => ({ value: d, label: d }))}
             />
             <span className="text-[var(--text-secondary)]">at</span>

--- a/src/components/chat/chat-panel/ChatQuickSettings.tsx
+++ b/src/components/chat/chat-panel/ChatQuickSettings.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Toggle } from "@/components/ui/toggle";
 import { ModelPicker } from "@/components/ui/model-picker";
+import { Select } from "@/components/ui/select";
 import { useEndpointConfig, isLocalBaseUrl } from "@/components/settings/endpoint-components";
 
 const MAX_STEPS_PRESETS = [10, 20, 30, 50, 1000] as const;
@@ -112,19 +113,18 @@ export function ChatQuickSettings({ disabled }: { disabled?: boolean }) {
           {/* Provider */}
           <div className="space-y-1">
             <span className="text-[0.714rem] text-[var(--text-secondary)]">Provider</span>
-            <select
+            <Select
               value={providerSelectValue}
-              onChange={(e) => handleProviderChange(e.target.value)}
+              onChange={handleProviderChange}
               disabled={disabled}
-              className="w-full rounded-md border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text-primary)] outline-none disabled:opacity-50"
-            >
-              <option value="__localllm__">On-device (Llama)</option>
-              {savedProviders.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
+              placeholder="Select provider"
+              ariaLabel="Provider"
+              className="w-full"
+              options={[
+                { value: "__localllm__", label: "On-device (Llama)" },
+                ...savedProviders.map((p) => ({ value: p.id, label: p.name })),
+              ]}
+            />
           </div>
 
           {/* Model */}

--- a/src/components/chat/chat-panel/ChatSubagentBlock.tsx
+++ b/src/components/chat/chat-panel/ChatSubagentBlock.tsx
@@ -68,6 +68,8 @@ export function ChatSubagentBlock({ sub }: { sub: ChatSubagent }) {
             contextLimit={contextLimit}
             completionTokens={sub.lastUsage.completionTokens}
             reasoningTokens={sub.lastUsage.reasoningTokens}
+            cacheReadTokens={sub.lastUsage.cacheReadTokens}
+            cacheCreationTokens={sub.lastUsage.cacheCreationTokens}
             costUsd={sub.lastUsage.costUsd}
             showBalance={false}
             size={12}

--- a/src/components/chat/chat-panel/index.tsx
+++ b/src/components/chat/chat-panel/index.tsx
@@ -613,6 +613,8 @@ export function ChatPanel({ prefill, onPrefillConsumed, popoutMode }: ChatPanelP
             breakdown={activeThread.lastUsage.breakdown}
             completionTokens={activeThread.lastUsage.completionTokens}
             reasoningTokens={activeThread.lastUsage.reasoningTokens}
+            cacheReadTokens={activeThread.lastUsage.cacheReadTokens}
+            cacheCreationTokens={activeThread.lastUsage.cacheCreationTokens}
             costUsd={activeThread.lastUsage.costUsd}
           />
         )}

--- a/src/components/kanban/card-detail-sidebar.tsx
+++ b/src/components/kanban/card-detail-sidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DatePicker } from "@/components/ui/date-picker";
+import { Select } from "@/components/ui/select";
 import { cn, formatRelative, PRIORITY_COLORS } from "@/lib/utils";
 import type { TaskCard, BoardColumn, Project, Priority } from "@/types";
 
@@ -85,16 +86,14 @@ export function CardDetailSidebar({
         <label htmlFor="card-detail-column" className="block text-[0.714rem] font-semibold text-[var(--text-tertiary)] mb-2 uppercase tracking-wider">
           <ArrowRight size={10} className="inline mr-0.5" aria-hidden="true" />Column
         </label>
-        <select
-          id="card-detail-column"
+        <Select
           value={card.columnId}
-          onChange={(e) => onUpdateCard(card.id, { columnId: e.target.value })}
-          className="w-full px-2 py-1.5 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-xs text-[var(--text-secondary)] focus:outline-none focus:border-[var(--accent)]"
-        >
-          {projectColumns.map((col) => (
-            <option key={col.id} value={col.id}>{col.name}</option>
-          ))}
-        </select>
+          options={projectColumns.map((col) => ({ value: col.id, label: col.name }))}
+          onChange={(v) => onUpdateCard(card.id, { columnId: v })}
+          id="card-detail-column"
+          ariaLabel="Move to column"
+          className="w-full"
+        />
       </div>
 
       {/* Assignee */}
@@ -151,28 +150,22 @@ export function CardDetailSidebar({
           </div>
         )}
         {candidateBlockers.length > 0 && (
-          <select
+          <Select
             value=""
-            onChange={async (e) => {
-              const blockerCardId = e.target.value;
-              if (!blockerCardId) return;
-              setBlockerError(null);
-              const result = await onAddBlocker(card.id, blockerCardId);
-              if (result.error) setBlockerError(result.error);
-              e.target.value = "";
-            }}
-            className="w-full px-2 py-1.5 rounded-md bg-[var(--surface-2)] border border-[var(--border)] text-[0.714rem] text-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)]"
-          >
-            <option value="">+ Add blocker…</option>
-            {candidateBlockers.map((c) => {
+            options={candidateBlockers.map((c) => {
               const col = columns.find((col) => col.id === c.columnId);
-              return (
-                <option key={c.id} value={c.id}>
-                  {c.title}{col ? ` (${col.name})` : ""}
-                </option>
-              );
+              return { value: c.id, label: col ? `${c.title} (${col.name})` : c.title };
             })}
-          </select>
+            onChange={async (v) => {
+              if (!v) return;
+              setBlockerError(null);
+              const result = await onAddBlocker(card.id, v);
+              if (result.error) setBlockerError(result.error);
+            }}
+            placeholder="+ Add blocker…"
+            ariaLabel="Add blocker"
+            className="w-full text-[var(--text-tertiary)]"
+          />
         )}
         {blockerError && (
           <p className="text-[0.714rem] text-[var(--danger)] mt-1">{blockerError}</p>

--- a/src/components/layout/topbar.tsx
+++ b/src/components/layout/topbar.tsx
@@ -19,6 +19,7 @@ import { useShallow } from "zustand/react/shallow";
 import { WorkspaceIcon, ProjectIcon } from "@/lib/workspace-icons";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
+import { Select } from "@/components/ui/select";
 import { STATUS_COLORS, PRIORITY_COLORS } from "@/lib/utils";
 import { QuickSettings } from "./QuickSettings";
 import { modKey } from "./sidebar-utils";
@@ -145,23 +146,16 @@ export function Topbar() {
       {project && (
         <>
           {/* Mobile dropdown view selector */}
-          <div className="flex sm:hidden items-center relative ml-2">
-            <select
+          <div className="flex sm:hidden items-center ml-2">
+            <Select
               value={activeView}
-              onChange={(e) => setView(e.target.value as ViewTabId)}
-              className="appearance-none bg-[var(--surface-2)] border border-[var(--border)] rounded-md pl-3 pr-8 py-1 text-xs font-medium text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)] cursor-pointer"
-            >
-              {VIEW_TABS.filter((tab) => !isHidden(hiddenViews, tab.id)).map((tab) => (
-                <option key={tab.id} value={tab.id} className="bg-[var(--surface-2)] text-[var(--text-primary)]">
-                  {tab.label}
-                </option>
-              ))}
-            </select>
-            <div className="absolute right-2.5 pointer-events-none text-[var(--text-tertiary)] flex items-center">
-              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M6 9l6 6 6-6"/>
-              </svg>
-            </div>
+              onChange={(v) => setView(v as ViewTabId)}
+              ariaLabel="View"
+              options={VIEW_TABS.filter((tab) => !isHidden(hiddenViews, tab.id)).map((tab) => ({
+                value: tab.id,
+                label: tab.label,
+              }))}
+            />
           </div>
 
           {/* Desktop tabs view selector */}

--- a/src/components/settings/LlamaServerConsole.tsx
+++ b/src/components/settings/LlamaServerConsole.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import { CheckCircle, RefreshCw, Cpu, Trash2, Star } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Select } from "@/components/ui/select";
 
 /**
  * On-Device Llama server console — the entire `provider === "localllm"` surface
@@ -343,19 +344,20 @@ export function LlamaServerConsole({
                 <span className="text-[0.65rem] text-[var(--text-tertiary)] mt-0.5">Context window per query. Clamps for memory stability.</span>
               </div>
               <div>
-                <select
+                <Select
                   value={contextLimit || 16384}
-                  onChange={(e) => onContextLimitChange(parseInt(e.target.value, 10))}
-                  className="px-2.5 py-1 text-[0.714rem] rounded-md bg-[var(--surface-3)] border border-[var(--border)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)] cursor-pointer"
-                >
-                  <option value={4096}>4,096 tokens (Fast / Low RAM)</option>
-                  <option value={8192}>8,192 tokens (Standard)</option>
-                  <option value={16384}>16,384 tokens (Recommended)</option>
-                  <option value={32768}>32,768 tokens (Heavy VRAM)</option>
-                  {contextLimit && ![4096, 8192, 16384, 32768].includes(contextLimit) && (
-                    <option value={contextLimit}>Custom: {contextLimit.toLocaleString()} tokens</option>
-                  )}
-                </select>
+                  onChange={onContextLimitChange}
+                  ariaLabel="Local context limit"
+                  options={[
+                    { value: 4096, label: "4,096 tokens (Fast / Low RAM)" },
+                    { value: 8192, label: "8,192 tokens (Standard)" },
+                    { value: 16384, label: "16,384 tokens (Recommended)" },
+                    { value: 32768, label: "32,768 tokens (Heavy VRAM)" },
+                    ...(contextLimit && ![4096, 8192, 16384, 32768].includes(contextLimit)
+                      ? [{ value: contextLimit, label: `Custom: ${contextLimit.toLocaleString()} tokens` }]
+                      : []),
+                  ]}
+                />
               </div>
             </div>
           )}

--- a/src/components/settings/tools/ServiceForm.tsx
+++ b/src/components/settings/tools/ServiceForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import type { CustomServiceConfig } from "@/types";
 import { type HeaderRow, headersToRows, inputCls, labelCls } from "./helpers";
@@ -56,11 +57,12 @@ export function ServiceForm({
       <div className="flex gap-2">
         <div className="w-28">
           <label className={labelCls}>Method</label>
-          <select value={method} onChange={(e) => setMethod(e.target.value as CustomServiceConfig["method"])} className={inputCls}>
-            {(["GET", "POST", "PUT", "DELETE"] as const).map((m) => (
-              <option key={m} value={m}>{m}</option>
-            ))}
-          </select>
+          <Select
+            value={method ?? "GET"}
+            onChange={setMethod}
+            className="w-full"
+            options={(["GET", "POST", "PUT", "DELETE"] as const).map((m) => ({ value: m, label: m }))}
+          />
         </div>
         <div className="flex-1">
           <label className={labelCls}>API URL *</label>

--- a/src/components/ui/model-picker.tsx
+++ b/src/components/ui/model-picker.tsx
@@ -198,42 +198,42 @@ export function ModelPicker({
         <DropdownMenuTrigger asChild disabled={disabled}>
           <button
             className={cn(
-              "flex-1 min-w-0 flex items-center justify-between gap-1 rounded-md border bg-[var(--surface-2)] text-[var(--text-primary)] transition-colors disabled:opacity-50",
+              "flex-1 min-w-0 relative flex flex-col gap-0.5 rounded-md border bg-[var(--surface-2)] text-[var(--text-primary)] transition-colors disabled:opacity-50",
               triggerPad,
               errored ? "border-[var(--danger)]" : "border-[var(--border)] hover:border-[var(--muted)]",
             )}
           >
             {value ? (
               <>
-                {triggerLogo && (
-                  <img
-                    src={triggerLogo}
-                    alt=""
-                    className="provider-logo h-3 w-3 rounded-[2px] object-contain flex-shrink-0"
-                    onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
-                  />
-                )}
-                <TruncatedModel text={value} className="font-mono" />
-                <CapabilityChips info={triggerInfo} />
-                {triggerNoToolCall && (
-                  <Tooltip content="This model doesn't support tool calling">
-                    <span className="flex-shrink-0 text-[var(--warning)]">
-                      <TriangleAlert size={11} />
-                    </span>
-                  </Tooltip>
-                )}
-                {triggerCost && (
-                  <span className="text-[0.607rem] tabular-nums text-[var(--text-tertiary)] flex-shrink-0">
-                    {triggerCost}
-                  </span>
-                )}
+                <div className="flex items-center gap-1.5 min-w-0 pr-4">
+                  {triggerLogo && (
+                    <img
+                      src={triggerLogo}
+                      alt=""
+                      className="provider-logo h-3 w-3 rounded-[2px] object-contain flex-shrink-0"
+                      onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
+                    />
+                  )}
+                  <TruncatedModel text={value} className="font-mono" />
+                  {triggerNoToolCall && (
+                    <Tooltip content="This model doesn't support tool calling">
+                      <span className="flex-shrink-0 text-[var(--warning)]">
+                        <TriangleAlert size={11} />
+                      </span>
+                    </Tooltip>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 pl-4 text-[0.607rem] text-[var(--text-tertiary)]">
+                  <CapabilityChips info={triggerInfo} />
+                  {triggerCost && <span className="tabular-nums">{triggerCost}</span>}
+                </div>
               </>
             ) : (
               <span className="truncate font-sans text-[var(--text-tertiary)]">
                 {placeholder || "Select model"}
               </span>
             )}
-            <ChevronDown size={11} className="text-[var(--text-tertiary)] flex-shrink-0" />
+            <ChevronDown size={11} className="text-[var(--text-tertiary)] flex-shrink-0 absolute right-2 top-1/2 -translate-y-1/2" />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -329,6 +329,10 @@ export function ModelPicker({
  * the menu), the active-check gutter, and the truncated model id. Selecting the
  * row picks the model; clicking the star only toggles the favorite.
  *
+ * Two-line layout: the model name (with logo / star / markers) sits on the first
+ * line, and the input-capability icons + per-1M cost on the second — so long
+ * model ids don't crowd out the capability/cost metadata.
+ *
  * When the models.dev catalog is loaded, the row is enriched with the provider
  * logo, a compact per-1M cost (`$in/$out`), and a warning marker when the model
  * is known not to support tool calls. Catalog data is best-effort — rows render
@@ -355,52 +359,54 @@ function ModelRow({
   return (
     <DropdownMenuItem
       onSelect={onSelect}
-      className={cn("group gap-1.5 font-mono text-xs", active && "text-[var(--accent)]")}
+      className={cn("group gap-2 font-mono text-xs items-start", active && "text-[var(--accent)]")}
     >
-      <button
-        type="button"
-        aria-label={favorite ? "Unfavorite model" : "Favorite model"}
-        title={favorite ? "Unfavorite" : "Favorite"}
-        // Radix Menu.Item triggers selection on pointerup / click. Stop those
-        // events at the star so tapping it only toggles the favorite instead of
-        // selecting the model and closing the menu. (Don't preventDefault on
-        // pointerdown — that would suppress the follow-up click in some engines.)
-        onPointerDown={(e) => e.stopPropagation()}
-        onPointerUp={(e) => e.stopPropagation()}
-        onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleFavorite(); }}
-        className={cn(
-          "flex-shrink-0 flex items-center justify-center rounded p-0.5 -ml-0.5 transition-colors",
-          favorite
-            ? "text-[var(--accent)] hover:text-[var(--text-tertiary)]"
-            : "text-[var(--text-tertiary)] opacity-0 group-hover:opacity-100 hover:text-[var(--accent)]",
-        )}
-      >
-        <Star size={12} className={favorite ? "fill-current" : ""} />
-      </button>
-      {active && <Check size={12} className="flex-shrink-0" />}
-      {logo && (
-        <img
-          src={logo}
-          alt=""
-          className="provider-logo h-3 w-3 rounded-[2px] object-contain flex-shrink-0"
-          // Some provider slugs 404 — drop the broken glyph rather than showing it.
-          onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
-        />
-      )}
-      <TruncatedModel text={model} />
-      <CapabilityChips info={info} />
-      {noToolCall && (
-        <Tooltip content="This model doesn't support tool calling">
-          <span className="flex-shrink-0 text-[var(--warning)]">
-            <TriangleAlert size={12} />
-          </span>
-        </Tooltip>
-      )}
-      {cost && (
-        <span className="ml-auto pl-2 text-[0.607rem] tabular-nums text-[var(--text-tertiary)] flex-shrink-0">
-          {cost}
-        </span>
-      )}
+      <div className="flex flex-col min-w-0 flex-1 gap-0.5">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <button
+            type="button"
+            aria-label={favorite ? "Unfavorite model" : "Favorite model"}
+            title={favorite ? "Unfavorite" : "Favorite"}
+            // Radix Menu.Item triggers selection on pointerup / click. Stop those
+            // events at the star so tapping it only toggles the favorite instead of
+            // selecting the model and closing the menu. (Don't preventDefault on
+            // pointerdown — that would suppress the follow-up click in some engines.)
+            onPointerDown={(e) => e.stopPropagation()}
+            onPointerUp={(e) => e.stopPropagation()}
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleFavorite(); }}
+            className={cn(
+              "flex-shrink-0 flex items-center justify-center rounded p-0.5 -ml-0.5 transition-colors",
+              favorite
+                ? "text-[var(--accent)] hover:text-[var(--text-tertiary)]"
+                : "text-[var(--text-tertiary)] opacity-0 group-hover:opacity-100 hover:text-[var(--accent)]",
+            )}
+          >
+            <Star size={12} className={favorite ? "fill-current" : ""} />
+          </button>
+          {active && <Check size={12} className="flex-shrink-0" />}
+          {logo && (
+            <img
+              src={logo}
+              alt=""
+              className="provider-logo h-3 w-3 rounded-[2px] object-contain flex-shrink-0"
+              // Some provider slugs 404 — drop the broken glyph rather than showing it.
+              onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
+            />
+          )}
+          <TruncatedModel text={model} />
+          {noToolCall && (
+            <Tooltip content="This model doesn't support tool calling">
+              <span className="flex-shrink-0 text-[var(--warning)]">
+                <TriangleAlert size={12} />
+              </span>
+            </Tooltip>
+          )}
+        </div>
+        <div className="flex items-center gap-2 pl-5 text-[0.607rem] text-[var(--text-tertiary)]">
+          <CapabilityChips info={info} />
+          {cost && <span className="tabular-nums">{cost}</span>}
+        </div>
+      </div>
     </DropdownMenuItem>
   );
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -75,7 +75,7 @@ export function Select<V extends string | number>({
           disabled={disabled}
           aria-label={ariaLabel}
           className={cn(
-            "flex items-center justify-between gap-1.5 rounded-md border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-primary)] transition-colors hover:border-[var(--muted)] focus:outline-none disabled:opacity-50",
+            "flex items-center justify-between gap-1.5 rounded-md border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-primary)] transition-colors hover:border-[var(--muted)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:border-[var(--accent)] disabled:opacity-50",
             SIZE_CLASSES[size],
             className
           )}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * Select — the app's styled dropdown selector.
+ *
+ * A Radix-dropdown-based replacement for native `<select>` so every dropdown
+ * across the app shares the same floating panel, keyboard handling, and theming
+ * (no OS-styled listboxes). Used by the usage source filter, chat quick-settings
+ * provider, card column/blocker pickers, automations, spawn-agent, llama console,
+ * and schedule builder.
+ *
+ * The trigger always renders the selected option's label (or the placeholder)
+ * and a chevron; the menu lists every option with a check gutter for the active
+ * one. `onChange` fires with the picked value on selection.
+ */
+
+import React from "react";
+import { ChevronDown, Check } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown";
+import { cn } from "@/lib/utils";
+
+export interface SelectOption<V extends string | number> {
+  value: V;
+  /** Rendered in both the trigger (when selected) and the menu item. */
+  label: React.ReactNode;
+  disabled?: boolean;
+}
+
+export interface SelectProps<V extends string | number> {
+  value: V;
+  options: SelectOption<V>[];
+  onChange: (value: V) => void;
+  placeholder?: React.ReactNode;
+  /** Visual density. "sm" = compact (toolbars, settings rows); "md" = form fields. */
+  size?: "sm" | "md";
+  align?: "start" | "center" | "end";
+  disabled?: boolean;
+  id?: string;
+  ariaLabel?: string;
+  className?: string;
+  contentClassName?: string;
+}
+
+const SIZE_CLASSES = {
+  sm: "px-2 py-1 text-[0.714rem]",
+  md: "px-2 py-2 text-sm",
+} as const;
+
+export function Select<V extends string | number>({
+  value,
+  options,
+  onChange,
+  placeholder,
+  size = "sm",
+  align = "start",
+  disabled,
+  id,
+  ariaLabel,
+  className,
+  contentClassName,
+}: SelectProps<V>) {
+  const selected = options.find((o) => o.value === value);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          id={id}
+          disabled={disabled}
+          aria-label={ariaLabel}
+          className={cn(
+            "flex items-center justify-between gap-1.5 rounded-md border border-[var(--border)] bg-[var(--surface-2)] text-[var(--text-primary)] transition-colors hover:border-[var(--muted)] focus:outline-none disabled:opacity-50",
+            SIZE_CLASSES[size],
+            className
+          )}
+        >
+          <span className="truncate text-left">{selected ? selected.label : (placeholder ?? "Select…")}</span>
+          <ChevronDown size={12} className="text-[var(--text-tertiary)] flex-shrink-0" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={align} className={cn("min-w-[160px] max-h-72 overflow-y-auto", contentClassName)}>
+        {options.map((o) => {
+          const active = o.value === value;
+          return (
+            <DropdownMenuItem
+              key={String(o.value)}
+              disabled={o.disabled}
+              onSelect={() => onChange(o.value)}
+              className={cn(active && "text-[var(--text-primary)]")}
+            >
+              <span className="w-4 flex-shrink-0 flex items-center justify-center">
+                {active && <Check size={12} className="text-[var(--accent)]" />}
+              </span>
+              <span className="flex-1 min-w-0">{o.label}</span>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/usage/UsageView.tsx
+++ b/src/components/usage/UsageView.tsx
@@ -5,6 +5,7 @@ import { RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useUsage, USAGE_RANGES } from "@/hooks/useUsage";
 import { UsageChart, type UsageMetric } from "./UsageChart";
+import { Select } from "@/components/ui/select";
 import { fmtCompact, fmtFull, fmtDateTime } from "./usage-format";
 import { formatUsd } from "../../../shared/chat/provider-credits";
 import { USAGE_SOURCE_LABELS, type UsageSource, type UsageTotals } from "@/types/usage";
@@ -117,9 +118,12 @@ export function UsageView() {
   const [rangeIdx, setRangeIdx] = useState(1); // 30D default
   const [metric, setMetric] = useState<UsageMetric>("tokens");
   const [source, setSource] = useState<UsageSource | "">("");
+  // Estimated rows (models.dev price guess, no provider-reported cost) shown by
+  // default; off → they're dropped from every aggregate and the history.
+  const [excludeEstimated, setExcludeEstimated] = useState(false);
 
   const range = USAGE_RANGES[rangeIdx];
-  const { overview, recent, loading, refresh } = useUsage(range.days, source);
+  const { overview, recent, loading, refresh } = useUsage(range.days, source, excludeEstimated);
 
   const totals = overview?.totals;
   const rangeLabel = range.days == null ? "period" : `${range.days}d`;
@@ -146,23 +150,42 @@ export function UsageView() {
             value={metric}
             onChange={setMetric}
           />
-          <select
+          <Select
             value={source}
-            onChange={(e) => setSource(e.target.value as UsageSource | "")}
-            className="rounded-md border border-[var(--border)] bg-[var(--surface-2)] px-2 py-1.5 text-xs text-[var(--text-secondary)] outline-none"
-          >
-            <option value="">All sources</option>
-            {(Object.keys(USAGE_SOURCE_LABELS) as UsageSource[]).map((k) => (
-              <option key={k} value={k}>
-                {USAGE_SOURCE_LABELS[k]}
-              </option>
-            ))}
-          </select>
+            options={[
+              { value: "" as const, label: "All sources" },
+              ...(Object.keys(USAGE_SOURCE_LABELS) as UsageSource[]).map((k) => ({
+                value: k,
+                label: USAGE_SOURCE_LABELS[k],
+              })),
+            ]}
+            onChange={setSource}
+            ariaLabel="Source filter"
+          />
           <Segmented<number>
             options={USAGE_RANGES.map((r, i) => ({ value: i, label: r.label }))}
             value={rangeIdx}
             onChange={setRangeIdx}
           />
+          <button
+            onClick={() => setExcludeEstimated((v) => !v)}
+            title={
+              excludeEstimated
+                ? "Estimates hidden — only calls with a provider-reported cost are shown"
+                : "Estimates shown — calls whose cost is estimated from models.dev pricing are included"
+            }
+            className={cn(
+              "flex items-center gap-1.5 px-2 py-1 rounded-md border text-xs transition-colors",
+              excludeEstimated
+                ? "border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]"
+                : "border-[var(--border)] text-[var(--text-tertiary)] hover:bg-[var(--surface-2)] hover:text-[var(--text-primary)]"
+            )}
+          >
+            <span className={cn("w-7 h-3.5 rounded-full transition-colors relative", excludeEstimated ? "bg-[var(--accent)]" : "bg-[var(--border)]")}>
+              <span className={cn("absolute top-0.5 w-2.5 h-2.5 rounded-full bg-white transition-all", excludeEstimated ? "left-4" : "left-0.5")} />
+            </span>
+            Estimates
+          </button>
           <button
             onClick={refresh}
             title="Reload data"
@@ -177,9 +200,10 @@ export function UsageView() {
       <div className="flex-1 min-h-0 overflow-y-auto">
         <div className="p-4 flex flex-col gap-4">
           {/* Stat cards */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
             <StatCard label="Input tokens" value={totals ? fmtCompact(totals.promptTokens) : "—"} valueClass="text-[var(--accent)]" delta={totals && overview?.previous ? deltaPct(totals, overview.previous, "promptTokens", rangeLabel) : undefined} />
             <StatCard label="Output tokens" value={totals ? fmtCompact(totals.completionTokens) : "—"} />
+            <StatCard label="Cached input" value={totals ? fmtCompact(totals.cacheReadTokens) : "—"} valueClass="text-[var(--warning)]" delta={totals && totals.promptTokens > 0 && totals.cacheReadTokens > 0 ? `${Math.round((totals.cacheReadTokens / totals.promptTokens) * 100)}% of input` : ""} />
             <StatCard label="Total cost" value={totals ? formatUsd(totals.costUsd) : "—"} delta={totals && overview?.previous ? deltaPct(totals, overview.previous, "costUsd", rangeLabel) : undefined} />
             <StatCard label="Requests" value={totals ? fmtFull(totals.requests) : "—"} />
           </div>
@@ -258,12 +282,14 @@ export function UsageView() {
               <div className="text-xs font-semibold text-[var(--text-primary)]">Usage history</div>
               <div className="text-[0.643rem] text-[var(--text-tertiary)]">{recent.length === 0 ? "" : `latest ${recent.length} calls`}</div>
             </div>
-            {recent.length > 0 && (
+            {recent.length > 0 && !excludeEstimated && (
               <div className="px-4 pb-1 text-[0.643rem] text-[var(--text-tertiary)]">~ = estimated from models.dev pricing</div>
             )}
             {recent.length === 0 ? (
               <div className="px-4 py-8 text-xs text-[var(--text-tertiary)]">
-                No LLM calls recorded yet — send a chat message or run an agent and it will appear here.
+                {excludeEstimated
+                  ? "No calls with a provider-reported cost in this range — toggle the Estimates switch to include models.dev estimates."
+                  : "No LLM calls recorded yet — send a chat message or run an agent and it will appear here."}
               </div>
             ) : (
               <div className="overflow-x-auto">
@@ -274,6 +300,7 @@ export function UsageView() {
                       <th className="text-left font-medium px-4 py-2 whitespace-nowrap">Model</th>
                       <th className="text-right font-medium px-4 py-2 whitespace-nowrap">Input</th>
                       <th className="text-right font-medium px-4 py-2 whitespace-nowrap">Output</th>
+                      <th className="text-right font-medium px-4 py-2 whitespace-nowrap">Cached</th>
                       <th className="text-right font-medium px-4 py-2 whitespace-nowrap">Reasoning</th>
                       <th className="text-left font-medium px-4 py-2 whitespace-nowrap">Provider</th>
                       <th className="text-left font-medium px-4 py-2 whitespace-nowrap">Source</th>
@@ -292,6 +319,20 @@ export function UsageView() {
                         </td>
                         <td className="px-4 py-2 whitespace-nowrap text-right font-mono tabular-nums text-[var(--accent)]">{fmtFull(r.promptTokens)}</td>
                         <td className="px-4 py-2 whitespace-nowrap text-right font-mono tabular-nums text-[var(--info)]">{fmtFull(r.completionTokens)}</td>
+                        <td className="px-4 py-2 whitespace-nowrap text-right">
+                          {r.cacheReadTokens > 0 ? (
+                            <span className="inline-flex flex-col items-end leading-tight">
+                              <span className="font-mono tabular-nums text-[var(--warning)]">{fmtFull(r.cacheReadTokens)}</span>
+                              {r.promptTokens > 0 && (
+                                <span className="text-[0.571rem] text-[var(--text-tertiary)]">
+                                  {Math.round((r.cacheReadTokens / r.promptTokens) * 100)}% of input
+                                </span>
+                              )}
+                            </span>
+                          ) : (
+                            <span className="font-mono tabular-nums text-[var(--text-tertiary)]">—</span>
+                          )}
+                        </td>
                         <td className="px-4 py-2 whitespace-nowrap text-right font-mono tabular-nums text-[var(--text-tertiary)]">{r.reasoningTokens > 0 ? fmtFull(r.reasoningTokens) : "—"}</td>
                         <td className="px-4 py-2 whitespace-nowrap text-[0.714rem] text-[var(--text-secondary)]">{r.provider ?? "—"}</td>
                         <td className="px-4 py-2 whitespace-nowrap">

--- a/src/components/usage/UsageView.tsx
+++ b/src/components/usage/UsageView.tsx
@@ -169,6 +169,7 @@ export function UsageView() {
           />
           <button
             onClick={() => setExcludeEstimated((v) => !v)}
+            aria-pressed={excludeEstimated}
             title={
               excludeEstimated
                 ? "Estimates hidden — only calls with a provider-reported cost are shown"
@@ -182,7 +183,7 @@ export function UsageView() {
             )}
           >
             <span className={cn("w-7 h-3.5 rounded-full transition-colors relative", excludeEstimated ? "bg-[var(--accent)]" : "bg-[var(--border)]")}>
-              <span className={cn("absolute top-0.5 w-2.5 h-2.5 rounded-full bg-white transition-all", excludeEstimated ? "left-4" : "left-0.5")} />
+              <span className={cn("absolute top-0.5 w-2.5 h-2.5 rounded-full bg-[var(--surface)] transition-all", excludeEstimated ? "left-4" : "left-0.5")} />
             </span>
             Estimates
           </button>

--- a/src/hooks/useChatStream.ts
+++ b/src/hooks/useChatStream.ts
@@ -257,11 +257,11 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
       if (!isForThisThread(e)) return;
       mutateSub(e.childId, (s) => ({
         ...s,
-        lastUsage: { promptTokens: e.promptTokens, completionTokens: e.completionTokens, reasoningTokens: e.reasoningTokens, costUsd: e.costUsd },
+        lastUsage: { promptTokens: e.promptTokens, completionTokens: e.completionTokens, reasoningTokens: e.reasoningTokens, costUsd: e.costUsd, cacheReadTokens: e.cacheReadTokens, cacheCreationTokens: e.cacheCreationTokens },
       }));
     });
 
-    const unsubDone = (electron.chat.onDone as (cb: (e: { content: string; reasoning?: string; contextRefs: unknown[]; error?: string; threadId?: string; usage?: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: TokenBreakdown; costUsd?: number } }) => void) => () => void)((e) => {
+    const unsubDone = (electron.chat.onDone as (cb: (e: { content: string; reasoning?: string; contextRefs: unknown[]; error?: string; threadId?: string; usage?: { promptTokens: number; completionTokens: number; reasoningTokens?: number; cacheReadTokens?: number; cacheCreationTokens?: number; breakdown?: TokenBreakdown; costUsd?: number } }) => void) => () => void)((e) => {
       if (!isForThisThread(e)) return;
       const tid = threadIdRef.current;
       // Mark any still-running tool as done before persisting.
@@ -314,7 +314,7 @@ export function useChatStream(threadId: string | null): UseChatStreamResult {
       }
     });
 
-    const unsubUsage = (electron.chat.onUsage as (cb: (e: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: TokenBreakdown; costUsd?: number; threadId?: string }) => void) => () => void)((e) => {
+    const unsubUsage = (electron.chat.onUsage as (cb: (e: { promptTokens: number; completionTokens: number; reasoningTokens?: number; cacheReadTokens?: number; cacheCreationTokens?: number; breakdown?: TokenBreakdown; costUsd?: number; threadId?: string }) => void) => () => void)((e) => {
       if (!isForThisThread(e)) return;
       const tid = threadIdRef.current;
       if (tid) {

--- a/src/hooks/useUsage.ts
+++ b/src/hooks/useUsage.ts
@@ -26,10 +26,12 @@ export interface UseUsageResult {
 
 /**
  * Fetches the usage overview + recent calls for the current workspace and range.
- * Re-fetches when the workspace, range, or source filter changes; `refresh`
- * forces a reload (e.g. after the user sends a chat turn).
+ * Re-fetches when the workspace, range, source filter, or estimate toggle
+ * changes; `refresh` forces a reload (e.g. after the user sends a chat turn).
+ * When `excludeEstimated` is true, rows whose cost is a models.dev estimate
+ * (provider reported none) are dropped from every aggregate and the history.
  */
-export function useUsage(days: number | null, source: UsageSource | ""): UseUsageResult {
+export function useUsage(days: number | null, source: UsageSource | "", excludeEstimated: boolean): UseUsageResult {
   const activeWorkspaceId = useCairnStore((s) => s.activeWorkspaceId);
   const [overview, setOverview] = useState<UsageOverview | null>(null);
   const [recent, setRecent] = useState<UsageRecentRow[]>([]);
@@ -55,6 +57,7 @@ export function useUsage(days: number | null, source: UsageSource | ""): UseUsag
         source: source || undefined,
         from,
         to: Date.now(),
+        excludeEstimated,
       };
       try {
         const [o, r] = await Promise.all([
@@ -78,7 +81,7 @@ export function useUsage(days: number | null, source: UsageSource | ""): UseUsag
     return () => {
       cancelled = true;
     };
-  }, [days, source, activeWorkspaceId, nonce]);
+  }, [days, source, activeWorkspaceId, nonce, excludeEstimated]);
 
   return { overview, recent, loading, refresh };
 }

--- a/src/lib/models-dev.ts
+++ b/src/lib/models-dev.ts
@@ -33,11 +33,11 @@ import {
 } from "../../shared/models/model-catalog";
 
 const API_URL = "https://models.dev/api.json";
-// v2: bumped when the parsed ModelInfo shape gains a field (maxOutput) so
-// existing caches re-fetch immediately instead of waiting out the weekly TTL
+// v3: bumped when the parsed ModelInfo shape gains a field (cacheRead/cacheWrite)
+// so existing caches re-fetch immediately instead of waiting out the weekly TTL
 // with the old field-poor entries.
-const CACHE_KEY = "ai.modelInfo.cache.v2"; // JSON { [modelId]: ModelInfo }
-const CACHE_AT_KEY = "ai.modelInfo.cachedAt.v2";
+const CACHE_KEY = "ai.modelInfo.cache.v3"; // JSON { [modelId]: ModelInfo }
+const CACHE_AT_KEY = "ai.modelInfo.cachedAt.v3";
 const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // refresh weekly
 // Canonical owner map (models.json): id → provider slug for logo resolution.
 // Tiny (282 entries) and keyed by canonical "<provider>/<model>" ids, so it's
@@ -257,17 +257,29 @@ export function prewarmModelCatalog(): void {
 }
 
 /**
- * The compact `modelId → { input, output }` per-1M pricing map (USD), sent to
- * the main process so the usage recorder can estimate cost for providers that
- * don't report it. Best-effort — no-op when the catalog isn't loaded yet or no
- * Electron bridge exists.
+ * The compact `modelId → pricing` per-1M map (USD), sent to the main process so
+ * the usage recorder can estimate cost for providers that don't report it.
+ * Best-effort — no-op when the catalog isn't loaded yet or no Electron bridge
+ * exists. Cache prices are optional (absent when the model doesn't price cache
+ * reads/writes separately).
  */
-export function getModelPricingMap(): Record<string, { input: number | null; output: number | null }> {
+export function getModelPricingMap(): Record<string, {
+  input: number | null;
+  output: number | null;
+  cacheRead?: number | null;
+  cacheWrite?: number | null;
+}> {
   const src = memoryCache ?? loadCache() ?? {};
-  const out: Record<string, { input: number | null; output: number | null }> = {};
+  const out: Record<string, { input: number | null; output: number | null; cacheRead?: number | null; cacheWrite?: number | null }> = {};
   for (const [id, info] of Object.entries(src)) {
     if (info.input == null && info.output == null) continue;
-    out[id] = { input: info.input ?? null, output: info.output ?? null };
+    const entry: { input: number | null; output: number | null; cacheRead?: number | null; cacheWrite?: number | null } = {
+      input: info.input ?? null,
+      output: info.output ?? null,
+    };
+    if (info.cacheRead != null) entry.cacheRead = info.cacheRead;
+    if (info.cacheWrite != null) entry.cacheWrite = info.cacheWrite;
+    out[id] = entry;
   }
   return out;
 }

--- a/src/store/slices/chat.ts
+++ b/src/store/slices/chat.ts
@@ -41,6 +41,8 @@ export interface ChatSlice {
     promptTokens: number;
     completionTokens: number;
     reasoningTokens?: number;
+    cacheReadTokens?: number;
+    cacheCreationTokens?: number;
     breakdown?: TokenBreakdown;
     costUsd?: number;
   } | undefined) => void;

--- a/src/store/slices/terminal-sessions.ts
+++ b/src/store/slices/terminal-sessions.ts
@@ -54,7 +54,7 @@ export interface TerminalSessionsSlice {
   /** Clear message history for a pi session */
   clearPiMessages: (sessionId: string) => void;
   /** Update token usage for a session after a step completes */
-  updatePiUsage: (sessionId: string, promptTokens: number, completionTokens: number, reasoningTokens: number, breakdown?: TokenBreakdown) => void;
+  updatePiUsage: (sessionId: string, promptTokens: number, completionTokens: number, reasoningTokens: number, breakdown?: TokenBreakdown, cacheReadTokens?: number, cacheCreationTokens?: number) => void;
   /** Register a new subagent on the last streaming assistant message */
   addPiSubagent: (sessionId: string, childSessionId: string) => void;
   /** Append a token to a subagent's last streaming message */
@@ -70,7 +70,7 @@ export interface TerminalSessionsSlice {
   /** Mark a subagent as done and store its result */
   completePiSubagent: (sessionId: string, childSessionId: string, result: string) => void;
   /** Update token usage on an inline subagent block */
-  updatePiSubagentUsage: (sessionId: string, childSessionId: string, promptTokens: number, completionTokens: number, reasoningTokens: number, breakdown?: TokenBreakdown) => void;
+  updatePiSubagentUsage: (sessionId: string, childSessionId: string, promptTokens: number, completionTokens: number, reasoningTokens: number, breakdown?: TokenBreakdown, cacheReadTokens?: number, cacheCreationTokens?: number) => void;
   /** Start a new step in a subagent (finalise current message) */
   stepPiSubagent: (sessionId: string, childSessionId: string) => void;
   /** Set the mode for a pi session and optionally record the plan note ID */
@@ -353,11 +353,11 @@ export const createTerminalSessionsSlice: StateCreator<CairnStore, [], [], Termi
     }));
   },
 
-  updatePiUsage(sessionId, promptTokens, completionTokens, reasoningTokens, breakdown) {
+  updatePiUsage(sessionId, promptTokens, completionTokens, reasoningTokens, breakdown, cacheReadTokens, cacheCreationTokens) {
     set((s) => ({
       terminalSessions: s.terminalSessions.map((t) =>
         t.sessionId === sessionId
-          ? { ...t, lastUsage: { promptTokens, completionTokens, reasoningTokens, breakdown } }
+          ? { ...t, lastUsage: { promptTokens, completionTokens, reasoningTokens, breakdown, cacheReadTokens, cacheCreationTokens } }
           : t
       ),
     }));
@@ -563,7 +563,7 @@ export const createTerminalSessionsSlice: StateCreator<CairnStore, [], [], Termi
     }));
   },
 
-  updatePiSubagentUsage(sessionId, childSessionId, promptTokens, completionTokens, reasoningTokens, breakdown) {
+  updatePiSubagentUsage(sessionId, childSessionId, promptTokens, completionTokens, reasoningTokens, breakdown, cacheReadTokens, cacheCreationTokens) {
     set((s) => ({
       terminalSessions: s.terminalSessions.map((t) => {
         if (t.sessionId !== sessionId) return t;
@@ -573,7 +573,7 @@ export const createTerminalSessionsSlice: StateCreator<CairnStore, [], [], Termi
             const subIdx = (msg.subagents ?? []).findIndex((sa) => sa.childSessionId === childSessionId);
             if (subIdx === -1) return msg;
             const newSubagents = [...msg.subagents!];
-            newSubagents[subIdx] = { ...newSubagents[subIdx], lastUsage: { promptTokens, completionTokens, reasoningTokens, breakdown } };
+            newSubagents[subIdx] = { ...newSubagents[subIdx], lastUsage: { promptTokens, completionTokens, reasoningTokens, breakdown, cacheReadTokens, cacheCreationTokens } };
             return { ...msg, subagents: newSubagents };
           }),
         };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -527,6 +527,10 @@ export interface ChatThread {
     completionTokens: number;
     /** Subset of completion_tokens produced by the model's reasoning/thinking step. 0 if the model didn't split. */
     reasoningTokens?: number;
+    /** Prompt tokens served from the provider's cache this turn (0 when the provider doesn't cache/report). */
+    cacheReadTokens?: number;
+    /** Prompt tokens written to the provider's cache this turn (0 when not split out). */
+    cacheCreationTokens?: number;
     breakdown?: TokenBreakdown;
     /** Provider-reported USD cost of the turn (e.g. Neuralwatt usage.cost), when present. */
     costUsd?: number;
@@ -545,6 +549,10 @@ export interface CompletionUsage {
   completionTokens: number;
   totalTokens?: number;
   reasoningTokens?: number;
+  /** Prompt tokens served from the provider's cache (billed at the cache_read rate). */
+  cacheReadTokens?: number;
+  /** Prompt tokens written to the provider's cache (billed at the cache_write rate). */
+  cacheCreationTokens?: number;
   breakdown?: TokenBreakdown;
   /** Provider-reported USD cost of the call (e.g. Neuralwatt usage.cost), when present. */
   costUsd?: number;
@@ -604,7 +612,7 @@ export interface ChatSubagent {
   /** Final result returned to the dispatcher (usually == content) */
   result?: string;
   /** This subagent's OWN latest context-window usage — drives its dedicated ring. */
-  lastUsage?: { promptTokens: number; completionTokens: number; reasoningTokens?: number; costUsd?: number };
+  lastUsage?: { promptTokens: number; completionTokens: number; reasoningTokens?: number; costUsd?: number; cacheReadTokens?: number; cacheCreationTokens?: number };
 }
 
 export type SuggestedAction =
@@ -891,7 +899,7 @@ export interface PiSubagentMessage {
   /** Final result returned to the parent */
   result?: string;
   /** Latest token usage from the subagent's LLM steps */
-  lastUsage?: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: TokenBreakdown; costUsd?: number };
+  lastUsage?: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: TokenBreakdown; costUsd?: number; cacheReadTokens?: number; cacheCreationTokens?: number };
 }
 
 export interface PiAgentMessage {
@@ -931,7 +939,7 @@ export interface TerminalSession {
   sessionType: "pty" | "pi";
   piMessages?: PiAgentMessage[];
   initialPrompt?: string;
-  lastUsage?: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: TokenBreakdown; costUsd?: number };
+  lastUsage?: { promptTokens: number; completionTokens: number; reasoningTokens?: number; breakdown?: TokenBreakdown; costUsd?: number; cacheReadTokens?: number; cacheCreationTokens?: number };
   mode?: "plan" | "execute";
   planNoteId?: string;
   /** Explicit plan approval choice for this session, if one was made. */

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -37,6 +37,8 @@ export interface UsageTotals {
   promptTokens: number;
   completionTokens: number;
   reasoningTokens: number;
+  /** Prompt tokens served from the provider's cache across the window. */
+  cacheReadTokens: number;
   costUsd: number;
   requests: number;
 }
@@ -66,6 +68,10 @@ export interface UsageRecentRow {
   promptTokens: number;
   completionTokens: number;
   reasoningTokens: number;
+  /** Prompt tokens served from the provider's cache. */
+  cacheReadTokens: number;
+  /** Prompt tokens written to the provider's cache. */
+  cacheCreationTokens: number;
   costUsd: number | null;
   costEstimated: boolean;
   finishReason: string | null;


### PR DESCRIPTION
## What does this PR do?

Two related chunks of work:

**1. Prompt-cache visibility.** Captures cache-read/creation tokens from provider usage (Anthropic `cache_read_input_tokens` / OpenAI `cached_tokens`) across chat, the Agent, subagents, automations, and one-shot AI calls. Surfaces them in the ContextRing (a **Prompt cache** row + tooltip), persists them to the usage log, and makes the Usage view show cached input as a stat and per-row column. Cost estimates from models.dev are now cache-aware (cached input priced at `cache_read`/`cache_write` rates instead of full input). The Usage view also gains an **Estimates** toggle to hide rows whose cost is a models.dev estimate.

**2. Consistent styled dropdowns.** The model picker now puts the model name on one line with capabilities + cost underneath, in both the open menu and the closed trigger. All remaining native `<select>` dropdowns were replaced with a shared styled `Select` component (Radix-based) so every dropdown has the same floating panel and theming: usage source filter, chat quick-settings provider, card column + blocker pickers, automation project scope + approval mode, schedule-builder units, spawn-agent binary, llama server context limit, service HTTP method, and the mobile topbar view selector.

## Type of change

- [x] New feature
- [ ] Bug fix
- [x] Refactor / code quality
- [x] Docs / changelog
- [x] Tests

## Screenshots / recording

n/a (desktop UI — happy to add screenshots on request)

## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (runs `npm run compile` first so `electron/bundle-guard.test.ts` actually executes — `npm run test:bundle` to run just that)
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [ ] If this ships a **major, user-facing feature**: added an entry to `scripts/features.config.js` so it appears in the "What's New" modal (generated JSON — run `node scripts/generate-features.js`)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [x] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [x] New DB migrations appended (not edited) in `schema.ts` — added columns via idempotent `ensureColumns` guards instead of a new migration
- [x] New SQL goes in `electron/db/queries.ts` — single source of truth (imported by both Electron main process and MCP server); never construct a `Database` instance outside `db/client.ts` (Electron) or `mcp-server.ts` (MCP runtime)
- [ ] New `dependencies` or `devDependencies` added to `ROLE_MAP` in `scripts/generate-licenses.js` and `licenses.json` regenerated
- [ ] New MCP tools registered in `electron/mcp/tools/index.ts` dispatch + `electron/lib/tool-schemas.ts` Zod schema
- [ ] If you added/removed a `--external:<pkg>` flag in the `compile` script: updated the appropriate allowlist group (`RUNTIME_PROVIDED` / `OPTIONAL_TRANSITIVE` / `SUBPROCESS_ONLY` / `SHIPPED_NATIVE`) in `electron/bundle-guard.test.ts` and (if `SHIPPED_NATIVE`) shipped the package via `electron-builder.yml`

## Notes for reviewer

- The `What's New` feature entry was intentionally skipped — this is a refinement of existing surfaces (ContextRing + Usage view) rather than a new headline feature; it's recorded in `changelogs/v2.6.7.md`.
- `e2e` tests not run locally (need the app harness) — flagged in the checklist for the merge gate.
- One pre-existing quirk left untouched: `coding-tools/subagent.ts` forwards the third `onUsage` arg (reasoning tokens) into the subagent `pi-agent:usage` event's `breakdown` field. Out of scope here; cache fields map to the correct positional args regardless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - View prompt-cache reads, writes, and usage percentages in chat context indicators and Usage history.
  - Track cached input tokens in usage totals and recent activity.
  - Apply cache-aware cost estimates using model-specific cache pricing.
  - Filter estimated-cost entries from Usage reports.
  - Added support for consistent model cache-pricing data.

- **Style**
  - Standardized dropdown controls across model pickers, settings, automation, chat, Kanban, and navigation views.
  - Improved model picker layout for clearer capability, warning, and pricing information.

- **Documentation**
  - Added v2.6.7 release changelog entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->