### PR TITLE
feat(ui): tag rendering + overflow, label typography and theme-token consistency sweep

### DIFF
--- a/changelogs/v2.6.11.md
+++ b/changelogs/v2.6.11.md
@@ -1,0 +1,9 @@
+## What's new
+
+### Changed
+
+- **Tags are now tidier everywhere.** The notes filter no longer dumps every tag into an endless wrap — tags are sorted by how often they're used, capped to a compact row, and the rest collapse behind a `+N` pill (with a "Show all" toggle). In the notes list, tags moved to their own line *below* the date at a smaller size, so rows no longer jumble; beyond three tags they collapse into a hoverable `+N` pill. The same `+N` treatment now applies to project headers, pinned notes, kanban cards, the note editor's tag bar (smaller badges + expandable overflow), and mobile note/calendar rows — and card-detail tag toggles sort most-used first.
+
+### Fixed
+
+- Tag rows no longer silently drop tags past an arbitrary cap — every capped surface shows a `+N` pill with the hidden tag names in a tooltip.

--- a/changelogs/v2.6.11.md
+++ b/changelogs/v2.6.11.md
@@ -3,7 +3,12 @@
 ### Changed
 
 - **Tags are now tidier everywhere.** The notes filter no longer dumps every tag into an endless wrap — tags are sorted by how often they're used, capped to a compact row, and the rest collapse behind a `+N` pill (with a "Show all" toggle). In the notes list, tags moved to their own line *below* the date at a smaller size, so rows no longer jumble; beyond three tags they collapse into a hoverable `+N` pill. The same `+N` treatment now applies to project headers, pinned notes, kanban cards, the note editor's tag bar (smaller badges + expandable overflow), and mobile note/calendar rows — and card-detail tag toggles sort most-used first.
+- **Overflow is now consistent everywhere, not just for tags.** The `+N` pill is a shared component used across tags, automation-run artifacts, task-flow previews, model usage, and recent agent sessions — so capped lists always show a tooltip with the hidden items instead of silently dropping them.
+- **Label typography is now on two canonical scales.** A shared `MicroLabel` (small field captions) and `SectionLabel` (section headers) component replace the ~6 ad-hoc micro font sizes that previously floated around settings, agent, calendar and onboarding surfaces.
 
 ### Fixed
 
 - Tag rows no longer silently drop tags past an arbitrary cap — every capped surface shows a `+N` pill with the hidden tag names in a tooltip.
+- Several stray theme-token violations: a hardcoded `green-400` on the chat copy state, hardcoded hex fallbacks in the matrix legend, and `rgba()` backgrounds in the priority-board dashboard template now use theme tokens (`--success`, `--accent`, `color-mix`) so they follow light/dark mode.
+- The AI-setup onboarding step referenced an undefined `--purple-500` CSS token for the Local Engine card's selected state, producing an invisible highlight — it now uses the standard accent token like the sibling provider card.
+- Remaining pixel-based font sizes (`text-[10px]`, `text-[10.5px]`, `text-[12.5px]`) were converted to the rem-based scale.

--- a/mobile/src/components/TagChips.tsx
+++ b/mobile/src/components/TagChips.tsx
@@ -11,9 +11,10 @@ export function TagChips({ tags, size = "md", max }: { tags: TagRow[]; size?: "s
   const t = useTheme();
   if (!tags.length) return null;
   const small = size === "sm";
-  const capped = typeof max === "number" && tags.length > max;
-  const shown = capped ? tags.slice(0, max) : tags;
-  const overflow = capped ? tags.length - max : 0;
+  const cap = typeof max === "number" && Number.isFinite(max) ? Math.max(0, Math.floor(max)) : Infinity;
+  const capped = tags.length > cap;
+  const shown = capped ? tags.slice(0, cap) : tags;
+  const overflow = capped ? tags.length - cap : 0;
   return (
     <View style={styles.row}>
       {shown.map((tag) => (

--- a/mobile/src/components/TagChips.tsx
+++ b/mobile/src/components/TagChips.tsx
@@ -5,14 +5,18 @@ import type { TagRow } from "@/db/queries";
 /**
  * Tag pills matching the desktop tag chips — a coloured dot + name on a tinted
  * background derived from the tag colour. Renders nothing when there are no tags.
+ * Pass `max` to cap the row; any tags beyond the cap collapse into a "+N" chip.
  */
-export function TagChips({ tags, size = "md" }: { tags: TagRow[]; size?: "sm" | "md" }) {
+export function TagChips({ tags, size = "md", max }: { tags: TagRow[]; size?: "sm" | "md"; max?: number }) {
   const t = useTheme();
   if (!tags.length) return null;
   const small = size === "sm";
+  const capped = typeof max === "number" && tags.length > max;
+  const shown = capped ? tags.slice(0, max) : tags;
+  const overflow = capped ? tags.length - max : 0;
   return (
     <View style={styles.row}>
-      {tags.map((tag) => (
+      {shown.map((tag) => (
         <View
           key={tag.id}
           style={[
@@ -27,6 +31,18 @@ export function TagChips({ tags, size = "md" }: { tags: TagRow[]; size?: "sm" | 
           </Text>
         </View>
       ))}
+      {overflow > 0 && (
+        <View
+          style={[
+            styles.chip,
+            small && styles.chipSm,
+            styles.overflowChip,
+            { borderColor: withAlpha(t.border, 1) },
+          ]}
+        >
+          <Text style={[styles.text, small && styles.textSm, { color: t.textTertiary }]}>+{overflow}</Text>
+        </View>
+      )}
     </View>
   );
 }
@@ -42,4 +58,5 @@ const styles = StyleSheet.create({
   dotSm: { width: 6, height: 6, borderRadius: 3 },
   text: { ...typeScale.label },
   textSm: { fontSize: 11 },
+  overflowChip: { backgroundColor: "transparent" },
 });

--- a/mobile/src/components/calendar/DayDetailRow.tsx
+++ b/mobile/src/components/calendar/DayDetailRow.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { View, Text } from "react-native";
 import { PressableScale } from "@/components/PressableScale";
 import { withAlpha, PRIORITY_COLOR, type Theme } from "@/theme";
@@ -25,7 +24,9 @@ export function DayDetailRow({
   t: Theme;
   styles: CalendarStyles;
 }) {
-  const shownTags = useMemo(() => (tags ?? []).slice(0, 3), [tags]);
+  const allTags = tags ?? [];
+  const shownTags = allTags.slice(0, 3);
+  const overflow = Math.max(0, allTags.length - shownTags.length);
   const status = getDueDateStatus(card.due_date);
   const priorityColor = PRIORITY_COLOR[card.priority] ?? t.textTertiary;
   return (
@@ -58,6 +59,11 @@ export function DayDetailRow({
               </Text>
             </View>
           ))}
+          {overflow > 0 && (
+            <View style={[styles.tagChip, { backgroundColor: "transparent", borderColor: t.border }]}>
+              <Text style={[styles.tagText, { color: t.textTertiary }]}>+{overflow}</Text>
+            </View>
+          )}
         </View>
       </View>
     </PressableScale>

--- a/mobile/src/screens/project/NoteRowItem.tsx
+++ b/mobile/src/screens/project/NoteRowItem.tsx
@@ -34,7 +34,6 @@ export const NoteRowItem = memo(function NoteRowItem({
     const text = stripMarkdown(note.content ?? "").trim();
     return text ? text.slice(0, 80) : "Empty note";
   }, [note.content]);
-  const shownTags = useMemo(() => (tags ?? []).slice(0, 3), [tags]);
   const onPress = useCallback(() => onOpen(note.id), [onOpen, note.id]);
   const handleLongPress = useCallback(() => onLongPress(note), [onLongPress, note]);
   return (
@@ -65,7 +64,7 @@ export const NoteRowItem = memo(function NoteRowItem({
       </Text>
       <View style={{ flexDirection: "row", alignItems: "center", gap: 8, paddingLeft: 21 }}>
         <Text style={{ color: t.textTertiary, ...typeScale.micro, fontWeight: "400" }}>{formatRelative(note.updated_at)}</Text>
-        {shownTags.length > 0 && <TagChips tags={shownTags} size="sm" />}
+        {(tags?.length ?? 0) > 0 && <TagChips tags={tags ?? []} size="sm" max={3} />}
       </View>
     </PressableScale>
   );

--- a/src/components/agent/AgentEmptyState.tsx
+++ b/src/components/agent/AgentEmptyState.tsx
@@ -4,6 +4,7 @@ import { useShallow } from "zustand/react/shallow";
 import { Plus, Bot, History, ArrowRight } from "lucide-react";
 import { useCairnStore } from "@/store";
 import { cn, formatDateCompact } from "@/lib/utils";
+import { OverflowPill } from "@/components/ui/overflow-pill";
 import { useAgentSessionActions } from "./useAgentSessionActions";
 
 export function AgentEmptyState() {
@@ -62,6 +63,13 @@ export function AgentEmptyState() {
               <ArrowRight size={10} className="text-[var(--text-tertiary)] shrink-0 opacity-0 group-hover:opacity-100" />
             </button>
           ))}
+          {piSessionHistory.length > recentSessions.length && (
+            <OverflowPill
+              count={piSessionHistory.length - recentSessions.length}
+              names={piSessionHistory.slice(recentSessions.length).map((s) => s.taskTitle)}
+              className="self-center mt-1"
+            />
+          )}
         </div>
       )}
     </div>

--- a/src/components/agent/ArchitectureSidebar.tsx
+++ b/src/components/agent/ArchitectureSidebar.tsx
@@ -27,6 +27,7 @@ import {
   Layers,
 } from "lucide-react";
 import { CairnEvents } from "@/lib/events";
+import { MicroLabel, SectionLabel } from "@/components/ui/labels";
 
 interface CodebaseSymbol {
   id: string; file_id: string; name: string; kind: string; line: number;
@@ -135,9 +136,9 @@ export function ArchitectureSidebar() {
       {/* Header */}
       <div className="flex items-center gap-2 px-3 h-9 border-b border-[var(--border)] flex-shrink-0">
         <Boxes size={13} className="text-[var(--accent)]" />
-        <span className="text-[0.7rem] uppercase tracking-wide text-[var(--text-tertiary)] flex-1 truncate">
+        <SectionLabel className="flex-1 truncate">
           Architecture
-        </span>
+        </SectionLabel>
         <button
           onClick={() => setCollapsed(true)}
           className="text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
@@ -238,9 +239,9 @@ function RelBlock({
   }
   return (
     <div className="flex flex-col gap-0.5">
-      <div className="flex items-center gap-1 text-[0.65rem] uppercase tracking-wide text-[var(--text-tertiary)]">
+      <MicroLabel className="flex items-center gap-1">
         {icon} {label} ({names.length})
-      </div>
+      </MicroLabel>
       {names.map((n) => (
         <div key={n} className="text-[0.7rem] font-mono text-[var(--text-secondary)] truncate pl-3">
           {n}

--- a/src/components/agent/ArchitectureView.tsx
+++ b/src/components/agent/ArchitectureView.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { SectionLabel } from "@/components/ui/labels";
 import { useCairnStore } from "@/store";
 import { CairnEvents } from "@/lib/events";
 import { ArchitectureGraphCanvas } from "./ArchitectureGraphCanvas";
@@ -474,9 +475,9 @@ export function ArchitectureView({ cwd }: ArchitectureViewProps) {
             {/* Symbol-kind breakdown */}
             {overview.kinds.length > 0 && (
               <div className="px-4 py-3 border-b border-[var(--border)] flex-shrink-0">
-                <div className="text-[0.7rem] uppercase tracking-wide text-[var(--text-tertiary)] mb-2">
+                <SectionLabel className="mb-2 block">
                   Symbols by kind
-                </div>
+                </SectionLabel>
                 <div className="flex flex-col gap-1.5">
                   {overview.kinds.map((k) => (
                     <div key={k.kind} className="flex items-center gap-2">
@@ -714,11 +715,11 @@ function RelationList({
 
   return (
     <div>
-      <div className="flex items-center gap-1.5 text-[0.7rem] uppercase tracking-wide text-[var(--text-tertiary)] mb-1.5">
+      <SectionLabel className="flex items-center gap-1.5 mb-1.5">
         {icon}
         {title}
         <span className="tabular-nums">({items.length})</span>
-      </div>
+      </SectionLabel>
       {items.length === 0 ? (
         <div className="text-[0.7rem] text-[var(--text-tertiary)]">{empty}</div>
       ) : (

--- a/src/components/agent/GitView.tsx
+++ b/src/components/agent/GitView.tsx
@@ -23,6 +23,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Tooltip } from "@/components/ui/tooltip";
+import { MicroLabel } from "@/components/ui/labels";
 import {
   type GitStatusData,
   type GitLogData,
@@ -857,9 +858,9 @@ export function GitView({ cwd }: GitViewProps) {
         {/* ── Recent commits ─────────────────────────────────────────────── */}
         {log.length > 0 && (
           <div className="border-t border-[var(--border)]">
-            <div className="px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)] bg-[var(--surface-2)] border-b border-[var(--border-subtle)]">
+            <MicroLabel className="block px-4 py-2 bg-[var(--surface-2)] border-b border-[var(--border-subtle)]">
               Recent commits
-            </div>
+            </MicroLabel>
             <div className="divide-y divide-[var(--border-subtle)]">
               {log.map((entry) => (
                 <div key={entry.hash} className="flex items-start gap-3 px-4 py-2 hover:bg-[var(--surface-2)] transition-colors">

--- a/src/components/agent/PlanApprovalCard.tsx
+++ b/src/components/agent/PlanApprovalCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { CheckCircle, MessageSquare, Play, Send } from "lucide-react";
 import { MarkdownContent } from "@/components/chat/chat-panel/MarkdownContent";
+import { MicroLabel } from "@/components/ui/labels";
 
 interface PlanApprovalCardProps {
   content: string;
@@ -28,7 +29,7 @@ export function PlanApprovalCard({ content, busy, onApprove, onRequestChanges }:
       <div className="flex items-center gap-2 px-3 py-2 border-b border-[var(--border)]">
         <CheckCircle size={13} className="text-[var(--warning,#f59e0b)]" />
         <span className="text-[0.714rem] font-semibold text-[var(--text-primary)] flex-1">Plan ready for your direction</span>
-        <span className="text-[0.607rem] uppercase tracking-wider text-[var(--text-tertiary)]">Choose autonomy</span>
+        <MicroLabel>Choose autonomy</MicroLabel>
       </div>
       <div className="max-h-52 overflow-y-auto px-3 py-2 text-[0.714rem] leading-relaxed text-[var(--text-secondary)]">
         <MarkdownContent content={content} />

--- a/src/components/agent/git/FileSection.tsx
+++ b/src/components/agent/git/FileSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChevronRight, ChevronDown } from "lucide-react";
+import { MicroLabel } from "@/components/ui/labels";
 
 /** Collapsible section header (Staged / Modified / Untracked) wrapping its file rows. */
 export function FileSection({
@@ -25,7 +26,7 @@ export function FileSection({
         }}
       >
         {expanded ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
-        <span className="text-[0.65rem] font-semibold uppercase tracking-widest text-[var(--text-tertiary)]">{label}</span>
+        <MicroLabel>{label}</MicroLabel>
         <span className="text-[0.65rem] text-[var(--text-tertiary)] opacity-60">{count}</span>
         {action && (
           <div className="ml-auto flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>

--- a/src/components/calendar/UnscheduledTray.tsx
+++ b/src/components/calendar/UnscheduledTray.tsx
@@ -14,6 +14,7 @@ import { useMemo, useState } from "react";
 import { ChevronDown, ChevronRight, Inbox } from "lucide-react";
 import { DraggableChip, DroppableTray } from "./CalendarDnd";
 import type { TaskCard } from "@/types";
+import { MicroLabel } from "@/components/ui/labels";
 
 interface UnscheduledTrayProps {
   cards: TaskCard[];
@@ -76,10 +77,10 @@ export function UnscheduledTray({ cards, onOpenCard, groupByProject, projectName
                 <div className="flex flex-col gap-2">
                   {groups.map((g) => (
                     <div key={g.name}>
-                      <div className="flex items-center gap-1 px-0.5 pb-1 text-[0.6rem] font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">
+                      <MicroLabel className="flex items-center gap-1 px-0.5 pb-1">
                         <span className="truncate">{g.name}</span>
                         <span className="font-normal">{g.items.length}</span>
-                      </div>
+                      </MicroLabel>
                       <div className="flex flex-wrap gap-1">{g.items.map(renderChip)}</div>
                     </div>
                   ))}

--- a/src/components/chat/chat-panel/ChatMessageBubble.tsx
+++ b/src/components/chat/chat-panel/ChatMessageBubble.tsx
@@ -139,7 +139,7 @@ export const ChatMessageBubble = React.memo(function ChatMessageBubble({ message
               title="Copy"
               className="p-0.5 rounded text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-3)] transition-colors"
             >
-              {copied ? <Check size={10} className="text-green-400" /> : <Copy size={10} />}
+              {copied ? <Check size={10} className="text-[var(--success)]" /> : <Copy size={10} />}
             </button>
             {isUser && onRetry && (
               <button

--- a/src/components/flow/NodeEditModal.tsx
+++ b/src/components/flow/NodeEditModal.tsx
@@ -141,7 +141,7 @@ function NotePicker({ selectedId, onSelect }: { selectedId: string; onSelect: (i
 
   return (
     <div className="flex flex-col gap-2">
-      <label className="text-[0.786rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Search notes</label>
+      <label className="text-[0.714rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Search notes</label>
       <div className="relative">
         <Search size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
         <input
@@ -155,7 +155,7 @@ function NotePicker({ selectedId, onSelect }: { selectedId: string; onSelect: (i
       </div>
       <div className="flex flex-col max-h-48 overflow-y-auto rounded-lg border border-[var(--border)] divide-y divide-[var(--border)]">
         {filtered.length === 0 ? (
-          <p className="px-3 py-3 text-[0.786rem] text-[var(--text-tertiary)] text-center">No notes found</p>
+          <p className="px-3 py-3 text-[0.714rem] text-[var(--text-tertiary)] text-center">No notes found</p>
         ) : (
           filtered.map((n) => (
             <button
@@ -204,7 +204,7 @@ function TaskPicker({ selectedId, onSelect }: { selectedId: string; onSelect: (i
 
   return (
     <div className="flex flex-col gap-2">
-      <label className="text-[0.786rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Search tasks</label>
+      <label className="text-[0.714rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Search tasks</label>
       <div className="relative">
         <Search size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
         <input
@@ -218,7 +218,7 @@ function TaskPicker({ selectedId, onSelect }: { selectedId: string; onSelect: (i
       </div>
       <div className="flex flex-col max-h-48 overflow-y-auto rounded-lg border border-[var(--border)] divide-y divide-[var(--border)]">
         {filtered.length === 0 ? (
-          <p className="px-3 py-3 text-[0.786rem] text-[var(--text-tertiary)] text-center">No tasks found</p>
+          <p className="px-3 py-3 text-[0.714rem] text-[var(--text-tertiary)] text-center">No tasks found</p>
         ) : (
           filtered.map((c) => (
             <button
@@ -287,7 +287,7 @@ function UrlEditor({
     <div className="flex flex-col gap-3">
       {/* URL row with Fetch button */}
       <div className="flex flex-col gap-1">
-        <label className="text-[0.786rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">URL</label>
+        <label className="text-[0.714rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">URL</label>
         <div className="flex gap-1.5">
           <input
             type="text"
@@ -338,7 +338,7 @@ function GroupEditor({
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-col gap-1">
-        <label className="text-[0.786rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide flex items-center gap-1.5">
+        <label className="text-[0.714rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide flex items-center gap-1.5">
           <Layers size={10} /> Label
         </label>
         <input
@@ -351,7 +351,7 @@ function GroupEditor({
         />
       </div>
       <div className="flex flex-col gap-1">
-        <label className="text-[0.786rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Colour</label>
+        <label className="text-[0.714rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Colour</label>
         <div className="flex items-center gap-2">
           {GROUP_COLORS.map((c) => (
             <button
@@ -384,7 +384,7 @@ function Field({
   const base = "w-full text-xs bg-[var(--surface-2)] border border-[var(--border)] rounded-lg px-2.5 py-1.5 text-[var(--text-primary)] placeholder-[var(--text-tertiary)] focus:outline-none resize-none";
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-[0.786rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">{label}</label>
+      <label className="text-[0.714rem] font-medium text-[var(--text-tertiary)] uppercase tracking-wide">{label}</label>
       {multiline ? (
         <textarea
           rows={3}

--- a/src/components/graph/MatrixCanvas.tsx
+++ b/src/components/graph/MatrixCanvas.tsx
@@ -290,11 +290,11 @@ export function MatrixCanvas({ nodes, onNodeClick, selectedNodeId }: Props) {
           {/* Legend */}
           <div className="flex items-center gap-4 mt-3 px-1">
             <div className="flex items-center gap-1.5">
-              <div className="w-3 h-3 rounded-sm opacity-50" style={{ background: tagColors[0] ?? "#6366f1" }} />
+              <div className="w-3 h-3 rounded-sm opacity-50" style={{ background: tagColors[0] ?? "var(--accent)" }} />
               <span className="text-[0.714rem] text-[var(--text-tertiary)]">co-occurrence</span>
             </div>
             <div className="flex items-center gap-1.5">
-              <div className="w-3 h-1.5 rounded-full" style={{ background: tagColors[0] ?? "#6366f1" }} />
+              <div className="w-3 h-1.5 rounded-full" style={{ background: tagColors[0] ?? "var(--accent)" }} />
               <span className="text-[0.714rem] text-[var(--text-tertiary)]">diagonal = total per tag</span>
             </div>
             <span className="text-[0.714rem] text-[var(--text-tertiary)] opacity-50 ml-2">click a cell to inspect</span>

--- a/src/components/kanban/card-detail-body.tsx
+++ b/src/components/kanban/card-detail-body.tsx
@@ -7,6 +7,7 @@ import { Tooltip } from "@/components/ui/tooltip";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
+import { sortTagsByUsage } from "@/lib/tag-utils";
 import { revealNote } from "@/lib/events";
 import { SpawnAgentModal } from "@/components/agent/SpawnAgentModal";
 import { NoteMarkdownPreview } from "@/components/notes/NoteMarkdownPreview";
@@ -67,6 +68,12 @@ export function CardDetailBody({
   const linkedNotes    = useMemo(() => card ? card.linkedNoteIds.map((nId) => notes.find((n) => n.id === nId)).filter(Boolean) : [], [card, notes]);
   const projectNotes   = useMemo(() => card ? getProjectNotes(card.projectId) : [], [card, getProjectNotes]);
   const projectTags    = useMemo(() => card ? tags.filter((t) => t.workspaceId === card.workspaceId) : [], [card, tags]);
+  const projectCards   = useMemo(() => card ? cards.filter((c) => c.projectId === card.projectId) : [], [card, cards]);
+  // Most-used tags float to the top of the toggle grid.
+  const sortedProjectTags = useMemo(
+    () => sortTagsByUsage(projectTags, projectNotes, projectCards),
+    [projectTags, projectNotes, projectCards],
+  );
   const otherProjects  = useMemo(() => card ? (activeWorkspaceId ? getWorkspaceProjects(activeWorkspaceId) : projects).filter((p) => p.id !== card.projectId && !p.archivedAt) : [], [card, activeWorkspaceId, getWorkspaceProjects, projects]);
 
   if (!card) return null;
@@ -150,7 +157,7 @@ export function CardDetailBody({
             <TagIcon size={10} className="inline mr-1" />Tags
           </label>
           <div className="flex flex-wrap gap-1.5">
-            {projectTags.map((tag) => (
+            {sortedProjectTags.map((tag) => (
               <button
                 key={tag.id}
                 onClick={() => {

--- a/src/components/kanban/card.tsx
+++ b/src/components/kanban/card.tsx
@@ -53,9 +53,10 @@ const CardContent = React.memo(function CardContent({ card, expanded, canExpand,
   const getTagById = useCairnStore((s) => s.getTagById);
   const isDone = useCairnStore((s) => s.columns.find((c) => c.id === card.columnId)?.type === "done");
   const isBlocked = (card.blockedByIds ?? []).length > 0;
-  const tags = card.tagIds.slice(0, 3).map((id) => getTagById(id)).filter(Boolean);
-  const extraTags = card.tagIds.slice(3).map((id) => getTagById(id)).filter(Boolean);
-  const extraTagCount = Math.max(0, card.tagIds.length - 3);
+  const allTags = card.tagIds.map((id) => getTagById(id)).filter(Boolean);
+  const tags = allTags.slice(0, 3);
+  const extraTags = allTags.slice(3);
+  const extraTagCount = extraTags.length;
   const description = card.description?.trim() || "";
 
   return (

--- a/src/components/kanban/card.tsx
+++ b/src/components/kanban/card.tsx
@@ -6,7 +6,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { Archive, Calendar, ChevronDown, ChevronUp, FileText, Lock, Pencil, Trash2, User } from "lucide-react";
 import { cn, formatDate, getDueDateStatus } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { TagOverflow } from "@/components/ui/tag-overflow";
+import { OverflowPill } from "@/components/ui/overflow-pill";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -162,7 +162,7 @@ const CardContent = React.memo(function CardContent({ card, expanded, canExpand,
                 )
             )}
             {extraTagCount > 0 && (
-              <TagOverflow count={extraTagCount} names={extraTags.map((t) => t?.name ?? "")} />
+              <OverflowPill count={extraTagCount} names={extraTags.map((t) => t?.name ?? "")} />
             )}
           </div>
         )}

--- a/src/components/kanban/card.tsx
+++ b/src/components/kanban/card.tsx
@@ -6,7 +6,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { Archive, Calendar, ChevronDown, ChevronUp, FileText, Lock, Pencil, Trash2, User } from "lucide-react";
 import { cn, formatDate, getDueDateStatus } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { Tooltip } from "@/components/ui/tooltip";
+import { TagOverflow } from "@/components/ui/tag-overflow";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -162,11 +162,7 @@ const CardContent = React.memo(function CardContent({ card, expanded, canExpand,
                 )
             )}
             {extraTagCount > 0 && (
-              <Tooltip content={extraTags.map((t) => t?.name).filter(Boolean).join(", ")}>
-                <span className="text-[0.643rem] text-[var(--text-tertiary)] self-center px-0.5 cursor-default">
-                  +{extraTagCount}
-                </span>
-              </Tooltip>
+              <TagOverflow count={extraTagCount} names={extraTags.map((t) => t?.name ?? "")} />
             )}
           </div>
         )}

--- a/src/components/kanban/column.tsx
+++ b/src/components/kanban/column.tsx
@@ -348,7 +348,7 @@ function KanbanColumnImpl({
               <div className="pt-1">
                 <button
                   onClick={() => setShowArchived((v) => !v)}
-                  className="flex items-center gap-1.5 w-full px-1 py-1 text-[10.5px] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
+                  className="flex items-center gap-1.5 w-full px-1 py-1 text-xs text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
                 >
                   {showArchived ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
                   {archivedCards.length} archived

--- a/src/components/layout/conflict-resolution-modal.tsx
+++ b/src/components/layout/conflict-resolution-modal.tsx
@@ -132,7 +132,7 @@ export function ConflictResolutionModal({ open, onClose }: { open: boolean; onCl
 
                 {editing ? (
                   <div className="p-3 space-y-2">
-                    <div className="flex items-center gap-1.5 text-[0.65rem] uppercase tracking-wide text-[var(--warning)]">
+                    <div className="flex items-center gap-1.5 text-[0.643rem] uppercase tracking-wide text-[var(--warning)]">
                       <Pencil size={11} />
                       Overlapping edits — review the merged result before saving
                     </div>
@@ -211,7 +211,7 @@ function DiffView({ current, copy, originalDeleted }: { current: string; copy: s
   if (originalDeleted) {
     return (
       <div className="p-3">
-        <div className="text-[0.65rem] uppercase tracking-wide text-[var(--text-tertiary)] mb-1.5">
+        <div className="text-[0.643rem] uppercase tracking-wide text-[var(--text-tertiary)] mb-1.5">
           Original was deleted — this is the conflicted copy
         </div>
         <pre className="text-[0.714rem] text-[var(--text-secondary)] whitespace-pre-wrap break-words max-h-56 overflow-y-auto font-mono leading-relaxed">
@@ -227,7 +227,7 @@ function DiffView({ current, copy, originalDeleted }: { current: string; copy: s
 
   return (
     <div>
-      <div className="px-3 pt-2.5 pb-1.5 flex items-center gap-3 text-[0.65rem] uppercase tracking-wide">
+      <div className="px-3 pt-2.5 pb-1.5 flex items-center gap-3 text-[0.643rem] uppercase tracking-wide">
         <span className="text-[var(--text-tertiary)]">Current vs conflicted copy</span>
         {identical ? (
           <span className="text-[var(--text-tertiary)]">identical body</span>

--- a/src/components/layout/project-overview/index.tsx
+++ b/src/components/layout/project-overview/index.tsx
@@ -11,6 +11,8 @@ import { ProjectIcon } from "@/lib/workspace-icons";
 import { cn, formatDate, STATUS_COLORS } from "@/lib/utils";
 import { CairnEvents, revealNote, revealCard } from "@/lib/events";
 import { Badge } from "@/components/ui/badge";
+import { TagOverflow } from "@/components/ui/tag-overflow";
+import { sortTagsByUsage, capTags } from "@/lib/tag-utils";
 import { Button } from "@/components/ui/button";
 import { PendingApprovals } from "@/components/automations/pending-approvals";
 import { useProjectMetrics } from "./useProjectMetrics";
@@ -117,6 +119,10 @@ export function ProjectOverview() {
   const toggleSection = (section: string) => toggleOverviewSection(project.id, section);
   const recentActivityCount = activityByDay.reduce((n, g) => n + g.items.length, 0);
 
+  // Header tags — sorted by usage and capped so a heavily-tagged project
+  // doesn't blow up the header row; the rest collapse behind a "+N" pill.
+  const headerTags = capTags(sortTagsByUsage(projectTags, notes, allCards), 4);
+
   return (
     <div className="flex-1 flex flex-col min-h-0 relative w-full min-w-0 overflow-x-hidden">
       <div className="flex-1 overflow-y-auto overflow-x-hidden w-full min-w-0">
@@ -147,7 +153,10 @@ export function ProjectOverview() {
                   <Calendar size={10} />{formatDate(project.dueDate)}
                 </span>
               )}
-              {projectTags.map((tag) => tag && <Badge key={tag.id} color={tag.color}>{tag.name}</Badge>)}
+              {headerTags.shown.map((tag) => tag && <Badge key={tag.id} color={tag.color} size="xs">{tag.name}</Badge>)}
+              {headerTags.hidden.length > 0 && (
+                <TagOverflow count={headerTags.hidden.length} names={headerTags.hidden.map((t) => t.name)} />
+              )}
             </div>
           </div>
           <div className="flex-shrink-0 flex flex-col items-center gap-1.5">

--- a/src/components/layout/project-overview/index.tsx
+++ b/src/components/layout/project-overview/index.tsx
@@ -11,7 +11,7 @@ import { ProjectIcon } from "@/lib/workspace-icons";
 import { cn, formatDate, STATUS_COLORS } from "@/lib/utils";
 import { CairnEvents, revealNote, revealCard } from "@/lib/events";
 import { Badge } from "@/components/ui/badge";
-import { TagOverflow } from "@/components/ui/tag-overflow";
+import { OverflowPill } from "@/components/ui/overflow-pill";
 import { sortTagsByUsage, capTags } from "@/lib/tag-utils";
 import { Button } from "@/components/ui/button";
 import { PendingApprovals } from "@/components/automations/pending-approvals";
@@ -155,7 +155,7 @@ export function ProjectOverview() {
               )}
               {headerTags.shown.map((tag) => tag && <Badge key={tag.id} color={tag.color} size="xs">{tag.name}</Badge>)}
               {headerTags.hidden.length > 0 && (
-                <TagOverflow count={headerTags.hidden.length} names={headerTags.hidden.map((t) => t.name)} />
+                <OverflowPill count={headerTags.hidden.length} names={headerTags.hidden.map((t) => t.name)} />
               )}
             </div>
           </div>

--- a/src/components/layout/project-overview/primitives.tsx
+++ b/src/components/layout/project-overview/primitives.tsx
@@ -15,7 +15,7 @@ export function SectionHeader({
 }) {
   return (
     <div className="flex items-center justify-between mb-3">
-      <div className="flex items-center gap-1.5 text-[0.786rem] font-semibold text-[var(--text-secondary)] uppercase tracking-wider">
+      <div className="flex items-center gap-1.5 text-[0.714rem] font-semibold text-[var(--text-secondary)] uppercase tracking-wider">
         {icon}{title}
       </div>
       {action && (
@@ -56,7 +56,7 @@ export function CollapsibleSection({
           aria-expanded={!collapsed}
           aria-controls={bodyId}
           title={collapsed ? `Expand ${title}` : `Collapse ${title}`}
-          className="flex items-center gap-1 text-[0.786rem] font-semibold text-[var(--text-secondary)] uppercase tracking-wider hover:text-[var(--text-primary)] transition-colors group cursor-pointer"
+          className="flex items-center gap-1 text-[0.714rem] font-semibold text-[var(--text-secondary)] uppercase tracking-wider hover:text-[var(--text-primary)] transition-colors group cursor-pointer"
         >
           <ChevronDown size={11} className={cn("text-[var(--text-tertiary)] transition-transform", collapsed && "-rotate-90")} />
           <span className="group-hover:text-[var(--text-primary)] transition-colors flex items-center gap-1.5">

--- a/src/components/layout/project-overview/sections.tsx
+++ b/src/components/layout/project-overview/sections.tsx
@@ -9,7 +9,7 @@ import { cn, formatRelative, getDueDateStatus, parseIsoLocal } from "@/lib/utils
 import { COLUMN_COLORS, PRIORITY_CSS_COLORS } from "@/lib/constants";
 import { revealColumn, revealNote, revealCard } from "@/lib/events";
 import { Badge } from "@/components/ui/badge";
-import { TagOverflow } from "@/components/ui/tag-overflow";
+import { OverflowPill } from "@/components/ui/overflow-pill";
 import { useCairnStore } from "@/store";
 import type { TaskCard, Note, BoardColumn, AppUIState } from "@/types";
 import type { ActivityGroup } from "./useProjectMetrics";
@@ -74,10 +74,13 @@ export function TaskFlowCard({
                 <div className="flex h-2 rounded-full bg-[var(--surface-2)] overflow-hidden">
                   <div className="h-full rounded-full transition-all duration-500" style={{ width: `${pct}%`, backgroundColor: color }} />
                 </div>
-                <div className="flex gap-x-3 mt-1">
+                <div className="flex gap-x-3 mt-1 items-center">
                   {cards.slice(0, 2).map((c) => (
                     <span key={c.id} className="text-[0.714rem] text-[var(--text-tertiary)] truncate">{c.title}</span>
                   ))}
+                  {cards.length > 2 && (
+                    <OverflowPill count={cards.length - 2} names={cards.slice(2).map((c) => c.title)} />
+                  )}
                   {cards.length === 0 && <span className="text-[0.714rem] text-[var(--text-tertiary)]">—</span>}
                 </div>
               </div>
@@ -230,7 +233,7 @@ export function PinnedNoteCard({ note, onClick }: { note: Note; onClick: () => v
         <div className="flex gap-1 items-center flex-shrink-0">
           {noteTags.map((tag) => <Badge key={tag.id} color={tag.color} size="xs">{tag.name}</Badge>)}
           {hiddenNoteTags.length > 0 && (
-            <TagOverflow count={hiddenNoteTags.length} names={hiddenNoteTags.map((t) => t.name)} />
+            <OverflowPill count={hiddenNoteTags.length} names={hiddenNoteTags.map((t) => t.name)} />
           )}
         </div>
       )}
@@ -337,7 +340,7 @@ export function RecentAutomationRunsFeed({
                   </button>
                 ))}
                 {artifacts.length > 2 && (
-                  <span className="text-[0.714rem] text-[var(--text-tertiary)] flex-shrink-0">+{artifacts.length - 2}</span>
+                  <OverflowPill count={artifacts.length - 2} names={artifacts.slice(2).map((a) => a.title)} />
                 )}
               </div>
             )}

--- a/src/components/layout/project-overview/sections.tsx
+++ b/src/components/layout/project-overview/sections.tsx
@@ -9,6 +9,7 @@ import { cn, formatRelative, getDueDateStatus, parseIsoLocal } from "@/lib/utils
 import { COLUMN_COLORS, PRIORITY_CSS_COLORS } from "@/lib/constants";
 import { revealColumn, revealNote, revealCard } from "@/lib/events";
 import { Badge } from "@/components/ui/badge";
+import { TagOverflow } from "@/components/ui/tag-overflow";
 import { useCairnStore } from "@/store";
 import type { TaskCard, Note, BoardColumn, AppUIState } from "@/types";
 import type { ActivityGroup } from "./useProjectMetrics";
@@ -211,7 +212,9 @@ export function DueCard({ card, columns, today, onClick }: { card: TaskCard; col
  */
 export function PinnedNoteCard({ note, onClick }: { note: Note; onClick: () => void }) {
   const getTagById = useCairnStore((s) => s.getTagById);
-  const noteTags = note.tagIds.slice(0, 2).map((id) => getTagById(id)).filter(Boolean) as import("@/types").Tag[];
+  const allNoteTags = note.tagIds.map((id) => getTagById(id)).filter(Boolean) as import("@/types").Tag[];
+  const noteTags = allNoteTags.slice(0, 2);
+  const hiddenNoteTags = allNoteTags.slice(2);
   return (
     <button onClick={onClick}
       className="flex items-center gap-3 w-full px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] hover:border-[var(--accent)]/40 hover:bg-[var(--surface-2)] transition-colors group text-left">
@@ -224,8 +227,11 @@ export function PinnedNoteCard({ note, onClick }: { note: Note; onClick: () => v
         </div>
       </div>
       {noteTags.length > 0 && (
-        <div className="flex gap-1 flex-shrink-0">
-          {noteTags.map((tag) => <Badge key={tag.id} color={tag.color}>{tag.name}</Badge>)}
+        <div className="flex gap-1 items-center flex-shrink-0">
+          {noteTags.map((tag) => <Badge key={tag.id} color={tag.color} size="xs">{tag.name}</Badge>)}
+          {hiddenNoteTags.length > 0 && (
+            <TagOverflow count={hiddenNoteTags.length} names={hiddenNoteTags.map((t) => t.name)} />
+          )}
         </div>
       )}
       <span className="text-[0.786rem] text-[var(--text-tertiary)] flex-shrink-0 tabular-nums">{formatRelative(note.updatedAt)}</span>

--- a/src/components/notes/BacklinksPanel.tsx
+++ b/src/components/notes/BacklinksPanel.tsx
@@ -6,7 +6,7 @@ import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { TagOverflow } from "@/components/ui/tag-overflow";
+import { OverflowPill } from "@/components/ui/overflow-pill";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import type { Note, Tag } from "@/types";
@@ -354,7 +354,7 @@ export function NoteTagBar({ note, workspaceTags, onToggleTag, onCreateTag, getT
         </button>
       ))}
       {assignedTags.length > 5 && (
-        <TagOverflow
+        <OverflowPill
           count={hiddenAssigned.length}
           names={hiddenAssigned.map((t) => t.name)}
           label={tagsExpanded ? "−" : `+${hiddenAssigned.length}`}

--- a/src/components/notes/BacklinksPanel.tsx
+++ b/src/components/notes/BacklinksPanel.tsx
@@ -6,6 +6,7 @@ import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
+import { TagOverflow } from "@/components/ui/tag-overflow";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import type { Note, Tag } from "@/types";
@@ -299,6 +300,7 @@ export interface NoteTagBarProps {
 export function NoteTagBar({ note, workspaceTags, onToggleTag, onCreateTag, getTagById }: NoteTagBarProps) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [newTagName, setNewTagName] = useState("");
+  const [tagsExpanded, setTagsExpanded] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -327,6 +329,9 @@ export function NoteTagBar({ note, workspaceTags, onToggleTag, onCreateTag, getT
     ? unassignedTags.filter((t) => t.name.toLowerCase().includes(newTagName.toLowerCase()))
     : unassignedTags;
 
+  const shownAssigned = tagsExpanded ? assignedTags : assignedTags.slice(0, 5);
+  const hiddenAssigned = assignedTags.slice(shownAssigned.length);
+
   function handleCreateTag() {
     const trimmed = newTagName.trim();
     if (!trimmed) return;
@@ -337,17 +342,26 @@ export function NoteTagBar({ note, workspaceTags, onToggleTag, onCreateTag, getT
 
   return (
     <div className="flex items-center gap-1.5 mt-2.5 max-w-4xl mx-auto flex-wrap relative">
-      {assignedTags.map((tag) => (
+      {shownAssigned.map((tag) => (
         <button
           key={tag.id}
           onClick={() => onToggleTag(tag.id)}
           className="group flex items-center gap-0.5"
           title={`Remove tag "${tag.name}"`}
         >
-          <Badge color={tag.color}>{tag.name}</Badge>
+          <Badge color={tag.color} size="xs">{tag.name}</Badge>
           <X size={9} className="opacity-0 group-hover:opacity-100 text-[var(--text-tertiary)] transition-opacity -ml-1" />
         </button>
       ))}
+      {assignedTags.length > 5 && (
+        <TagOverflow
+          count={hiddenAssigned.length}
+          names={hiddenAssigned.map((t) => t.name)}
+          label={tagsExpanded ? "−" : `+${hiddenAssigned.length}`}
+          tooltip={tagsExpanded ? "Show fewer tags" : undefined}
+          onClick={() => setTagsExpanded((v) => !v)}
+        />
+      )}
 
       <div className="relative" ref={pickerRef}>
         <button

--- a/src/components/notes/CodeBlock.tsx
+++ b/src/components/notes/CodeBlock.tsx
@@ -176,7 +176,7 @@ export function CodeBlock({ code, language }: Props) {
   return (
     <div
       data-cairn-codeblock=""
-      className="my-4 rounded-lg overflow-hidden text-[12.5px] font-mono"
+      className="my-4 rounded-lg overflow-hidden text-sm font-mono"
       style={{ border: `1px solid ${borderColor}` }}
     >
       {/* Header bar */}

--- a/src/components/notes/DashboardTemplateModal.tsx
+++ b/src/components/notes/DashboardTemplateModal.tsx
@@ -157,8 +157,8 @@ window.addEventListener('cairn:refresh', load);
   .group { border: 1px solid var(--border); border-radius: 8px; padding: 12px; background: var(--surface); }
   .group-header { display: flex; align-items: center; margin-bottom: 10px; }
   .badge { display: inline-block; font-size: 10px; font-weight: 600; padding: 2px 7px; border-radius: 20px; text-transform: uppercase; letter-spacing: 0.04em; }
-  .urgent { background: rgba(239,68,68,0.15); color: var(--danger); }
-  .high { background: rgba(245,158,11,0.15); color: var(--warning); }
+  .urgent { background: color-mix(in srgb, var(--danger) 15%, transparent); color: var(--danger); }
+  .high { background: color-mix(in srgb, var(--warning) 15%, transparent); color: var(--warning); }
   .medium { background: var(--accent-dim); color: var(--accent); }
   .low { background: var(--surface-3); color: var(--text-secondary); }
   .task { padding: 6px 0; border-bottom: 1px solid var(--border); font-size: 12px; color: var(--text-secondary); }

--- a/src/components/notes/dashboard-view.tsx
+++ b/src/components/notes/dashboard-view.tsx
@@ -293,7 +293,7 @@ export function DashboardView({ note, onBack }: DashboardViewProps) {
       {errors.length > 0 && (
         <div className="flex-shrink-0 border-b border-[var(--danger)]/30 bg-[var(--danger)]/[0.06] px-4 py-3 space-y-1.5">
           <div className="flex items-center justify-between mb-1">
-            <div className="flex items-center gap-1.5 text-[0.786rem] font-semibold text-[var(--danger)] uppercase tracking-wider">
+            <div className="flex items-center gap-1.5 text-[0.714rem] font-semibold text-[var(--danger)] uppercase tracking-wider">
               <AlertTriangle size={11} />
               Dashboard error{errors.length > 1 ? `s (${errors.length})` : ""}
             </div>

--- a/src/components/notes/notes-view.tsx
+++ b/src/components/notes/notes-view.tsx
@@ -331,7 +331,8 @@ export function NotesView() {
     }
     return base;
   }, [sortedProjectTags, tagsExpanded, activeTagId]);
-  const hiddenProjectTags = sortedProjectTags.slice(shownProjectTags.length);
+  const shownProjectTagIds = new Set(shownProjectTags.map((t) => t.id));
+  const hiddenProjectTags = sortedProjectTags.filter((t) => !shownProjectTagIds.has(t.id));
 
   const filtered   = useNoteFilter(notes, filter, activeTagId);
   // Resolve the active note across notes and templates (templates are excluded

--- a/src/components/notes/notes-view.tsx
+++ b/src/components/notes/notes-view.tsx
@@ -23,6 +23,8 @@ import { NoteListItem } from "./notes-view/NoteListItem";
 import { ArchivedNoteListItem } from "./notes-view/ArchivedNoteListItem";
 import { FolderTreeNode } from "./notes-view/FolderTreeNode";
 import { setActiveCrossProjectDrag } from "@/lib/cross-project-dnd";
+import { sortTagsByUsage } from "@/lib/tag-utils";
+import { TagOverflow } from "@/components/ui/tag-overflow";
 import { FolderPickerDialog } from "./notes-view/FolderPickerDialog";
 import { instantiateTemplate, defaultTitleFromTemplate } from "../../../shared/notes/templates";
 import { STARTER_TEMPLATES } from "../../../shared/notes/starter-templates";
@@ -32,6 +34,9 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogClose } from "@
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown";
 
 // ── NotesView orchestrator ──────────────────────────────────────────────────
+
+/** How many tag-filter chips are shown before collapsing behind a "+N" pill. */
+const TAG_FILTER_CAP = 6;
 
 export function NotesView() {
   const {
@@ -313,6 +318,20 @@ export function NotesView() {
     const tagIds = [...new Set(notes.flatMap((n) => n.tagIds))];
     return tagIds.map((id) => getTagById(id)).filter(Boolean) as import("@/types").Tag[];
   }, [notes, getTagById]);
+  const sortedProjectTags = useMemo(() => sortTagsByUsage(projectTags, notes), [projectTags, notes]);
+  const [tagsExpanded, setTagsExpanded] = useState(false);
+  // Show the most-used tags first, capped to a compact row. If the active filter
+  // tag falls outside the cap it is promoted into view so the selection stays visible.
+  const shownProjectTags = useMemo(() => {
+    if (tagsExpanded) return sortedProjectTags;
+    const base = sortedProjectTags.slice(0, TAG_FILTER_CAP);
+    if (activeTagId && !base.some((t) => t.id === activeTagId)) {
+      const active = sortedProjectTags.find((t) => t.id === activeTagId);
+      if (active) base.push(active);
+    }
+    return base;
+  }, [sortedProjectTags, tagsExpanded, activeTagId]);
+  const hiddenProjectTags = sortedProjectTags.slice(shownProjectTags.length);
 
   const filtered   = useNoteFilter(notes, filter, activeTagId);
   // Resolve the active note across notes and templates (templates are excluded
@@ -596,17 +615,37 @@ export function NotesView() {
             )}
           </div>
           {projectTags.length > 0 && (
-            <div className="flex flex-wrap gap-1 mt-1.5">
-              {projectTags.map((tag) => (
-                <button key={tag.id} onClick={() => setActiveTagId(activeTagId === tag.id ? null : tag.id)}
-                  className={cn("flex items-center gap-1 px-1.5 py-0.5 rounded text-[0.714rem] border transition-colors",
-                    activeTagId === tag.id
-                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
-                      : "border-[var(--border)] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]")}>
-                  <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: tag.color }} />
-                  {tag.name}
-                </button>
-              ))}
+            <div className="mt-1.5">
+              <div className="flex items-center justify-between mb-1 px-0.5">
+                <span className="text-[0.643rem] uppercase tracking-wider text-[var(--text-tertiary)]">Tags</span>
+                {hiddenProjectTags.length > 0 && (
+                  <button
+                    onClick={() => setTagsExpanded((v) => !v)}
+                    className="text-[0.643rem] text-[var(--accent)] hover:underline transition-colors"
+                  >
+                    {tagsExpanded ? "Show less" : `Show all ${projectTags.length}`}
+                  </button>
+                )}
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {shownProjectTags.map((tag) => (
+                  <button key={tag.id} onClick={() => setActiveTagId(activeTagId === tag.id ? null : tag.id)}
+                    className={cn("flex items-center gap-1 px-1.5 py-0.5 rounded text-[0.714rem] border transition-colors",
+                      activeTagId === tag.id
+                        ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-dim)]"
+                        : "border-[var(--border)] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]")}>
+                    <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: tag.color }} />
+                    {tag.name}
+                  </button>
+                ))}
+                {hiddenProjectTags.length > 0 && (
+                  <TagOverflow
+                    count={hiddenProjectTags.length}
+                    names={hiddenProjectTags.map((t) => t.name)}
+                    onClick={() => setTagsExpanded(true)}
+                  />
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/src/components/notes/notes-view.tsx
+++ b/src/components/notes/notes-view.tsx
@@ -24,7 +24,7 @@ import { ArchivedNoteListItem } from "./notes-view/ArchivedNoteListItem";
 import { FolderTreeNode } from "./notes-view/FolderTreeNode";
 import { setActiveCrossProjectDrag } from "@/lib/cross-project-dnd";
 import { sortTagsByUsage } from "@/lib/tag-utils";
-import { TagOverflow } from "@/components/ui/tag-overflow";
+import { OverflowPill } from "@/components/ui/overflow-pill";
 import { FolderPickerDialog } from "./notes-view/FolderPickerDialog";
 import { instantiateTemplate, defaultTitleFromTemplate } from "../../../shared/notes/templates";
 import { STARTER_TEMPLATES } from "../../../shared/notes/starter-templates";
@@ -639,7 +639,7 @@ export function NotesView() {
                   </button>
                 ))}
                 {hiddenProjectTags.length > 0 && (
-                  <TagOverflow
+                  <OverflowPill
                     count={hiddenProjectTags.length}
                     names={hiddenProjectTags.map((t) => t.name)}
                     onClick={() => setTagsExpanded(true)}

--- a/src/components/notes/notes-view/NoteListItem.tsx
+++ b/src/components/notes/notes-view/NoteListItem.tsx
@@ -8,6 +8,7 @@ import {
 import { cn, formatRelative } from "@/lib/utils";
 import type { Note } from "@/types";
 import { Badge } from "@/components/ui/badge";
+import { TagOverflow } from "@/components/ui/tag-overflow";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useCairnStore } from "@/store";
 import {
@@ -38,7 +39,9 @@ function revealLabel(): string {
 
 export const NoteListItem = memo(function NoteListItem({ note, isActive, indent = 0, onClick, onPin, onDelete, onArchive, onMove, onMoveToFolder, onReveal, onDragStart, onDragEnd }: NoteListItemProps) {
   const getTagById = useCairnStore((s) => s.getTagById);
-  const tags = note.tagIds.slice(0, 3).map((id) => getTagById(id)).filter(Boolean);
+  const allTags = note.tagIds.map((id) => getTagById(id)).filter(Boolean);
+  const tags = allTags.slice(0, 3);
+  const hiddenTags = allTags.slice(3);
 
   return (
     <ContextMenu>
@@ -95,10 +98,17 @@ export const NoteListItem = memo(function NoteListItem({ note, isActive, indent 
         <span className="text-[0.786rem] text-[var(--text-tertiary)] truncate">{note.contentText.slice(0, 60) || (note.type === "dashboard" ? "Dashboard" : "Empty note")}</span>
         <div className="flex items-center gap-1.5">
           <span className="text-[0.714rem] text-[var(--text-tertiary)]">{formatRelative(note.updatedAt)}</span>
-          {tags.length > 0 && tags.map((tag) => tag && (
-            <Badge key={tag.id} color={tag.color} size="xs">{tag.name}</Badge>
-          ))}
         </div>
+        {tags.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1">
+            {tags.map((tag) => tag && (
+              <Badge key={tag.id} color={tag.color} size="xs">{tag.name}</Badge>
+            ))}
+            {hiddenTags.length > 0 && (
+              <TagOverflow count={hiddenTags.length} names={hiddenTags.map((t) => t!.name)} />
+            )}
+          </div>
+        )}
       </div>
       </ContextMenuTrigger>
 

--- a/src/components/notes/notes-view/NoteListItem.tsx
+++ b/src/components/notes/notes-view/NoteListItem.tsx
@@ -8,7 +8,7 @@ import {
 import { cn, formatRelative } from "@/lib/utils";
 import type { Note } from "@/types";
 import { Badge } from "@/components/ui/badge";
-import { TagOverflow } from "@/components/ui/tag-overflow";
+import { OverflowPill } from "@/components/ui/overflow-pill";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useCairnStore } from "@/store";
 import {
@@ -105,7 +105,7 @@ export const NoteListItem = memo(function NoteListItem({ note, isActive, indent 
               <Badge key={tag.id} color={tag.color} size="xs">{tag.name}</Badge>
             ))}
             {hiddenTags.length > 0 && (
-              <TagOverflow count={hiddenTags.length} names={hiddenTags.map((t) => t!.name)} />
+              <OverflowPill count={hiddenTags.length} names={hiddenTags.map((t) => t!.name)} />
             )}
           </div>
         )}

--- a/src/components/onboarding/StepAISetup.tsx
+++ b/src/components/onboarding/StepAISetup.tsx
@@ -105,7 +105,7 @@ export function StepAISetup({
                   className={cn(
                     "flex flex-col items-center justify-center p-4 rounded-xl border text-center transition-all gap-1.5 relative select-none",
                     provider === "localllm"
-                      ? "border-purple-500 bg-[color-mix(in_srgb,var(--purple-500)_10%,transparent)] shadow-sm"
+                      ? "border-[var(--accent)] bg-[var(--accent-dim)] shadow-sm"
                       : localLLMAvailable === false
                         ? "opacity-50 cursor-not-allowed border-[var(--border)]"
                         : "border-[var(--border)] hover:border-[var(--accent)] hover:bg-[var(--surface-2)] cursor-pointer"

--- a/src/components/onboarding/StepCreateProject.tsx
+++ b/src/components/onboarding/StepCreateProject.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect } from "react";
 import { ArrowLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { MicroLabel } from "@/components/ui/labels";
 import { WORKSPACE_ICONS, ProjectIcon } from "@/lib/workspace-icons";
 import { Shell } from "./shared";
 
@@ -109,7 +110,7 @@ export function StepCreateProject({
 
         <div className="flex items-center gap-3">
           <div className="flex-1 h-px bg-[var(--border)]" />
-          <span className="text-[0.65rem] text-[var(--text-tertiary)] uppercase tracking-wider">or</span>
+          <MicroLabel>or</MicroLabel>
           <div className="flex-1 h-px bg-[var(--border)]" />
         </div>
 

--- a/src/components/settings/LlamaServerConsole.tsx
+++ b/src/components/settings/LlamaServerConsole.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from "react";
 import { CheckCircle, RefreshCw, Cpu, Trash2, Star } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Select } from "@/components/ui/select";
+import { MicroLabel } from "@/components/ui/labels";
 
 /**
  * On-Device Llama server console — the entire `provider === "localllm"` surface
@@ -430,9 +431,9 @@ export function LlamaServerConsole({
               )}
 
               <div className="border-t border-[var(--border)] pt-3 space-y-2">
-                <p className="text-[0.65rem] text-[var(--text-tertiary)] uppercase tracking-wider font-semibold">
+                <MicroLabel className="block">
                   Alternative manual installation
-                </p>
+                </MicroLabel>
                 <div className="bg-[var(--surface-1)] border border-[var(--border)] p-2.5 rounded font-mono text-[0.714rem] text-[var(--text-primary)] flex items-center justify-between">
                   <span>brew install llama.cpp</span>
                   <button

--- a/src/components/settings/MobileSettings.tsx
+++ b/src/components/settings/MobileSettings.tsx
@@ -145,7 +145,7 @@ export function MobileSettings() {
                   <Shield size={13} className="text-[var(--success)]" />
                   PIN Code Authentication
                 </div>
-                <p className="text-[10px] text-[var(--text-tertiary)] mt-0.5 max-w-xs">
+                <p className="text-[0.714rem] text-[var(--text-tertiary)] mt-0.5 max-w-xs">
                   Enforces validation using a unique PIN code upon first visiting from a new browser.
                 </p>
               </div>
@@ -185,7 +185,7 @@ export function MobileSettings() {
       {!status.running && (
         <div className="flex gap-2.5 p-3 rounded-xl border border-[var(--border)] bg-[var(--surface-2)] opacity-80 mt-4">
           <AlertCircle size={14} className="text-[var(--text-tertiary)] mt-0.5 shrink-0" />
-          <p className="text-[10px] text-[var(--text-tertiary)] leading-normal">
+          <p className="text-[0.714rem] text-[var(--text-tertiary)] leading-normal">
             Exposing your workspace over the local network allows you to access notes, kanban boards, and chat with AI agents on other devices. Activate network access above to see connection links.
           </p>
         </div>

--- a/src/components/settings/tools/BrowseCommunityModal.tsx
+++ b/src/components/settings/tools/BrowseCommunityModal.tsx
@@ -476,7 +476,7 @@ export function BrowseCommunityModal({ onClose }: { onClose: () => void }) {
           </p>
           {secretPrompt.names.map((n) => (
             <div key={n} className="mb-2">
-              <label className="text-[0.65rem] uppercase tracking-widest text-[var(--text-tertiary)] block mb-1">
+              <label className="text-[0.643rem] uppercase tracking-widest text-[var(--text-tertiary)] block mb-1">
                 {n}
               </label>
               <input

--- a/src/components/shared/ConnectorToolCard.tsx
+++ b/src/components/shared/ConnectorToolCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { ConnectorLogo } from "@/components/settings/tools/ConnectorLogo";
+import { MicroLabel } from "@/components/ui/labels";
 import { ExternalRefChip } from "@/components/shared/cairn-ref-chip";
 import { humanizeTool } from "@/lib/humanize-tool";
 import { prettyToolOutput, redactToolOutput, redactTranscriptValue } from "@/lib/redact-agent-transcript";
@@ -95,7 +96,7 @@ function ToolPayload({ label, value }: { label: string; value: string }) {
   }
   return (
     <div className="mt-1 rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 py-1.5">
-      <p className="mb-1 text-[0.607rem] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">{label}</p>
+      <MicroLabel className="mb-1 block">{label}</MicroLabel>
       {parsed !== undefined ? <JsonTree value={parsed} /> : <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words text-[0.643rem] leading-5 text-[var(--text-tertiary)]">{value}</pre>}
     </div>
   );

--- a/src/components/ui/labels.tsx
+++ b/src/components/ui/labels.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Canonical section-header label: uppercase, letter-spaced, tertiary. Use for
+ * the headline label above a section/group. Consolidates the ad-hoc
+ * `text-[0.714rem] font-semibold uppercase tracking-*` fragments.
+ */
+export function SectionLabel({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      className={cn(
+        "text-[0.714rem] font-semibold uppercase tracking-wider text-[var(--text-tertiary)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * Canonical micro field label: the small uppercase caption under/next to
+ * fields and rows. Consolidates the ad-hoc `text-[0.643rem] font-medium
+ * uppercase tracking-*` fragments.
+ */
+export function MicroLabel({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      className={cn(
+        "text-[0.643rem] font-medium uppercase tracking-wide text-[var(--text-tertiary)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/model-picker.tsx
+++ b/src/components/ui/model-picker.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 import { useCairnStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import { Tooltip } from "@/components/ui/tooltip";
+import { MicroLabel } from "@/components/ui/labels";
 import {
   getModelInfo,
   getModelCatalogVersion,
@@ -292,9 +293,9 @@ export function ModelPicker({
           )}
           {favs.length > 0 && (
             <>
-              <div className="px-2.5 pt-1 pb-0.5 text-[0.607rem] uppercase tracking-wide text-[var(--text-tertiary)]">
+              <MicroLabel className="px-2.5 pt-1 pb-0.5 block">
                 Favorites
-              </div>
+              </MicroLabel>
               {favs.map((m) => (
                 <ModelRow
                   key={m}

--- a/src/components/ui/overflow-pill.tsx
+++ b/src/components/ui/overflow-pill.tsx
@@ -32,21 +32,21 @@ function previewNames(names: string[]): string {
  * passing onClick turns it into an expand/collapse toggle.
  */
 export function OverflowPill({ count, names, onClick, label, tooltip, className }: OverflowPillProps) {
-  return (
-    <Tooltip content={tooltip ?? previewNames(names)}>
-      <span
-        role={onClick ? "button" : undefined}
-        tabIndex={onClick ? 0 : undefined}
-        onClick={onClick}
-        onKeyDown={onClick ? (e) => { if (e.key === "Enter") onClick(); } : undefined}
-        className={cn(
-          "inline-flex items-center rounded border border-[var(--border)] px-1 py-0.5 text-[0.643rem] font-medium text-[var(--text-tertiary)] cursor-default select-none",
-          onClick && "cursor-pointer transition-colors hover:text-[var(--text-secondary)] hover:border-[var(--text-tertiary)]",
-          className,
-        )}
-      >
-        {label ?? `+${count}`}
-      </span>
-    </Tooltip>
+  const pillClasses = cn(
+    "inline-flex items-center rounded border border-[var(--border)] px-1 py-0.5 text-[0.643rem] font-medium text-[var(--text-tertiary)] select-none",
+    onClick
+      ? "cursor-pointer bg-transparent transition-colors hover:text-[var(--text-secondary)] hover:border-[var(--text-tertiary)]"
+      : "cursor-default",
+    className,
   );
+  const content = onClick ? (
+    <button type="button" onClick={onClick} className={pillClasses}>
+      {label ?? `+${count}`}
+    </button>
+  ) : (
+    <span className={pillClasses}>
+      {label ?? `+${count}`}
+    </span>
+  );
+  return <Tooltip content={tooltip ?? previewNames(names)}>{content}</Tooltip>;
 }

--- a/src/components/ui/overflow-pill.tsx
+++ b/src/components/ui/overflow-pill.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import { Tooltip } from "@/components/ui/tooltip";
 
-interface TagOverflowProps {
+interface OverflowPillProps {
   count: number;
   names: string[];
   /** When provided, the pill becomes a button (used to expand/collapse). */
@@ -16,22 +16,22 @@ interface TagOverflowProps {
   className?: string;
 }
 
-/** Preview this many hidden tag names before trailing "+N more". */
+/** Preview this many hidden item names before trailing "+N more". */
 const TOOLTIP_NAME_PREVIEW = 5;
 
 function previewNames(names: string[]): string {
-  if (names.length === 0) return "More tags";
+  if (names.length === 0) return "More";
   if (names.length <= TOOLTIP_NAME_PREVIEW) return names.join(", ");
   const rest = names.length - TOOLTIP_NAME_PREVIEW;
   return `${names.slice(0, TOOLTIP_NAME_PREVIEW).join(", ")}… +${rest} more`;
 }
 
 /**
- * Compact "+N" pill shown when tags are capped, styled to sit beside
- * `<Badge size="xs">`. Hover reveals the hidden tag names; passing onClick
- * turns it into an expand/collapse toggle.
+ * Compact "+N" pill shown when a list is capped (tags, artifact chips, etc.),
+ * styled to sit beside `<Badge size="xs">`. Hover reveals the hidden names;
+ * passing onClick turns it into an expand/collapse toggle.
  */
-export function TagOverflow({ count, names, onClick, label, tooltip, className }: TagOverflowProps) {
+export function OverflowPill({ count, names, onClick, label, tooltip, className }: OverflowPillProps) {
   return (
     <Tooltip content={tooltip ?? previewNames(names)}>
       <span

--- a/src/components/ui/tag-overflow.tsx
+++ b/src/components/ui/tag-overflow.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Tooltip } from "@/components/ui/tooltip";
+
+interface TagOverflowProps {
+  count: number;
+  names: string[];
+  /** When provided, the pill becomes a button (used to expand/collapse). */
+  onClick?: () => void;
+  /** Label override — defaults to "+N". */
+  label?: string;
+  /** Overrides the names-based tooltip (e.g. a collapse hint). */
+  tooltip?: string;
+  className?: string;
+}
+
+/** Preview this many hidden tag names before trailing "+N more". */
+const TOOLTIP_NAME_PREVIEW = 5;
+
+function previewNames(names: string[]): string {
+  if (names.length === 0) return "More tags";
+  if (names.length <= TOOLTIP_NAME_PREVIEW) return names.join(", ");
+  const rest = names.length - TOOLTIP_NAME_PREVIEW;
+  return `${names.slice(0, TOOLTIP_NAME_PREVIEW).join(", ")}… +${rest} more`;
+}
+
+/**
+ * Compact "+N" pill shown when tags are capped, styled to sit beside
+ * `<Badge size="xs">`. Hover reveals the hidden tag names; passing onClick
+ * turns it into an expand/collapse toggle.
+ */
+export function TagOverflow({ count, names, onClick, label, tooltip, className }: TagOverflowProps) {
+  return (
+    <Tooltip content={tooltip ?? previewNames(names)}>
+      <span
+        role={onClick ? "button" : undefined}
+        tabIndex={onClick ? 0 : undefined}
+        onClick={onClick}
+        onKeyDown={onClick ? (e) => { if (e.key === "Enter") onClick(); } : undefined}
+        className={cn(
+          "inline-flex items-center rounded border border-[var(--border)] px-1 py-0.5 text-[0.643rem] font-medium text-[var(--text-tertiary)] cursor-default select-none",
+          onClick && "cursor-pointer transition-colors hover:text-[var(--text-secondary)] hover:border-[var(--text-tertiary)]",
+          className,
+        )}
+      >
+        {label ?? `+${count}`}
+      </span>
+    </Tooltip>
+  );
+}

--- a/src/components/usage/UsageView.tsx
+++ b/src/components/usage/UsageView.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo, useState, useEffect, useSyncExternalStore } from "react";
 import { RefreshCw, Percent, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { OverflowPill } from "@/components/ui/overflow-pill";
 import { useUsage, USAGE_RANGES } from "@/hooks/useUsage";
 import { UsageChart, type UsageMetric } from "./UsageChart";
 import { Select } from "@/components/ui/select";
@@ -347,6 +348,13 @@ export function UsageView() {
                       </div>
                     );
                   })
+                )}
+                {byModel.length > 6 && (
+                  <OverflowPill
+                    count={byModel.length - 6}
+                    names={byModel.slice(6).map((m) => m.model)}
+                    className="self-start"
+                  />
                 )}
               </div>
             </div>

--- a/src/lib/tag-utils.test.ts
+++ b/src/lib/tag-utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { sortTagsByUsage, capTags } from "./tag-utils";
+import type { Tag } from "@/types";
+
+const tag = (id: string): Tag => ({ id, name: id, color: "#000", workspaceId: "w" });
+
+describe("sortTagsByUsage", () => {
+  it("sorts by combined usage across notes and cards, descending", () => {
+    const tags = [tag("a"), tag("b"), tag("c")];
+    const notes = [
+      { tagIds: ["a", "b"] },
+      { tagIds: ["a"] },
+    ];
+    const cards = [{ tagIds: ["c"] }];
+    expect(sortTagsByUsage(tags, notes, cards).map((t) => t.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("preserves order for tags with equal usage", () => {
+    const tags = [tag("x"), tag("y"), tag("z")];
+    expect(sortTagsByUsage(tags, [{ tagIds: ["x", "y", "z"] }]).map((t) => t.id)).toEqual(["x", "y", "z"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const tags = [tag("a"), tag("b")];
+    const original = [...tags];
+    sortTagsByUsage(tags, [{ tagIds: ["b"] }]);
+    expect(tags).toEqual(original);
+  });
+});
+
+describe("capTags", () => {
+  it("splits into shown and hidden", () => {
+    const tags = [tag("a"), tag("b"), tag("c")];
+    expect(capTags(tags, 2).shown.map((t) => t.id)).toEqual(["a", "b"]);
+    expect(capTags(tags, 2).hidden.map((t) => t.id)).toEqual(["c"]);
+  });
+
+  it("returns empty hidden when under the cap", () => {
+    expect(capTags([tag("a")], 2).hidden).toEqual([]);
+  });
+});

--- a/src/lib/tag-utils.ts
+++ b/src/lib/tag-utils.ts
@@ -1,0 +1,21 @@
+import type { Tag } from "@/types";
+
+interface Tagged {
+  tagIds: string[];
+}
+
+/** Sort tags by combined usage across the given notes/cards collections (descending). */
+export function sortTagsByUsage<T extends Tag>(tags: T[], ...collections: Tagged[][]): T[] {
+  const counts = new Map<string, number>();
+  for (const collection of collections) {
+    for (const item of collection) {
+      for (const id of item.tagIds) counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+  }
+  return [...tags].sort((a, b) => (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0));
+}
+
+/** Split tags into the first `max` and the rest (for "+N" overflow pills). */
+export function capTags<T extends Tag>(tags: T[], max: number): { shown: T[]; hidden: T[] } {
+  return { shown: tags.slice(0, max), hidden: tags.slice(max) };
+}


### PR DESCRIPTION
## What does this PR do?

A UX/UI consistency sweep. The notes-hierarchy tag rendering was messy (busy filter, cramped row badges), so I audited tag/overflow/label/color usage across the whole app and standardized the patterns:

- **Tags**: notes filter sorted by usage + capped behind a `+N` pill; note rows put tags below the date at `xs`; same `+N` treatment across project headers, pinned notes, kanban cards, editor tag bar, and mobile.
- **Overflow**: generalized the tag pill into a shared `OverflowPill` used for automation-run artifacts, task-flow previews, usage-by-model and recent agent sessions — no more silent drops or bare `+N`s.
- **Typography**: new `MicroLabel` / `SectionLabel` components collapse ~6 ad-hoc micro font sizes down to two canonical scales; removed all remaining pixel-based font classes.
- **Theme tokens**: fixed stray hardcoded colours (`green-400`, hex fallbacks, `rgba()` in the dashboard template) and an undefined `--purple-500` token that left an onboarding card's selected state invisible.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code quality
- [ ] Docs / changelog
- [x] Tests

## Screenshots / recording

UI changes; before/after captures for the notes sidebar tag filter and note rows can be added on request — this pass was driven by a live audit rather than screenshots.

## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (runs `npm run compile` first so `electron/bundle-guard.test.ts` actually executes — `npm run test:bundle` to run just that)
- [ ] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [ ] If this ships a **major, user-facing feature**: added an entry to `scripts/features.config.js` so it appears in the "What's New" modal (generated JSON — run `node scripts/generate-features.js`)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts`
- [ ] New SQL goes in `electron/db/queries.ts` — single source of truth (imported by both Electron main process and MCP server); never construct a `Database` instance outside `db/client.ts` (Electron) or `mcp-server.ts` (MCP runtime)
- [ ] New `dependencies` or `devDependencies` added to `ROLE_MAP` in `scripts/generate-licenses.js` and `licenses.json` regenerated
- [ ] New MCP tools registered in `electron/mcp/tools/index.ts` dispatch + `electron/lib/tool-schemas.ts` Zod schema
- [ ] If you added/removed a `--external:<pkg>` flag in the `compile` script: updated the appropriate allowlist group (`RUNTIME_PROVIDED` / `OPTIONAL_TRANSITIVE` / `SUBPROCESS_ONLY` / `SHIPPED_NATIVE`) in `electron/bundle-guard.test.ts` and (if `SHIPPED_NATIVE`) shipped the package via `electron-builder.yml`

## Notes for reviewer

- The fixed code-block/mermaid palettes were intentionally left on their own dark/light scheme (not app theme tokens) — only the copy-state success colour was touched.
- Calendar grid headers (`MonthGrid`/`WeekGrid`) and SVG canvas labels keep their smaller scales on purpose (cramped cells / chart density) and were excluded from the label normalization.
- A follow-up PR is planned to unify the ~30 hand-rolled empty states into a shared primitive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent `+N` overflow indicators for tags, sessions, tasks, notes, and models, with expandable details where applicable.
  * Improved tag ordering based on usage across project and note views.
  * Added consistent section headings and compact field labels throughout the interface.

* **Style**
  * Refined typography, spacing, badge sizing, and responsive font units across multiple screens.
  * Updated colors and highlights to follow the active theme, including success states, accents, legends, and priority badges.
  * Improved local AI setup selection styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->