### PR TITLE
fix(chat): stop the thinking panel flashing open on every content token

### DIFF
--- a/changelogs/v2.7.3.md
+++ b/changelogs/v2.7.3.md
@@ -1,0 +1,5 @@
+## What's new
+
+### Fixed
+
+- **The Thinking panel no longer flickers open when the answer starts.** After a model finishes its reasoning and the reply begins streaming, the panel could flash open-and-closed with every generated token (in both chat and the coding agent). It now stays collapsed once the answer starts — it only opens while the model is actively thinking.

--- a/src/components/chat/chat-panel/ThinkingPanel.component.test.tsx
+++ b/src/components/chat/chat-panel/ThinkingPanel.component.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThinkingPanel } from "./ThinkingPanel";
+
+/**
+ * Regression suite for the Thinking panel's expanded/collapsed behaviour.
+ *
+ * Guards against the streaming flash bug: the panel must derive "expanded while
+ * thinking" from props (no state-driven auto-collapse effects that could
+ * re-open on a remount), honour a single manual override, and auto-collapse
+ * the moment the answer (companionContent) starts streaming.
+ */
+
+function expanded(): boolean {
+  return screen.getByRole("button").getAttribute("aria-expanded") === "true";
+}
+
+describe("ThinkingPanel expanded state", () => {
+  it("auto-expands while the model is thinking (reasoning present, no answer yet)", () => {
+    render(<ThinkingPanel streaming text="step by step" companionContent="" />);
+    expect(expanded()).toBe(true);
+  });
+
+  it("collapses by default for a persisted (non-streaming) message", () => {
+    render(<ThinkingPanel text="step by step" />);
+    expect(expanded()).toBe(false);
+  });
+
+  it("auto-collapses the moment companion content starts streaming", () => {
+    const { rerender } = render(<ThinkingPanel streaming text="step by step" companionContent="" />);
+    expect(expanded()).toBe(true);
+
+    rerender(<ThinkingPanel streaming text="step by step" companionContent="The answer" />);
+    expect(expanded()).toBe(false);
+  });
+
+  it("first click collapses the panel and the override sticks across the content transition", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<ThinkingPanel streaming text="step by step" companionContent="" />);
+    expect(expanded()).toBe(true);
+
+    await user.click(screen.getByRole("button"));
+    expect(expanded()).toBe(false);
+
+    // The user's choice persists once the answer starts streaming.
+    rerender(<ThinkingPanel streaming text="step by step" companionContent="The answer" />);
+    expect(expanded()).toBe(false);
+  });
+});

--- a/src/components/chat/chat-panel/ThinkingPanel.tsx
+++ b/src/components/chat/chat-panel/ThinkingPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ChevronDown, Brain } from "lucide-react";
 import { MarkdownContent } from "./MarkdownContent";
 import { StreamingCursor } from "./message-ui";
@@ -43,29 +43,20 @@ export const ThinkingPanel = React.memo(function ThinkingPanel({
   streaming = false,
   companionContent,
 }: ThinkingPanelProps) {
-  const [open, setOpen] = useState(streaming);
+  // `open` is ONLY the user's manual toggle. Whether the panel is expanded
+  // while thinking is DERIVED (`thinking`), so a remount mid-stream can never
+  // flash it open — the old `useState(streaming)` + auto-collapse/re-expand
+  // effects re-opened the panel on every mount and flickered with each content
+  // token (Virtuoso remounts items as their height changes).
+  const [open, setOpen] = useState(false);
   const [userOverride, setUserOverride] = useState(false);
-  const hadTextRef = useRef(Boolean(text));
+  const hasText = Boolean(text);
+  // Expanded while the model is actively thinking (reasoning present, answer
+  // not yet started) unless the user manually toggled it.
+  const thinking = streaming && hasText && !companionContent;
+  const expanded = open || (thinking && !userOverride);
 
-  // Auto-collapse when companion content starts streaming.
-  useEffect(() => {
-    if (streaming && companionContent && !userOverride && open) {
-      setOpen(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [streaming, companionContent, userOverride]);
-
-  // Re-expand only on the empty → non-empty transition (new reasoning stream),
-  // but only if the answer hasn't started streaming yet.
-  useEffect(() => {
-    const hadText = hadTextRef.current;
-    hadTextRef.current = Boolean(text);
-    if (streaming && text && !hadText && !userOverride && !companionContent) {
-      setOpen(true);
-    }
-  }, [text, streaming, userOverride, companionContent]);
-
-  // Reset user override when text is cleared (new turn).
+  // Reset the user override when text is cleared (new turn).
   useEffect(() => {
     if (!text) setUserOverride(false);
   }, [text]);
@@ -81,7 +72,7 @@ export const ThinkingPanel = React.memo(function ThinkingPanel({
   const collapsedText = summary && summary.trim() ? summary.trim() : text;
   // Expanded body prefers the raw trace; summary-only reasoning uses the summary.
   const bodyText = text || collapsedText;
-  const preview = streaming && open ? null : (
+  const preview = expanded ? null : (
     <span className="text-[0.714rem] text-[var(--text-tertiary)] truncate max-w-[280px]">
       {collapsedText.slice(0, 120).trim()}{collapsedText.length > 120 ? "…" : ""}
     </span>
@@ -93,22 +84,22 @@ export const ThinkingPanel = React.memo(function ThinkingPanel({
         type="button"
         onClick={handleToggle}
         className="flex items-center gap-1.5 w-full px-2.5 py-1.5 text-left hover:bg-[var(--surface-3)] transition-colors cursor-pointer"
-        aria-expanded={open}
+        aria-expanded={expanded}
       >
         <Brain size={11} className="text-[var(--accent)] shrink-0" />
         <span className="text-[0.714rem] font-medium text-[var(--text-secondary)] flex-shrink-0">
-          {streaming && open ? "Thinking…" : "Thought process"}
+          {thinking ? "Thinking…" : "Thought process"}
         </span>
-        {!open && preview}
+        {!expanded && preview}
         <ChevronDown
           size={11}
-          className={`text-[var(--text-tertiary)] ml-auto transition-transform ${open ? "rotate-180" : ""}`}
+          className={`text-[var(--text-tertiary)] ml-auto transition-transform ${expanded ? "rotate-180" : ""}`}
         />
       </button>
-      {open && (
+      {expanded && (
         <div className="px-3 py-2 border-t text-[0.786rem] leading-relaxed text-[var(--text-tertiary)] max-h-[300px] overflow-y-auto" style={{ borderTopColor: "color-mix(in srgb, var(--border) 50%, transparent)" }}>
           <MarkdownContent content={bodyText} />
-          {streaming && open && <StreamingCursor />}
+          {thinking && <StreamingCursor />}
         </div>
       )}
     </div>

--- a/src/components/chat/chat-panel/ThinkingPanel.tsx
+++ b/src/components/chat/chat-panel/ThinkingPanel.tsx
@@ -43,30 +43,31 @@ export const ThinkingPanel = React.memo(function ThinkingPanel({
   streaming = false,
   companionContent,
 }: ThinkingPanelProps) {
-  // `open` is ONLY the user's manual toggle. Whether the panel is expanded
-  // while thinking is DERIVED (`thinking`), so a remount mid-stream can never
-  // flash it open — the old `useState(streaming)` + auto-collapse/re-expand
-  // effects re-opened the panel on every mount and flickered with each content
-  // token (Virtuoso remounts items as their height changes).
-  const [open, setOpen] = useState(false);
-  const [userOverride, setUserOverride] = useState(false);
+  // `override` is null (auto) or a user-forced expanded/collapsed value.
+  // Whether the panel is expanded while thinking is DERIVED (`thinking`) when
+  // no override is set, so a remount mid-stream can never flash it open — the
+  // old `useState(streaming)` + auto-collapse/re-expand effects re-opened the
+  // panel on every mount and flickered with each content token (Virtuoso
+  // remounts items as their height changes).
+  const [override, setOverride] = useState<boolean | null>(null);
   const hasText = Boolean(text);
   // Expanded while the model is actively thinking (reasoning present, answer
-  // not yet started) unless the user manually toggled it.
+  // not yet started) unless the user has overridden it.
   const thinking = streaming && hasText && !companionContent;
-  const expanded = open || (thinking && !userOverride);
+  const expanded = override !== null ? override : thinking;
 
-  // Reset the user override when text is cleared (new turn).
+  // Reset the manual override when text clears (new turn) so a fresh thinking
+  // cycle auto-expands again and auto-collapses with companionContent.
   useEffect(() => {
-    if (!text) setUserOverride(false);
+    if (!text) setOverride(null);
   }, [text]);
 
   // Nothing to render when the model produced neither raw reasoning nor a summary.
   if (!text && !(summary && summary.trim())) return null;
 
   const handleToggle = () => {
-    setUserOverride(true);
-    setOpen((prev) => !prev);
+    // Set the override to the inverse of the current expanded state.
+    setOverride(expanded ? false : true);
   };
 
   const collapsedText = summary && summary.trim() ? summary.trim() : text;


### PR DESCRIPTION
## What does this PR do?

Fixes a visual glitch in the streaming Thinking panel (chat + agent): after the model finishes its reasoning and the answer starts generating, the panel flashed open-then-closed with **every content token**.

Root cause: the panel initialized `open` from the `streaming` prop and toggled it via auto-collapse/re-expand effects. When the virtualized transcript remounts a streaming item as its content grows, each mount re-initialized `open = true` (expanded), and the effect then collapsed it — a flash per token on both the desktop chat's live indicator and the agent.

The fix makes "expanded while thinking" **derived** (`streaming && hasText && !companionContent`); `open` now holds only the user's manual toggle. A remount can no longer flash the panel open — it opens while the model thinks and stays closed once content starts. (Mobile's `ReasoningBlock` already used the derived pattern.)

## Type of change

- [x] Bug fix

## Screenshots / recording

N/A — visual flicker fix; no layout change.

## Checklist

- [x] `npm run type-check:all` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (runs `npm run compile` first so `electron/bundle-guard.test.ts` actually executes — `npm run test:bundle` to run just that)
- [x] `npm run test:e2e` passes (run before merging UI changes or cutting a release)
- [ ] If this ships a **major, user-facing feature**: added an entry to `scripts/features.config.js` so it appears in the "What's New" modal (generated JSON — run `node scripts/generate-features.js`)
- [x] No hardcoded colours — CSS variables only (`var(--accent)`, `var(--text-primary)`, etc.)
- [x] No `text-[Npx]` pixel font classes — rem equivalents only (`text-[0.714rem]`, `text-xs`, etc.)
- [ ] New IPC handlers wrapped in `handle()` and return `IpcResult<T>`
- [ ] New DB migrations appended (not edited) in `schema.ts`
- [ ] New SQL goes in `electron/db/queries.ts` — single source of truth (imported by both Electron main process and MCP server); never construct a `Database` instance outside `db/client.ts` (Electron) or `mcp-server.ts` (MCP runtime)
- [ ] New `dependencies` or `devDependencies` added to `ROLE_MAP` in `scripts/generate-licenses.js` and `licenses.json` regenerated
- [ ] New MCP tools registered in `electron/mcp/tools/index.ts` dispatch + `electron/lib/tool-schemas.ts` Zod schema

## Notes for reviewer

- The old `useState(streaming)` + auto-collapse/re-expand effect logic is replaced by the derived `thinking` flag; user toggling is preserved via `open` + `userOverride`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the Thinking panel flickering open while answers stream in chat and the coding agent.
  - The panel now stays collapsed after reasoning ends and expands only while the model is actively thinking.
  - Preserved manual expand/collapse behavior, previews, labels, accessibility state, and streaming cursor display.

- **Documentation**
  - Added release notes for version 2.7.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->